### PR TITLE
fix: correct slippage conversion from basis points to decimal in PumpFun trades

### DIFF
--- a/electron/services/PumpFunService.ts
+++ b/electron/services/PumpFunService.ts
@@ -209,7 +209,7 @@ export async function buyToken(input: TradeInput): Promise<TxResult> {
     user: keypair.publicKey,
     amount: tokenAmount,
     solAmount: solLamports,
-    slippage: input.slippageBps / 100,
+    slippage: input.slippageBps / 10_000,
     tokenProgram: TOKEN_PROGRAM_ID,
   })
 
@@ -253,7 +253,7 @@ export async function sellToken(input: TradeInput): Promise<TxResult> {
     user: keypair.publicKey,
     amount: tokenAmount,
     solAmount,
-    slippage: input.slippageBps / 100,
+    slippage: input.slippageBps / 10_000,
     tokenProgram: TOKEN_PROGRAM_ID,
   })
 


### PR DESCRIPTION
## Summary
- Slippage parameter in `buyToken` and `sellToken` was divided by 100 instead of 10,000 when converting basis points to the decimal value expected by the pump-sdk
- A user setting 50 bps (0.5%) slippage was actually submitting trades with 50% slippage tolerance, accepting drastically worse prices
- Fixed both `buyInstructions` and `sellInstructions` calls to divide by 10,000

## Test plan
- [ ] Verify slippage value passed to pump-sdk is correct (50 bps → 0.005)
- [ ] Confirm buy/sell trades respect the intended slippage tolerance
- [ ] Run `pnpm run typecheck` — passes clean
- [ ] Run `pnpm run test` — all wallet tests pass (19/19)