### PR TITLE
fix: include pending transactions in agent wallet spend limit check

### DIFF
--- a/electron/services/WalletService.ts
+++ b/electron/services/WalletService.ts
@@ -528,7 +528,7 @@ export async function transferSOL(fromWalletId: string, toAddress: string, amoun
   const walletRow = db.prepare('SELECT wallet_type FROM wallets WHERE id = ?').get(fromWalletId) as { wallet_type: string } | undefined
   if (walletRow?.wallet_type === 'agent') {
     const dayAgo = Date.now() - 86_400_000
-    const row = db.prepare('SELECT COALESCE(SUM(amount), 0) as total FROM transaction_history WHERE wallet_id = ? AND status = ? AND type = ? AND created_at > ?').get(fromWalletId, 'confirmed', 'sol_transfer', dayAgo) as { total: number }
+    const row = db.prepare('SELECT COALESCE(SUM(amount), 0) as total FROM transaction_history WHERE wallet_id = ? AND status IN (?, ?) AND type = ? AND created_at > ?').get(fromWalletId, 'confirmed', 'pending', 'sol_transfer', dayAgo) as { total: number }
     if (row.total + amountSol > 2) throw new Error('Agent wallet daily spend limit (2 SOL) exceeded')
   }
 


### PR DESCRIPTION
## Summary
- The daily spend limit query only counted `status = 'confirmed'` transactions
- Concurrent transfers could bypass the 2 SOL agent wallet limit because pending transactions were invisible to the check
- Now counts both `confirmed` and `pending` transactions toward the daily limit

## Test plan
- [ ] Submit concurrent agent transfers that total over 2 SOL — verify the limit is enforced
- [ ] Verify failed transactions are not counted toward the limit
- [ ] Run `pnpm run typecheck` — passes clean
- [ ] Run `pnpm run test` — all wallet tests pass (19/19)