### PR TITLE
fix: wrap email account deletion in database transaction

### DIFF
--- a/electron/services/EmailService.ts
+++ b/electron/services/EmailService.ts
@@ -162,16 +162,18 @@ export async function removeAccount(accountId: string): Promise<void> {
   const db = getDb()
   const row = getAccountRow(accountId)
 
-  // Clean up secure keys for Gmail
-  if (row.client_id_ref) {
-    db.prepare('DELETE FROM secure_keys WHERE key_name = ?').run(row.client_id_ref)
-  }
-  if (row.client_secret_ref) {
-    db.prepare('DELETE FROM secure_keys WHERE key_name = ?').run(row.client_secret_ref)
-  }
+  db.transaction(() => {
+    // Clean up secure keys for Gmail
+    if (row.client_id_ref) {
+      db.prepare('DELETE FROM secure_keys WHERE key_name = ?').run(row.client_id_ref)
+    }
+    if (row.client_secret_ref) {
+      db.prepare('DELETE FROM secure_keys WHERE key_name = ?').run(row.client_secret_ref)
+    }
 
-  db.prepare('DELETE FROM email_message_cache WHERE account_id = ?').run(accountId)
-  db.prepare('DELETE FROM email_accounts WHERE id = ?').run(accountId)
+    db.prepare('DELETE FROM email_message_cache WHERE account_id = ?').run(accountId)
+    db.prepare('DELETE FROM email_accounts WHERE id = ?').run(accountId)
+  })()
 }
 
 export async function getMessages(accountId: string, query?: string, max?: number): Promise<EmailMessage[]> {


### PR DESCRIPTION
## Summary
- `removeAccount` ran 4 DELETE statements (secure_keys ×2, email_message_cache, email_accounts) without a transaction wrapper
- A crash between any two deletes could leave orphaned secure keys or cached messages in the database
- All deletes now execute atomically via `db.transaction()`

## Test plan
- [ ] Delete an email account — verify all related data is removed
- [ ] Run `pnpm run typecheck` — passes clean
- [ ] Run `pnpm run test` — all tests pass