### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- bump the app version to 2.0.3 after the cleanup merge
- prepare main for the first successful GitHub release tag

## Testing
- no code changes beyond version metadata
