### PR TITLE
fix: call electron-builder directly in release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           if ("${{ secrets.CSC_KEY_PASSWORD }}") {
             $env:CSC_KEY_PASSWORD = "${{ secrets.CSC_KEY_PASSWORD }}"
           }
-          pnpm run package -- --publish never
+          pnpm exec electron-builder --publish never
       - name: Generate checksums
         shell: pwsh
         run: |
@@ -128,7 +128,7 @@ jobs:
             echo "Notarization secrets found, enabling notarize"
             npx json -I -f electron-builder.json -e 'this.mac.notarize=true'
           fi
-          pnpm run package -- --publish never
+          pnpm exec electron-builder --publish never
       - name: Generate checksums
         run: |
           cd release
@@ -170,7 +170,7 @@ jobs:
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      - run: pnpm run package -- --publish never
+      - run: pnpm exec electron-builder --publish never
       - name: Generate checksums
         run: |
           cd release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- call electron-builder directly in release jobs so `--publish never` is parsed correctly
- bump the app version to 2.0.5 for the next release tag

## Why
The v2.0.4 workflow still failed because the npm script invocation forwarded the extra args as literal `--` tokens, so electron-builder continued to auto-publish on tagged builds.
