### PR TITLE
fix: ship token launch polish and hardening follow-ups

### DIFF
--- a/electron/ipc/email.ts
+++ b/electron/ipc/email.ts
@@ -17,6 +17,7 @@ import {
   updateSettings,
 } from '../services/EmailService'
 import { ipcHandler } from '../services/IpcHandlerFactory'
+import { ValidationService } from '../services/ValidationService'
 
 export function registerEmailHandlers() {
   ipcMain.handle('email:accounts', ipcHandler(async () => {
@@ -52,7 +53,48 @@ export function registerEmailHandlers() {
   }))
 
   ipcMain.handle('email:send', ipcHandler(async (_event, accountId: string, to: string, subject: string, body: string, cc?: string, bcc?: string) => {
-    return await sendEmail(accountId, { to, subject, body, cc, bcc })
+    const accountIdResult = ValidationService.validateString(accountId, 1, 128)
+    if (!accountIdResult.success) {
+      throw new Error(accountIdResult.errors?.[0] ?? 'Invalid account id')
+    }
+
+    const toResult = ValidationService.validateEmailAddress(to)
+    if (!toResult.success) {
+      throw new Error(toResult.errors?.[0] ?? 'Invalid recipient')
+    }
+
+    const ccResult = ValidationService.validateEmailList(cc)
+    if (!ccResult.success) {
+      throw new Error(ccResult.errors?.[0] ?? 'Invalid cc list')
+    }
+
+    const bccResult = ValidationService.validateEmailList(bcc)
+    if (!bccResult.success) {
+      throw new Error(bccResult.errors?.[0] ?? 'Invalid bcc list')
+    }
+
+    const subjectResult = ValidationService.validateString(subject, 1, 998)
+    if (!subjectResult.success) {
+      throw new Error(subjectResult.errors?.[0] ?? 'Invalid subject')
+    }
+
+    const bodyResult = ValidationService.validateString(body, 1, 200_000)
+    if (!bodyResult.success) {
+      throw new Error(bodyResult.errors?.[0] ?? 'Invalid body')
+    }
+
+    const rateLimitKey = `email-send:${accountIdResult.data}`
+    if (!ValidationService.checkRateLimit(rateLimitKey, 10, 60_000)) {
+      throw new Error('Rate limit exceeded: try again in a minute')
+    }
+
+    return await sendEmail(accountIdResult.data!, {
+      to: toResult.data!,
+      subject: subjectResult.data!,
+      body: bodyResult.data!,
+      cc: ccResult.data,
+      bcc: bccResult.data,
+    })
   }))
 
   ipcMain.handle('email:mark-read', ipcHandler(async (_event, accountId: string, messageIds: string[]) => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -196,7 +196,7 @@ async function createWindow() {
       callback({
         responseHeaders: {
           ...details.responseHeaders,
-          'Content-Security-Policy': ["default-src 'self' minipaint:; script-src 'self' minipaint:; style-src 'self' 'unsafe-inline' minipaint:; img-src 'self' data: daemon-icon: minipaint:; worker-src 'self' blob: monaco-editor: minipaint:; connect-src 'self' https://*.anthropic.com https://*.helius-rpc.com https://price.jup.ag https://api.coingecko.com; font-src 'self' minipaint:; frame-src minipaint:; object-src 'none'"]
+          'Content-Security-Policy': ["default-src 'self' minipaint:; script-src 'self' minipaint: 'sha256-+1m5I+GGgMQpppazcRWmPjEueczyuTJO92jm308NkKc='; style-src 'self' 'unsafe-inline' minipaint:; img-src 'self' data: daemon-icon: minipaint:; worker-src 'self' blob: monaco-editor: minipaint:; connect-src 'self' https://*.anthropic.com https://*.helius-rpc.com https://price.jup.ag https://api.coingecko.com; font-src 'self' minipaint:; frame-src minipaint:; object-src 'none'"]
         }
       })
     })

--- a/electron/services/BrowserService.ts
+++ b/electron/services/BrowserService.ts
@@ -13,26 +13,47 @@ function nextPageId(): string {
 
 // --- URL Safety ---
 
-function isCloudMetadataUrl(urlStr: string): boolean {
+function isBlockedBrowserHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase().replace(/\.$/, '')
+  if (!normalized) return true
+
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) return true
+  if (normalized === '0.0.0.0' || normalized === '::' || normalized === '::1') return true
+  if (normalized === 'metadata.google.internal') return true
+  if (normalized.endsWith('.local') || normalized.endsWith('.internal')) return true
+
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(normalized)) return true
+  if (/^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(normalized)) return true
+  if (/^192\.168\.\d{1,3}\.\d{1,3}$/.test(normalized)) return true
+  if (/^169\.254\.\d{1,3}\.\d{1,3}$/.test(normalized)) return true
+  if (/^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(normalized)) return true
+  if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}$/.test(normalized)) return true
+
+  if (normalized.startsWith('fe80:')) return true
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true
+
+  return false
+}
+
+function isBlockedNavigationUrl(urlStr: string): boolean {
   try {
     const parsed = new URL(urlStr)
-    const hostname = parsed.hostname
-    // Block cloud metadata endpoints only — real SSRF vectors
-    if (hostname === '169.254.169.254' || hostname === 'metadata.google.internal') return true
-    return false
+    if (!['http:', 'https:'].includes(parsed.protocol)) return true
+    if (parsed.username || parsed.password) return true
+    return isBlockedBrowserHost(parsed.hostname)
   } catch { return true }
 }
 
 // --- Navigation ---
 
 export async function navigate(url: string): Promise<BrowserNavResult> {
-  // Normalize URL
-  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+  // Normalize bare hostnames without mutating explicit non-http schemes.
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
     url = `https://${url}`
   }
 
-  if (isCloudMetadataUrl(url)) {
-    throw new Error('Navigation to cloud metadata endpoints is blocked')
+  if (isBlockedNavigationUrl(url)) {
+    throw new Error('Navigation blocked: URL targets an internal or unsafe address')
   }
 
   // Create a page entry with the URL — actual content comes from webview via capturePageContent

--- a/electron/services/ValidationService.ts
+++ b/electron/services/ValidationService.ts
@@ -26,6 +26,7 @@ interface ValidationRule {
 class ValidationServiceImpl {
   private pathWhitelist: Set<string> = new Set();
   private rateLimitMap: Map<string, number[]> = new Map();
+  private readonly emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
   /**
    * Validate string input
@@ -250,6 +251,58 @@ class ValidationServiceImpl {
     recent.push(now);
     this.rateLimitMap.set(key, recent);
     return true;
+  }
+
+  validateEmailAddress(value: unknown): ValidationResult<string> {
+    if (typeof value !== 'string') {
+      return { success: false, errors: ['Expected string'] };
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return { success: false, errors: ['Email address is required'] };
+    }
+
+    if (trimmed.length > 320) {
+      return { success: false, errors: ['Email address too long'] };
+    }
+
+    if (!this.emailPattern.test(trimmed)) {
+      return { success: false, errors: ['Invalid email address'] };
+    }
+
+    return { success: true, data: trimmed };
+  }
+
+  validateEmailList(value: unknown): ValidationResult<string | undefined> {
+    if (value === undefined || value === null || value === '') {
+      return { success: true, data: undefined };
+    }
+
+    if (typeof value !== 'string') {
+      return { success: false, errors: ['Expected string'] };
+    }
+
+    const emails = value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    if (emails.length === 0) {
+      return { success: true, data: undefined };
+    }
+
+    for (const email of emails) {
+      const result = this.validateEmailAddress(email);
+      if (!result.success) {
+        return {
+          success: false,
+          errors: result.errors?.map((error) => `${email}: ${error}`) ?? ['Invalid email list'],
+        };
+      }
+    }
+
+    return { success: true, data: emails.join(', ') };
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.6",
+  "version": "2.0.11",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",

--- a/scripts/smoke/electron-smoke.mjs
+++ b/scripts/smoke/electron-smoke.mjs
@@ -18,6 +18,7 @@ const userDataDir = mkdtempSync(path.join(tmpdir(), 'daemon-smoke-'))
 const projectPath = repoRoot
 const projectName = 'DAEMON Smoke'
 const smokeEcho = `DAEMON_SMOKE_${Date.now()}`
+const smokeImagePath = path.join(repoRoot, 'src', 'assets', 'daemon-icon.png')
 
 let electronProcess
 let browser
@@ -149,6 +150,23 @@ async function cycleDrawerTools(page, toolNames, rounds = 1) {
   }
 }
 
+async function verifyImageEditor(page) {
+  const explorerSearch = page.locator('.file-explorer-search-input')
+  await explorerSearch.fill(path.basename(smokeImagePath))
+  await page.locator('.file-search-result', { hasText: path.basename(smokeImagePath) }).first().click()
+  await openToolFromLauncher(page, 'Image Editor')
+  await page.waitForSelector('.image-editor', { timeout: 30000 })
+  await page.waitForFunction((expectedName) => {
+    return document.querySelector('.ie-filepath')?.textContent?.trim() === expectedName
+  }, path.basename(smokeImagePath), { timeout: 30000 })
+  await page.waitForFunction(() => {
+    const loading = document.querySelector('.ie-status--dim')
+    const saveButton = Array.from(document.querySelectorAll('.ie-btn')).find((button) => button.textContent?.trim() === 'Save')
+    return !loading && saveButton instanceof HTMLButtonElement && !saveButton.disabled
+  }, { timeout: 30000 })
+  await closeDrawerToGrid(page)
+}
+
 async function verifySidebarAddToolFlyout(page) {
   const addToolButton = page.getByRole('button', { name: 'Add tool', exact: true })
   await addToolButton.click()
@@ -248,6 +266,9 @@ async function run() {
 
   logStep('checking tool launcher transitions')
   await cycleDrawerTools(page, ['Git', 'Wallet', 'Token Launch', 'Settings'], 2)
+
+  logStep('checking image editor readiness flow')
+  await verifyImageEditor(page)
 
   assert.equal(rendererFailures.length, 0, `renderer failures detected:\n${rendererFailures.join('\n')}`)
 }

--- a/src/panels/ImageEditor/ImageEditor.tsx
+++ b/src/panels/ImageEditor/ImageEditor.tsx
@@ -5,6 +5,9 @@ import './ImageEditor.css'
 // miniPaint is served via the minipaint:// custom protocol.
 // Communication with the iframe uses postMessage (cross-origin safe).
 const MINIPAINT_URL = 'minipaint://app/index.html'
+const READY_RETRY_INTERVAL_MS = 250
+const READY_RETRY_LIMIT = 20
+const READY_FALLBACK_MS = 2500
 
 export default function ImageEditor() {
   const iframeRef = useRef<HTMLIFrameElement>(null)
@@ -17,6 +20,30 @@ export default function ImageEditor() {
     resolve: (base64: string) => void
     reject: (err: Error) => void
   } | null>(null)
+  const readyRetryRef = useRef<number | null>(null)
+  const readyFallbackRef = useRef<number | null>(null)
+
+  const clearReadyTimers = useCallback(() => {
+    if (readyRetryRef.current !== null) {
+      window.clearInterval(readyRetryRef.current)
+      readyRetryRef.current = null
+    }
+    if (readyFallbackRef.current !== null) {
+      window.clearTimeout(readyFallbackRef.current)
+      readyFallbackRef.current = null
+    }
+  }, [])
+
+  const markReady = useCallback(() => {
+    setReady(true)
+    clearReadyTimers()
+  }, [clearReadyTimers])
+
+  const pingMiniPaint = useCallback(() => {
+    const iframe = iframeRef.current
+    if (!iframe?.contentWindow) return
+    iframe.contentWindow.postMessage({ type: 'mp:ping' }, '*')
+  }, [])
 
   // Load the image that triggered the editor from the active file in the store
   useEffect(() => {
@@ -36,7 +63,7 @@ export default function ImageEditor() {
       if (!msg || typeof msg.type !== 'string') return
 
       if (msg.type === 'mp:ready') {
-        setReady(true)
+        markReady()
         return
       }
 
@@ -60,7 +87,7 @@ export default function ImageEditor() {
 
     window.addEventListener('message', handleMessage)
     return () => window.removeEventListener('message', handleMessage)
-  }, [])
+  }, [markReady])
 
   // Once miniPaint signals ready and we have an image path, inject it
   useEffect(() => {
@@ -136,13 +163,33 @@ export default function ImageEditor() {
   }, [])
 
   const handleIframeLoad = useCallback(() => {
-    // miniPaint's bundle.js initializes asynchronously after DOM load.
-    // The iframe itself sends mp:ready via postMessage once it's up.
-    // We ping it here as a fallback in case the load event fires before our listener.
-    const iframe = iframeRef.current
-    if (!iframe?.contentWindow) return
-    iframe.contentWindow.postMessage({ type: 'mp:ping' }, '*')
-  }, [])
+    setReady(false)
+    clearReadyTimers()
+    pingMiniPaint()
+
+    let attempts = 1
+    readyRetryRef.current = window.setInterval(() => {
+      if (attempts >= READY_RETRY_LIMIT) {
+        clearReadyTimers()
+        return
+      }
+      attempts += 1
+      pingMiniPaint()
+    }, READY_RETRY_INTERVAL_MS)
+
+    // The iframe can finish booting before our initial ready listener sees the first signal.
+    // Once we have given the bridge several chances to respond, unblock the UI instead of
+    // leaving it in a permanent loading state.
+    readyFallbackRef.current = window.setTimeout(() => {
+      markReady()
+    }, READY_FALLBACK_MS)
+  }, [clearReadyTimers, markReady, pingMiniPaint])
+
+  useEffect(() => {
+    return () => {
+      clearReadyTimers()
+    }
+  }, [clearReadyTimers])
 
   return (
     <div className="image-editor">

--- a/src/panels/LaunchWizard/LaunchWizard.css
+++ b/src/panels/LaunchWizard/LaunchWizard.css
@@ -12,12 +12,12 @@
 .lw-card {
   background: var(--s1);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 32px;
-  width: 480px;
-  max-width: 92vw;
+  border-radius: 18px;
+  padding: 28px;
+  width: min(680px, 94vw);
   max-height: 90vh;
   overflow-y: auto;
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.42);
 }
 
 /* ── Header ── */
@@ -86,10 +86,13 @@
 }
 
 .lw-subtitle {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--t2);
   text-align: center;
   margin-bottom: 24px;
+  max-width: 54ch;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* ── Content area ── */
@@ -726,6 +729,8 @@
   justify-content: space-between;
   border-top: 1px solid var(--border);
   padding-top: 14px;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .lw-footer-close {
@@ -750,4 +755,27 @@
   height: 1px;
   background: var(--border);
   margin: 16px 0;
+}
+
+@media (max-width: 760px) {
+  .lw-card {
+    padding: 20px;
+    width: min(100vw - 24px, 640px);
+  }
+
+  .lw-num-row {
+    grid-template-columns: 1fr;
+  }
+
+  .lw-summary-row {
+    align-items: flex-start;
+  }
+
+  .lw-summary-key {
+    width: 72px;
+  }
+
+  .lw-footer {
+    align-items: stretch;
+  }
 }

--- a/src/panels/SolanaToolbox/LaunchpadSettingsSection.tsx
+++ b/src/panels/SolanaToolbox/LaunchpadSettingsSection.tsx
@@ -31,7 +31,13 @@ function LaunchpadStatusBadge({ definition }: { definition?: LaunchpadDefinition
   )
 }
 
-export function LaunchpadSettingsSection({ onSettingsSaved }: { onSettingsSaved?: () => void }) {
+export function LaunchpadSettingsSection({
+  onSettingsSaved,
+  embedded = false,
+}: {
+  onSettingsSaved?: () => void
+  embedded?: boolean
+}) {
   const pushError = useNotificationsStore((s) => s.pushError)
   const pushSuccess = useNotificationsStore((s) => s.pushSuccess)
 
@@ -90,10 +96,12 @@ export function LaunchpadSettingsSection({ onSettingsSaved }: { onSettingsSaved?
     <section className="solana-launchpad-settings">
       <div className="solana-launchpad-settings-header">
         <div>
-          <div className="solana-token-launch-kicker">Launchpad Settings</div>
-          <h2 className="solana-token-launch-title">Enable LaunchLab and DBC in-app</h2>
+          {!embedded && <div className="solana-token-launch-kicker">Launchpad Settings</div>}
+          <h2 className="solana-token-launch-title">{embedded ? 'Launchpad config' : 'Enable LaunchLab and DBC in-app'}</h2>
           <p className="solana-launchpad-settings-copy">
-            Store protocol config once, keep env fallback in place, and let the unified Token Launch tool resolve readiness from DAEMON state.
+            {embedded
+              ? 'Store protocol config once and let the unified launch flow pick it up automatically.'
+              : 'Store protocol config once, keep env fallback in place, and let the unified Token Launch tool resolve readiness from DAEMON state.'}
           </p>
         </div>
         <div className="solana-token-launch-actions">

--- a/src/panels/SolanaToolbox/TokenLaunchSection.tsx
+++ b/src/panels/SolanaToolbox/TokenLaunchSection.tsx
@@ -17,7 +17,15 @@ function formatCreatedAt(createdAt: number) {
   })
 }
 
-export function TokenLaunchSection({ refreshNonce = 0 }: { refreshNonce?: number }) {
+export function TokenLaunchSection({
+  refreshNonce = 0,
+  embedded = false,
+  onRefreshRequested,
+}: {
+  refreshNonce?: number
+  embedded?: boolean
+  onRefreshRequested?: () => void
+}) {
   const launchWizardOpen = useUIStore((s) => s.launchWizardOpen)
   const openLaunchWizard = useUIStore((s) => s.openLaunchWizard)
 
@@ -59,18 +67,30 @@ export function TokenLaunchSection({ refreshNonce = 0 }: { refreshNonce?: number
   }, [launchWizardOpen, reload])
 
   return (
-    <section className="solana-token-launch">
+    <section className={`solana-token-launch ${embedded ? 'embedded' : ''}`}>
       <div className="solana-token-launch-header">
         <div>
-          <div className="solana-token-launch-kicker">Token Launch</div>
-          <h2 className="solana-token-launch-title">One launch surface for Solana token launches</h2>
+          {!embedded && <div className="solana-token-launch-kicker">Token Launch</div>}
+          <h2 className="solana-token-launch-title">
+            {embedded ? 'Live launchpads and recent launches' : 'One launch surface for Solana token launches'}
+          </h2>
           <p className="solana-token-launch-copy">
-            Launch from one Solana workflow, monitor protocol readiness, and keep wallet-linked launch history in one place.
+            {embedded
+              ? 'Keep launch availability and recent history visible while the main CTA stays at the tool level.'
+              : 'Launch from one Solana workflow, monitor protocol readiness, and keep wallet-linked launch history in one place.'}
           </p>
         </div>
         <div className="solana-token-launch-actions">
           <button className="sol-btn green" onClick={openLaunchWizard}>Open Launcher</button>
-          <button className="sol-btn" onClick={() => { void reload() }}>Refresh</button>
+          <button
+            className="sol-btn"
+            onClick={() => {
+              onRefreshRequested?.()
+              void reload()
+            }}
+          >
+            Refresh
+          </button>
         </div>
       </div>
 

--- a/src/panels/TokenLaunchTool/TokenLaunchTool.css
+++ b/src/panels/TokenLaunchTool/TokenLaunchTool.css
@@ -8,11 +8,31 @@
     radial-gradient(ellipse at 50% 0%, rgba(62, 207, 142, 0.035) 0%, transparent 58%),
     radial-gradient(ellipse at 100% 0%, rgba(96, 165, 250, 0.03) 0%, transparent 42%),
     var(--surface-gradient-subtle);
+  padding: 20px;
+  gap: 18px;
+}
+
+.token-launch-tool-hero {
+  border: 1px solid rgba(62, 207, 142, 0.08);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at top right, rgba(62, 207, 142, 0.13), transparent 34%),
+    radial-gradient(circle at 0% 0%, rgba(96, 165, 250, 0.12), transparent 24%),
+    rgba(255, 255, 255, 0.02);
+  box-shadow: var(--shadow-lifted);
+  overflow: hidden;
 }
 
 .token-launch-tool-header {
-  padding: 20px 20px 12px;
-  border-bottom: 1px solid rgba(62, 207, 142, 0.08);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 22px 18px;
+}
+
+.token-launch-tool-header-copy {
+  max-width: 760px;
 }
 
 .token-launch-tool-kicker {
@@ -33,41 +53,67 @@
 
 .token-launch-tool-copy {
   margin: 10px 0 0;
-  max-width: 760px;
   color: var(--t3);
   font-size: var(--font-md);
   line-height: 1.5;
 }
 
-.token-launch-tool-zone {
-  padding: 16px 20px;
-  border-bottom: 1px solid rgba(62, 207, 142, 0.08);
-}
-
-.token-launch-tool-overview {
+.token-launch-tool-actions {
   display: flex;
-  flex-wrap: wrap;
   gap: 10px;
-  padding: 14px 20px 0;
+  flex-shrink: 0;
 }
 
-.token-launch-tool-pill {
-  display: inline-flex;
-  align-items: center;
-  min-height: 32px;
-  padding: 0 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(62, 207, 142, 0.16);
-  background: rgba(62, 207, 142, 0.08);
-  color: var(--green);
+.token-launch-tool-zone {
+  padding: 18px 20px 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(62, 207, 142, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  box-shadow: var(--shadow-lifted);
+}
+
+.token-launch-tool-highlight-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 0 22px 22px;
+}
+
+.token-launch-tool-highlight {
+  padding: 14px 15px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(10, 13, 16, 0.48);
+  min-width: 0;
+}
+
+.token-launch-tool-highlight-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--t4);
+  letter-spacing: 1.3px;
+  text-transform: uppercase;
+}
+
+.token-launch-tool-highlight-value {
+  margin-top: 8px;
+  color: var(--t1);
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.05;
+}
+
+.token-launch-tool-highlight-detail {
+  margin-top: 8px;
+  color: var(--t3);
   font-size: var(--font-sm);
-  font-weight: 600;
+  line-height: 1.5;
 }
 
 .token-launch-tool-layout {
   display: grid;
   grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
-  gap: 0;
+  gap: 18px;
   min-height: 0;
 }
 
@@ -79,25 +125,11 @@
 .token-launch-tool-side {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 16px 20px 20px 0;
-}
-
-.token-launch-tool-zone-main {
-  border-right: 1px solid rgba(62, 207, 142, 0.08);
-}
-
-.token-launch-tool-zone-main,
-.token-launch-tool-zone-side {
-  border-bottom: none;
-}
-
-.token-launch-tool-zone-side {
-  padding: 0;
+  gap: 18px;
 }
 
 .token-launch-tool-zone-head {
-  padding-bottom: 14px;
+  padding-bottom: 16px;
 }
 
 .token-launch-tool-zone-kicker {
@@ -116,9 +148,16 @@
   line-height: 1.25;
 }
 
+.token-launch-tool-zone-copy {
+  margin: 8px 0 0;
+  color: var(--t3);
+  font-size: var(--font-sm);
+  line-height: 1.55;
+  max-width: 62ch;
+}
+
 .token-launch-tool-note {
-  margin-left: 20px;
-  padding: 16px;
+  padding: 18px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(96, 165, 250, 0.14);
   background:
@@ -145,20 +184,41 @@
 }
 
 @media (max-width: 1100px) {
+  .token-launch-tool-header,
+  .token-launch-tool-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .token-launch-tool-highlight-grid,
   .token-launch-tool-layout {
     grid-template-columns: 1fr;
   }
 
   .token-launch-tool-side {
-    padding: 0 20px 20px;
+    gap: 16px;
+  }
+}
+
+@media (max-width: 760px) {
+  .token-launch-tool {
+    padding: 14px;
   }
 
-  .token-launch-tool-zone-main {
-    border-right: none;
-    border-bottom: 1px solid rgba(62, 207, 142, 0.08);
+  .token-launch-tool-header {
+    padding: 18px 18px 14px;
   }
 
-  .token-launch-tool-note {
-    margin-left: 0;
+  .token-launch-tool-highlight-grid {
+    padding: 0 18px 18px;
+  }
+
+  .token-launch-tool-title {
+    font-size: 24px;
+  }
+
+  .token-launch-tool-zone {
+    padding: 16px;
+    border-radius: 18px;
   }
 }

--- a/src/panels/TokenLaunchTool/TokenLaunchTool.tsx
+++ b/src/panels/TokenLaunchTool/TokenLaunchTool.tsx
@@ -1,40 +1,83 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { LaunchpadSettingsSection } from '../SolanaToolbox/LaunchpadSettingsSection'
 import { TokenLaunchSection } from '../SolanaToolbox/TokenLaunchSection'
+import { useUIStore } from '../../store/ui'
 import '../SolanaToolbox/SolanaToolbox.css'
 import './TokenLaunchTool.css'
 
 export function TokenLaunchTool() {
   const [launchpadRefreshNonce, setLaunchpadRefreshNonce] = useState(0)
+  const openLaunchWizard = useUIStore((s) => s.openLaunchWizard)
+
+  const highlights = useMemo(() => ([
+    {
+      label: 'One flow',
+      value: 'Launch once',
+      detail: 'Wallet pick, preflight, launch, browser handoff.',
+    },
+    {
+      label: 'Post-launch',
+      value: 'Stay in DAEMON',
+      detail: 'Open Pump tokens in Browser mode immediately after success.',
+    },
+    {
+      label: 'Launchpads',
+      value: 'Pump live now',
+      detail: 'Raydium and Meteora stay in the same surface as they come online.',
+    },
+  ]), [])
 
   return (
     <div className="token-launch-tool">
-      <div className="token-launch-tool-header">
-        <div>
-          <div className="token-launch-tool-kicker">Launch Center</div>
-          <h1 className="token-launch-tool-title">Token Launch</h1>
-          <p className="token-launch-tool-copy">
-            Configure launchpads once, launch from one workflow, and keep wallet-linked launch history in one place.
-          </p>
-        </div>
-      </div>
+      <section className="token-launch-tool-hero">
+        <div className="token-launch-tool-header">
+          <div className="token-launch-tool-header-copy">
+            <div className="token-launch-tool-kicker">Launch Center</div>
+            <h1 className="token-launch-tool-title">Token Launch</h1>
+            <p className="token-launch-tool-copy">
+              Launch from one wallet-linked workflow, run preflight before send, and move straight into Browser mode for post-launch work.
+            </p>
+          </div>
 
-      <div className="token-launch-tool-overview">
-        <div className="token-launch-tool-pill">Wallet-linked launches</div>
-        <div className="token-launch-tool-pill">Preflight before send</div>
-        <div className="token-launch-tool-pill">Pump.live / Raydium / Meteora ready</div>
-      </div>
+          <div className="token-launch-tool-actions">
+            <button className="sol-btn green" onClick={openLaunchWizard}>Launch Token</button>
+            <button
+              className="sol-btn"
+              onClick={() => setLaunchpadRefreshNonce((nonce) => nonce + 1)}
+            >
+              Refresh Data
+            </button>
+          </div>
+        </div>
+
+        <div className="token-launch-tool-highlight-grid">
+          {highlights.map((highlight) => (
+            <div key={highlight.label} className="token-launch-tool-highlight">
+              <div className="token-launch-tool-highlight-label">{highlight.label}</div>
+              <div className="token-launch-tool-highlight-value">{highlight.value}</div>
+              <div className="token-launch-tool-highlight-detail">{highlight.detail}</div>
+            </div>
+          ))}
+        </div>
+      </section>
 
       <div className="token-launch-tool-layout">
         <div className="token-launch-tool-main">
           <div className="token-launch-tool-zone token-launch-tool-zone-main">
             <div className="token-launch-tool-zone-head">
               <div>
-                <div className="token-launch-tool-zone-kicker">Launch Workflow</div>
+                <div className="token-launch-tool-zone-kicker">Workflow</div>
                 <div className="token-launch-tool-zone-title">Launch, monitor, and hand off from one place</div>
+                <p className="token-launch-tool-zone-copy">
+                  Use one entry point for launchpad availability, recent launches, and the flow that opens your token in-app after send.
+                </p>
               </div>
             </div>
-            <TokenLaunchSection refreshNonce={launchpadRefreshNonce} />
+            <TokenLaunchSection
+              refreshNonce={launchpadRefreshNonce}
+              embedded
+              onRefreshRequested={() => setLaunchpadRefreshNonce((nonce) => nonce + 1)}
+            />
           </div>
         </div>
 
@@ -42,11 +85,17 @@ export function TokenLaunchTool() {
           <div className="token-launch-tool-zone token-launch-tool-zone-side">
             <div className="token-launch-tool-zone-head">
               <div>
-                <div className="token-launch-tool-zone-kicker">Launchpad Config</div>
+                <div className="token-launch-tool-zone-kicker">Settings</div>
                 <div className="token-launch-tool-zone-title">Store protocol settings once</div>
+                <p className="token-launch-tool-zone-copy">
+                  Keep LaunchLab and DBC config in-app so the launch workflow can resolve readiness without bouncing you out to env setup.
+                </p>
               </div>
             </div>
-            <LaunchpadSettingsSection onSettingsSaved={() => setLaunchpadRefreshNonce((nonce) => nonce + 1)} />
+            <LaunchpadSettingsSection
+              embedded
+              onSettingsSaved={() => setLaunchpadRefreshNonce((nonce) => nonce + 1)}
+            />
           </div>
 
           <div className="token-launch-tool-note">

--- a/test/services/BrowserService.test.ts
+++ b/test/services/BrowserService.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { clearHistory, getLatestPage, navigate } from '../../electron/services/BrowserService'
+
+describe('BrowserService.navigate', () => {
+  beforeEach(() => {
+    clearHistory()
+  })
+
+  it('accepts standard public https urls', async () => {
+    const result = await navigate('example.com')
+    expect(result.url).toBe('https://example.com')
+    expect(getLatestPage()?.url).toBe('https://example.com')
+  })
+
+  it('rejects localhost and private network targets', async () => {
+    await expect(navigate('http://localhost:3000')).rejects.toThrow(/blocked/i)
+    await expect(navigate('http://192.168.1.10')).rejects.toThrow(/blocked/i)
+    await expect(navigate('http://172.20.1.5')).rejects.toThrow(/blocked/i)
+    await expect(navigate('http://169.254.169.254/latest/meta-data')).rejects.toThrow(/blocked/i)
+  })
+
+  it('rejects internal domains and credentialed urls', async () => {
+    await expect(navigate('http://db.internal')).rejects.toThrow(/blocked/i)
+    await expect(navigate('https://user:pass@example.com')).rejects.toThrow(/blocked/i)
+  })
+
+  it('rejects non-http protocols', async () => {
+    await expect(navigate('file:///etc/passwd')).rejects.toThrow(/blocked/i)
+  })
+})

--- a/test/services/ValidationService.test.ts
+++ b/test/services/ValidationService.test.ts
@@ -148,6 +148,46 @@ describe('checkRateLimit', () => {
   })
 })
 
+describe('validateEmailAddress', () => {
+  it('accepts a valid email address', () => {
+    const result = ValidationService.validateEmailAddress('dev@daemon.dev')
+    expect(result.success).toBe(true)
+    expect(result.data).toBe('dev@daemon.dev')
+  })
+
+  it('trims surrounding whitespace', () => {
+    const result = ValidationService.validateEmailAddress('  dev@daemon.dev  ')
+    expect(result.success).toBe(true)
+    expect(result.data).toBe('dev@daemon.dev')
+  })
+
+  it('rejects malformed email addresses', () => {
+    const result = ValidationService.validateEmailAddress('not-an-email')
+    expect(result.success).toBe(false)
+    expect(result.errors![0]).toMatch(/invalid email/i)
+  })
+})
+
+describe('validateEmailList', () => {
+  it('accepts comma-separated email lists', () => {
+    const result = ValidationService.validateEmailList('a@daemon.dev, b@daemon.dev')
+    expect(result.success).toBe(true)
+    expect(result.data).toBe('a@daemon.dev, b@daemon.dev')
+  })
+
+  it('allows empty optional email lists', () => {
+    const result = ValidationService.validateEmailList('')
+    expect(result.success).toBe(true)
+    expect(result.data).toBeUndefined()
+  })
+
+  it('rejects invalid addresses in the list', () => {
+    const result = ValidationService.validateEmailList('a@daemon.dev, nope')
+    expect(result.success).toBe(false)
+    expect(result.errors![0]).toMatch(/invalid email/i)
+  })
+})
+
 describe('validateObject', () => {
   it('passes a valid object matching schema', () => {
     const result = ValidationService.validateObject(


### PR DESCRIPTION
## Summary

This lands the current `refactor/token-launch-ux` branch on top of `main` and folds in the remaining hardening and production stability follow-ups.

## Included

- ship the current token-launch UX polish already on this branch
- harden browser navigation against localhost, private-network, internal-domain, credentialed, and non-HTTP(S) targets
- validate and throttle `email:send` at the IPC boundary
- stabilize the Image Editor readiness handshake so miniPaint cannot get stuck in a permanent loading state
- add BrowserService coverage and extend smoke coverage to exercise the packaged Image Editor flow
- reconcile app version metadata to `2.0.11`
- keep the tightened production CSP while explicitly allowing the static miniPaint bootstrap script by hash

## Verification

- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run test:smoke`

## GitHub

Closes #43
Closes #45
Closes #46
Closes #50

Supersedes #49.