### PR TITLE
chore: release v2.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- bump the app version to 2.0.12
- cut the next patch release from the current hardened mainline

## Included since v2.0.11
- browser and email hardening from #53
- token launch UX polish from #53
- image editor teardown race fix from #54
