### PR TITLE
Hotfix UI state recovery and layout reset

### DIFF
--- a/electron/ipc/settings.ts
+++ b/electron/ipc/settings.ts
@@ -62,6 +62,10 @@ export function registerSettingsHandlers() {
     db.prepare('DELETE FROM app_crashes').run()
   }))
 
+  ipcMain.handle('settings:recover-ui-state', ipcHandler(async () => {
+    return Settings.recoverUiState()
+  }))
+
   ipcMain.handle('settings:get-pinned-tools', ipcHandler(async () => {
     return Settings.getPinnedTools()
   }))

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -40,6 +40,7 @@ import { registerValidatorHandlers } from '../ipc/validator'
 import { registerPnlHandlers } from '../ipc/pnl'
 import { registerFeedbackHandlers } from '../ipc/feedback'
 import { clearLoadedWallets } from '../services/RecoveryService'
+import { maybeRecoverUnstableUiState, type UiRecoveryResult } from '../services/SettingsService'
 import pkg from 'electron-updater'
 const { autoUpdater } = pkg
 
@@ -108,6 +109,7 @@ if (!SMOKE_TEST_MODE && !app.requestSingleInstanceLock()) {
 
 let win: BrowserWindow | null = null
 let ipcRegistered = false
+let startupUiRecovery: UiRecoveryResult | null = null
 const preload = path.join(__dirname, '../preload/index.mjs')
 const indexHtml = path.join(RENDERER_DIST, 'index.html')
 
@@ -344,10 +346,16 @@ async function createWindow() {
     const recentCrashes = db.prepare(
       'SELECT COUNT(*) as count FROM app_crashes WHERE created_at > ?'
     ).get(Date.now() - 3600_000) as { count: number }
+    startupUiRecovery = maybeRecoverUnstableUiState(recentCrashes.count)
 
     if (recentCrashes.count > 3) {
       win.webContents.on('did-finish-load', () => {
         win?.webContents.send('crash-warning', recentCrashes.count)
+      })
+    }
+    if (startupUiRecovery) {
+      win.webContents.on('did-finish-load', () => {
+        win?.webContents.send('ui-recovery-applied', startupUiRecovery)
       })
     }
   } catch { /* table may not exist yet on first run */ }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -246,6 +246,7 @@ contextBridge.exposeInMainWorld('daemon', {
     reportCrash: (data: { type: string; message: string; stack: string }) => ipcRenderer.invoke('settings:report-crash', data),
     getCrashes: () => ipcRenderer.invoke('settings:get-crashes'),
     clearCrashes: () => ipcRenderer.invoke('settings:clear-crashes'),
+    recoverUiState: () => ipcRenderer.invoke('settings:recover-ui-state'),
     getPinnedTools: () => ipcRenderer.invoke('settings:get-pinned-tools'),
     setPinnedTools: (tools: string[]) => ipcRenderer.invoke('settings:set-pinned-tools', tools),
     getDrawerToolOrder: () => ipcRenderer.invoke('settings:get-drawer-tool-order'),
@@ -262,6 +263,11 @@ contextBridge.exposeInMainWorld('daemon', {
       const handler = (_event: Electron.IpcRendererEvent, count: number) => callback(count)
       ipcRenderer.on('crash-warning', handler)
       return () => ipcRenderer.off('crash-warning', handler)
+    },
+    onUiRecoveryApplied: (callback: (result: { clearedKeys: string[]; clearedActiveSessions: number; ranAt: number }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, result: { clearedKeys: string[]; clearedActiveSessions: number; ranAt: number }) => callback(result)
+      ipcRenderer.on('ui-recovery-applied', handler)
+      return () => ipcRenderer.off('ui-recovery-applied', handler)
     },
   },
 

--- a/electron/services/SettingsService.ts
+++ b/electron/services/SettingsService.ts
@@ -92,30 +92,99 @@ export function setOnboardingProgress(progress: OnboardingProgress): void {
   setJsonSetting('onboarding_progress', progress)
 }
 
+const DEFAULT_PINNED_TOOLS = ['git', 'browser', 'token-launch', 'solana-toolbox']
+const UI_RECOVERY_KEYS = [
+  'layout_center_mode',
+  'layout_right_panel_tab',
+  'workspace_profile',
+  'pinned_tools',
+  'drawer_tool_order',
+] as const
+const UI_RECOVERY_THRESHOLD = 3
+const UI_RECOVERY_COOLDOWN_MS = 60 * 60 * 1000
+const UI_RECOVERY_MARKER_KEY = 'ui_recovery_last_run_at'
+
+export interface UiRecoveryResult {
+  clearedKeys: string[]
+  clearedActiveSessions: number
+  ranAt: number
+}
+
+function sanitizePinnedTools(value: unknown): string[] {
+  if (!Array.isArray(value)) return DEFAULT_PINNED_TOOLS
+  const seen = new Set<string>()
+  const safe = value
+    .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    .map((entry) => entry.trim())
+    .filter((entry) => {
+      if (seen.has(entry)) return false
+      seen.add(entry)
+      return true
+    })
+    .slice(0, 50)
+  return safe.length > 0 ? safe : DEFAULT_PINNED_TOOLS
+}
+
+function sanitizeWorkspaceProfile(value: WorkspaceProfile | null): WorkspaceProfile | null {
+  if (!value || typeof value !== 'object') return null
+  if (value.name !== 'web' && value.name !== 'solana' && value.name !== 'custom') return null
+  if (!value.toolVisibility || typeof value.toolVisibility !== 'object') return null
+  const toolVisibility = Object.fromEntries(
+    Object.entries(value.toolVisibility).filter(([, visible]) => typeof visible === 'boolean')
+  ) as Record<string, boolean>
+  return { name: value.name, toolVisibility }
+}
+
 export function getWorkspaceProfile(): WorkspaceProfile | null {
-  return getJsonSetting<WorkspaceProfile | null>('workspace_profile', null)
+  return sanitizeWorkspaceProfile(getJsonSetting<WorkspaceProfile | null>('workspace_profile', null))
 }
 
 export function setWorkspaceProfile(profile: WorkspaceProfile): void {
-  setJsonSetting('workspace_profile', profile)
+  const safe = sanitizeWorkspaceProfile(profile)
+  if (!safe) throw new Error('Invalid workspace profile')
+  setJsonSetting('workspace_profile', safe)
 }
 
-const DEFAULT_PINNED_TOOLS = ['git', 'browser', 'token-launch', 'solana-toolbox']
-
 export function getPinnedTools(): string[] {
-  return getJsonSetting<string[]>('pinned_tools', DEFAULT_PINNED_TOOLS)
+  return sanitizePinnedTools(getJsonSetting<unknown>('pinned_tools', DEFAULT_PINNED_TOOLS))
 }
 
 export function setPinnedTools(tools: string[]): void {
-  setJsonSetting('pinned_tools', tools)
+  setJsonSetting('pinned_tools', sanitizePinnedTools(tools))
 }
 
 export function getDrawerToolOrder(): string[] {
-  return getJsonSetting<string[]>('drawer_tool_order', [])
+  return sanitizePinnedTools(getJsonSetting<unknown>('drawer_tool_order', []))
 }
 
 export function setDrawerToolOrder(order: string[]): void {
-  setJsonSetting('drawer_tool_order', order)
+  setJsonSetting('drawer_tool_order', sanitizePinnedTools(order))
+}
+
+export function recoverUiState(): UiRecoveryResult {
+  const db = getDb()
+  const now = Date.now()
+  const deleteSetting = db.prepare('DELETE FROM app_settings WHERE key = ?')
+  for (const key of UI_RECOVERY_KEYS) {
+    deleteSetting.run(key)
+  }
+  const clearedActiveSessions = db.prepare('DELETE FROM active_sessions').run().changes
+  setJsonSetting(UI_RECOVERY_MARKER_KEY, now)
+  return {
+    clearedKeys: [...UI_RECOVERY_KEYS],
+    clearedActiveSessions,
+    ranAt: now,
+  }
+}
+
+export function maybeRecoverUnstableUiState(recentCrashCount: number): UiRecoveryResult | null {
+  if (recentCrashCount <= UI_RECOVERY_THRESHOLD) return null
+  const lastRanAt = getJsonSetting<number>(UI_RECOVERY_MARKER_KEY, 0)
+  const now = Date.now()
+  if (typeof lastRanAt === 'number' && now - lastRanAt < UI_RECOVERY_COOLDOWN_MS) {
+    return null
+  }
+  return recoverUiState()
 }
 
 const DEFAULT_TOKEN_LAUNCH_SETTINGS: TokenLaunchSettings = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,6 +219,21 @@ function App() {
   }, [])
 
   useEffect(() => {
+    return daemon.settings.onUiRecoveryApplied((result) => {
+      const cleared = result.clearedKeys.length
+      const sessionSuffix = result.clearedActiveSessions > 0
+        ? ` and ${result.clearedActiveSessions} stale session${result.clearedActiveSessions === 1 ? '' : 's'}`
+        : ''
+      useNotificationsStore.getState().pushToast({
+        kind: 'warning',
+        context: 'Workspace recovery',
+        ttlMs: 9000,
+        message: `DAEMON reset ${cleared} unstable UI setting${cleared === 1 ? '' : 's'}${sessionSuffix} so the workspace could boot cleanly.`,
+      })
+    })
+  }, [])
+
+  useEffect(() => {
     if (!smokeMode) return
     console.log('[smoke-renderer] app:state', JSON.stringify({
       appReady,

--- a/src/panels/SettingsPanel/SettingsPanel.tsx
+++ b/src/panels/SettingsPanel/SettingsPanel.tsx
@@ -575,6 +575,8 @@ function CrashesSection() {
 }
 
 function SetupSection() {
+  const [resettingLayout, setResettingLayout] = useState(false)
+
   const handleRerunWizard = async () => {
     const freshProgress = { profile: 'pending' as const, claude: 'pending' as const, gmail: 'pending' as const, vercel: 'pending' as const, railway: 'pending' as const, tour: 'pending' as const }
     await window.daemon.settings.setOnboardingComplete(false)
@@ -588,18 +590,46 @@ function SetupSection() {
     useOnboardingStore.getState().startTour()
   }
 
+  const handleResetLayout = async () => {
+    setResettingLayout(true)
+    try {
+      const res = await window.daemon.settings.recoverUiState()
+      if (!res.ok) throw new Error(res.error ?? 'Failed to reset UI layout')
+      useNotificationsStore.getState().pushToast({
+        kind: 'warning',
+        context: 'Workspace recovery',
+        ttlMs: 5000,
+        message: 'UI layout reset. Reloading workspace...',
+      })
+      window.daemon.window.reload()
+    } catch (err) {
+      useNotificationsStore.getState().pushError(err, 'Reset UI layout')
+      setResettingLayout(false)
+    }
+  }
+
   return (
     <div className="settings-section">
       <div className="settings-section-desc">
         Re-run the setup wizard or take the app tour again.
       </div>
-      <div style={{ display: 'flex', gap: 8 }}>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
         <button className="settings-btn primary" onClick={handleRerunWizard}>
           Re-run Setup Wizard
         </button>
         <button className="settings-btn" onClick={handleStartTour}>
           Take App Tour
         </button>
+        <button className="settings-btn danger" onClick={handleResetLayout} disabled={resettingLayout}>
+          {resettingLayout ? 'Resetting...' : 'Reset UI Layout'}
+        </button>
+      </div>
+      <div className="settings-section-desc" style={{ marginTop: 8 }}>
+        Reset UI Layout clears saved panel/layout state and stale sessions, then reloads DAEMON. Project, wallet, key, and history data stay intact.
+      </div>
+      <div className="settings-divider" />
+      <div className="settings-section-desc">
+        Recovery is the right first step if the app opens blank, freezes after launch, or restores into a broken layout.
       </div>
     </div>
   )

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -387,6 +387,12 @@ declare global {
     created_at: number
   }
 
+  interface UiRecoveryResult {
+    clearedKeys: string[]
+    clearedActiveSessions: number
+    ranAt: number
+  }
+
   interface DaemonSettings {
     getUi: () => Promise<IpcResponse<UiSettings>>
     setShowMarketTape: (enabled: boolean) => Promise<IpcResponse>
@@ -398,6 +404,7 @@ declare global {
     reportCrash: (data: { type: string; message: string; stack: string }) => Promise<IpcResponse>
     getCrashes: () => Promise<IpcResponse<AppCrashEntry[]>>
     clearCrashes: () => Promise<IpcResponse>
+    recoverUiState: () => Promise<IpcResponse<UiRecoveryResult>>
     getPinnedTools: () => Promise<IpcResponse<string[]>>
     setPinnedTools: (tools: string[]) => Promise<IpcResponse>
     getDrawerToolOrder: () => Promise<IpcResponse<string[]>>
@@ -411,6 +418,7 @@ declare global {
     getLayout: () => Promise<IpcResponse<{ centerMode: string | null; rightPanelTab: string | null }>>
     setLayout: (layout: { centerMode?: string; rightPanelTab?: string }) => Promise<IpcResponse>
     onCrashWarning: (callback: (count: number) => void) => () => void
+    onUiRecoveryApplied: (callback: (result: UiRecoveryResult) => void) => () => void
   }
 
   interface DaemonAgents {

--- a/test/services/SettingsService.test.ts
+++ b/test/services/SettingsService.test.ts
@@ -12,7 +12,14 @@ vi.mock('../../electron/db/db', () => ({
   }),
 }))
 
-import { getTokenLaunchSettings, setTokenLaunchSettings } from '../../electron/services/SettingsService'
+import {
+  getPinnedTools,
+  getTokenLaunchSettings,
+  getWorkspaceProfile,
+  maybeRecoverUnstableUiState,
+  recoverUiState,
+  setTokenLaunchSettings,
+} from '../../electron/services/SettingsService'
 
 describe('SettingsService token launch settings', () => {
   beforeEach(() => {
@@ -20,6 +27,8 @@ describe('SettingsService token launch settings', () => {
     mockPrepare.mockImplementation((sql: string) => {
       if (sql.includes('SELECT value FROM app_settings')) return { get: mockGet }
       if (sql.includes('INSERT INTO app_settings')) return { run: mockRun }
+      if (sql.includes('DELETE FROM app_settings WHERE key = ?')) return { run: mockRun }
+      if (sql.includes('DELETE FROM active_sessions')) return { run: () => ({ changes: 2 }) }
       return { get: vi.fn(), run: vi.fn() }
     })
     mockGet.mockReturnValue(undefined)
@@ -64,5 +73,41 @@ describe('SettingsService token launch settings', () => {
       expect.stringContaining('"configId":"11111111111111111111111111111111"'),
       expect.any(Number),
     )
+  })
+
+  it('sanitizes pinned tools from storage', () => {
+    mockGet.mockReturnValue({
+      value: JSON.stringify(['git', '', 'browser', 'git', 42]),
+    })
+
+    expect(getPinnedTools()).toEqual(['git', 'browser'])
+  })
+
+  it('drops invalid workspace profiles from storage', () => {
+    mockGet.mockReturnValue({
+      value: JSON.stringify({ name: 'broken', toolVisibility: { git: true } }),
+    })
+
+    expect(getWorkspaceProfile()).toBeNull()
+  })
+
+  it('recovers unstable UI state by clearing persisted layout keys and sessions', () => {
+    const result = recoverUiState()
+
+    expect(mockRun).toHaveBeenCalledWith('layout_center_mode')
+    expect(mockRun).toHaveBeenCalledWith('layout_right_panel_tab')
+    expect(mockRun).toHaveBeenCalledWith('workspace_profile')
+    expect(mockRun).toHaveBeenCalledWith('pinned_tools')
+    expect(mockRun).toHaveBeenCalledWith('drawer_tool_order')
+    expect(mockRun).toHaveBeenCalledWith('ui_recovery_last_run_at', expect.any(String), expect.any(Number))
+    expect(result.clearedActiveSessions).toBe(2)
+  })
+
+  it('auto-recovers once crash threshold is exceeded', () => {
+    mockGet.mockReturnValueOnce(undefined)
+
+    const result = maybeRecoverUnstableUiState(4)
+
+    expect(result?.clearedKeys).toContain('workspace_profile')
   })
 })


### PR DESCRIPTION
## Summary
- add automatic recovery for unstable persisted UI state after repeated crashes
- add a manual Reset UI Layout action in Settings
- sanitize persisted layout/profile state before loading it
- surface recovery feedback to the user on boot

## Verification
- `pnpm exec vitest run test/services/SettingsService.test.ts`
- `pnpm run typecheck`
- `pnpm run build`