### PR TITLE
Refactor shell into canvas workflows

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -369,6 +369,21 @@ Output: bullet points with inline citations. Be direct. No fluff.`,
     console.warn('[Migrations] solana-mcp-server registry seed check failed:', (err as Error).message)
   }
 
+  // Ensure Phantom Connect SDK docs MCP exists in registry (remote HTTP MCP from Phantom docs)
+  try {
+    const hasPhantomDocsMcp = db.prepare("SELECT name FROM mcp_registry WHERE name = 'phantom-docs'").get()
+    if (!hasPhantomDocsMcp) {
+      db.prepare('INSERT OR IGNORE INTO mcp_registry (name, config, description, is_global) VALUES (?,?,?,?)').run(
+        'phantom-docs',
+        JSON.stringify({ type: 'http', url: 'https://docs.phantom.com/mcp' }),
+        'Phantom Connect SDK documentation MCP for wallet connection, signing, and Phantom Portal guidance',
+        0,
+      )
+    }
+  } catch (err) {
+    console.warn('[Migrations] phantom-docs registry seed check failed:', (err as Error).message)
+  }
+
   // Ensure payai-mcp-server exists in registry (x402 payment protocol for AI agents)
   try {
     const hasPayaiMcp = db.prepare("SELECT name FROM mcp_registry WHERE name = 'payai-mcp-server'").get()
@@ -677,6 +692,12 @@ function seedMcpRegistry(db: Database.Database) {
       name: 'solana-mcp-server',
       config: JSON.stringify({ command: 'npx', args: ['-y', 'solana-mcp-server'] }),
       description: 'Solana program deployment, account inspection, and docs search',
+      isGlobal: 0,
+    },
+    {
+      name: 'phantom-docs',
+      config: JSON.stringify({ type: 'http', url: 'https://docs.phantom.com/mcp' }),
+      description: 'Phantom Connect SDK docs MCP for wallet connection, signing, and Phantom Portal guidance',
       isGlobal: 0,
     },
     {

--- a/electron/ipc/settings.ts
+++ b/electron/ipc/settings.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { ipcMain, app } from 'electron'
 import crypto from 'node:crypto'
 import * as Settings from '../services/SettingsService'
 import { ipcHandler } from '../services/IpcHandlerFactory'
@@ -7,6 +7,16 @@ import { getDb } from '../db/db'
 export function registerSettingsHandlers() {
   ipcMain.handle('settings:get-ui', ipcHandler(async () => {
     return Settings.getUiSettings()
+  }))
+
+  ipcMain.handle('settings:get-app-meta', ipcHandler(async () => {
+    return {
+      version: app.getVersion(),
+      electronVersion: process.versions.electron,
+      platform: process.platform,
+      updateChannel: 'release',
+      releaseUrl: 'https://github.com/nullxnothing/daemon/releases/latest',
+    }
   }))
 
   ipcMain.handle('settings:set-show-market-tape', ipcHandler(async (_event, enabled: boolean) => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -237,6 +237,7 @@ contextBridge.exposeInMainWorld('daemon', {
 
   settings: {
     getUi: () => ipcRenderer.invoke('settings:get-ui'),
+    getAppMeta: () => ipcRenderer.invoke('settings:get-app-meta'),
     setShowMarketTape: (enabled: boolean) => ipcRenderer.invoke('settings:set-show-market-tape', enabled),
     setShowTitlebarWallet: (enabled: boolean) => ipcRenderer.invoke('settings:set-show-titlebar-wallet', enabled),
     isOnboardingComplete: () => ipcRenderer.invoke('settings:is-onboarding-complete'),

--- a/electron/services/McpConfig.ts
+++ b/electron/services/McpConfig.ts
@@ -8,10 +8,11 @@ export type { McpEntry }
 export type McpListEntry = McpEntry
 
 interface McpServerConfig {
-  command: string
-  args: string[]
+  command?: string
+  args?: string[]
   env?: Record<string, string>
   type?: string
+  url?: string
 }
 
 const CLAUDE_JSON_PATH = path.join(os.homedir(), '.claude.json')

--- a/electron/services/SolanaDetector.ts
+++ b/electron/services/SolanaDetector.ts
@@ -80,7 +80,7 @@ export function detect(projectPath: string): SolanaProjectInfo {
   // Suggest MCPs based on detection
   const suggestedMcps: string[] = []
   if (isSolanaProject) {
-    suggestedMcps.push('solana-mcp-server', 'helius')
+    suggestedMcps.push('solana-mcp-server', 'helius', 'phantom-docs')
   }
 
   return { isSolanaProject, framework, indicators, suggestedMcps }

--- a/electron/shared/types.ts
+++ b/electron/shared/types.ts
@@ -205,7 +205,7 @@ export interface GhostPort {
 
 export interface McpEntry {
   name: string
-  config: { command?: string; args?: string[]; env?: Record<string, string>; type?: string }
+  config: { command?: string; args?: string[]; env?: Record<string, string>; type?: string; url?: string }
   source: string
   enabled: boolean
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "release": "npm version patch && git push && git push --tags",
     "pretest": "vite build --mode=test",
     "test": "vitest run",
-    "test:smoke": "pnpm run build && node scripts/smoke/electron-smoke.mjs"
+    "test:smoke": "pnpm run build && node scripts/smoke/electron-smoke.mjs",
+    "test:journeys": "pnpm run build && node scripts/smoke/workflow-journeys.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",

--- a/scripts/smoke/workflow-journeys.mjs
+++ b/scripts/smoke/workflow-journeys.mjs
@@ -169,13 +169,11 @@ async function verifyWalletJourney(page) {
     const body = document.body.textContent ?? ''
     return body.includes('tracked') || body.includes('Wallet data couldn\'t load')
   }, { timeout: 30000 })
-  await page.locator('.wallet-panel .wallet-icon-btn').click()
+  await page.getByRole('button', { name: 'Infra', exact: true }).click()
   await page.waitForFunction(() => {
     const body = document.body.textContent ?? ''
-    return body.includes('Wallet Infrastructure') || body.includes('No wallets configured') || body.includes('Add Wallet')
+    return body.includes('Infrastructure') || body.includes('Save RPC Settings') || body.includes('Save Execution Settings')
   }, { timeout: 30000 })
-  await page.keyboard.press('Escape')
-  await page.waitForFunction(() => !document.querySelector('.wallet-panel'), { timeout: 30000 })
 }
 
 async function verifySolanaWorkflowTabs(page) {
@@ -206,10 +204,13 @@ async function verifySolanaWorkflowTabs(page) {
       return activeLabel === expectedTab
     }, tab.name, { timeout: 30000 })
     await tab.check()
+    if (tab.name === 'Connect') {
+      await page.waitForFunction(() => {
+        const body = document.body.textContent ?? ''
+        return body.includes('Phantom Docs') || body.includes('phantom-docs')
+      }, { timeout: 30000 })
+    }
   }
-
-  await page.keyboard.press('Escape')
-  await page.waitForFunction(() => !document.querySelector('.solana-toolbox'), { timeout: 30000 })
 }
 
 async function verifyTokenLaunchFlow(page) {
@@ -226,8 +227,6 @@ async function verifyTokenLaunchFlow(page) {
     const body = document.body.textContent ?? ''
     return body.includes('Pump live now') && body.includes('Launch Token')
   }, { timeout: 30000 })
-  await page.keyboard.press('Escape')
-  await page.waitForFunction(() => !document.querySelector('.token-launch-tool'), { timeout: 30000 })
 }
 
 async function verifyRecoverySurface(page) {

--- a/scripts/smoke/workflow-journeys.mjs
+++ b/scripts/smoke/workflow-journeys.mjs
@@ -1,0 +1,298 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import net from 'node:net'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+const repoRoot = path.resolve(__dirname, '..', '..')
+const electronBinary = process.env.DAEMON_SMOKE_ELECTRON || require('electron')
+const mainEntry = path.join(repoRoot, 'dist-electron', 'main', 'index.js')
+const userDataDir = mkdtempSync(path.join(tmpdir(), 'daemon-workflow-smoke-'))
+
+const projectPath = repoRoot
+const projectName = 'DAEMON Workflow Smoke'
+const validConfig = '11111111111111111111111111111111'
+
+let electronProcess
+let browser
+const rendererFailures = []
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.unref()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Unable to allocate port')))
+        return
+      }
+      server.close(() => resolve(address.port))
+    })
+  })
+}
+
+function waitForPort(port, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs
+  return new Promise((resolve, reject) => {
+    const tryConnect = () => {
+      const socket = net.connect({ port, host: '127.0.0.1' })
+      socket.once('connect', () => {
+        socket.destroy()
+        resolve()
+      })
+      socket.once('error', () => {
+        socket.destroy()
+        if (Date.now() >= deadline) {
+          reject(new Error(`Timed out waiting for port ${port}`))
+          return
+        }
+        setTimeout(tryConnect, 250)
+      })
+    }
+    tryConnect()
+  })
+}
+
+async function getPage() {
+  const deadline = Date.now() + 30000
+  while (Date.now() < deadline) {
+    const context = browser?.contexts()?.[0]
+    const page = context?.pages()?.[0]
+    if (page) return page
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error('Timed out waiting for a BrowserWindow page')
+}
+
+function attachPageDiagnostics(page) {
+  page.on('pageerror', (error) => {
+    rendererFailures.push(error.message)
+  })
+  page.on('console', (message) => {
+    if (message.type() === 'error') rendererFailures.push(message.text())
+  })
+}
+
+async function waitForAppReady(page) {
+  await page.waitForFunction(() => !!window.daemon, { timeout: 30000 })
+  await page.waitForSelector('.titlebar', { timeout: 30000 })
+  await page.waitForSelector('.main-layout', { timeout: 30000 })
+}
+
+async function seedWorkflowState(page) {
+  await page.evaluate(async ({ projectPath, projectName, validConfig }) => {
+    await window.daemon.settings.setOnboardingComplete(true)
+    await window.daemon.settings.setTokenLaunchSettings({
+      raydium: { configId: validConfig, quoteMint: validConfig },
+      meteora: { configId: validConfig, quoteMint: validConfig, baseSupply: '1000000000' },
+    })
+
+    const projects = await window.daemon.projects.list()
+    let project = projects.ok ? projects.data?.find((entry) => entry.path === projectPath) : null
+    if (!project) {
+      const created = await window.daemon.projects.create({ name: projectName, path: projectPath })
+      project = created.ok ? created.data : null
+    }
+
+    const wallets = await window.daemon.wallet.list()
+    let wallet = wallets.ok ? wallets.data?.find((entry) => entry.hasKeypair) ?? wallets.data?.[0] : null
+    if (!wallet) {
+      const generated = await window.daemon.wallet.generate({ name: 'Workflow Wallet' })
+      wallet = generated.ok ? generated.data : null
+    }
+
+    if (project?.id && wallet?.id) {
+      await window.daemon.wallet.assignProject(project.id, wallet.id)
+    }
+  }, { projectPath, projectName, validConfig })
+}
+
+async function openToolFromLauncher(page, toolName, readySelector = null) {
+  const drawerVisible = await page.locator('.command-drawer').isVisible().catch(() => false)
+  if (!drawerVisible) {
+    await page.getByRole('button', { name: 'Tools', exact: true }).click()
+    await page.waitForSelector('.command-drawer', { timeout: 30000 })
+  }
+
+  const drawerSearchVisible = await page.locator('.drawer-search').isVisible().catch(() => false)
+  if (!drawerSearchVisible) {
+    await page.keyboard.press('Escape')
+    await page.waitForSelector('.drawer-search', { timeout: 30000 })
+  }
+
+  const clicked = await page.locator('.drawer-tool-card').evaluateAll((nodes, expectedName) => {
+    for (const node of nodes) {
+      const label = node.querySelector('.drawer-tool-name')?.textContent?.trim()
+      if (label === expectedName) {
+        ;(node).scrollIntoView({ block: 'center' })
+        ;(node).click()
+        return true
+      }
+    }
+    return false
+  }, toolName)
+  if (!clicked) {
+    throw new Error(`Could not find drawer tool card for ${toolName}`)
+  }
+  if (readySelector) {
+    await page.waitForSelector(readySelector, { timeout: 30000 })
+    return
+  }
+  await page.waitForFunction((expected) => {
+    const title = document.querySelector('.drawer-title')?.textContent?.trim()
+    return title?.toLowerCase() === String(expected).toLowerCase()
+  }, toolName, { timeout: 30000 })
+}
+
+async function verifyFirstLaunchOnboarding(page) {
+  await page.waitForSelector('.wizard-overlay', { timeout: 30000 })
+  await page.waitForSelector('.wizard-card', { timeout: 30000 })
+  await page.reload()
+  await waitForAppReady(page)
+}
+
+async function verifyWalletJourney(page) {
+  await openToolFromLauncher(page, 'Wallet', '.wallet-panel')
+  await page.waitForFunction(() => {
+    const tabs = Array.from(document.querySelectorAll('.wallet-tab')).map((node) => node.textContent?.trim())
+    return tabs.includes('Wallet') && tabs.includes('Agents')
+  }, { timeout: 30000 })
+  await page.waitForFunction(() => {
+    const body = document.body.textContent ?? ''
+    return body.includes('tracked') || body.includes('Wallet data couldn\'t load')
+  }, { timeout: 30000 })
+  await page.locator('.wallet-panel .wallet-icon-btn').click()
+  await page.waitForFunction(() => {
+    const body = document.body.textContent ?? ''
+    return body.includes('Wallet Infrastructure') || body.includes('No wallets configured') || body.includes('Add Wallet')
+  }, { timeout: 30000 })
+  await page.keyboard.press('Escape')
+  await page.waitForFunction(() => !document.querySelector('.wallet-panel'), { timeout: 30000 })
+}
+
+async function verifySolanaWorkflowTabs(page) {
+  await openToolFromLauncher(page, 'Solana', '.solana-toolbox')
+  const tabs = [
+    { name: 'Overview', check: () => page.locator('.solana-workflow-title').waitFor({ timeout: 30000 }) },
+    { name: 'Connect', check: () => page.locator('.solana-service-row, .solana-split-title').first().waitFor({ timeout: 30000 }) },
+    { name: 'Build', check: () => page.locator('.solana-integration-row, .solana-skill-group').first().waitFor({ timeout: 30000 }) },
+    { name: 'Integrate', check: () => page.locator('.solana-protocol-card').first().waitFor({ timeout: 30000 }) },
+    { name: 'Diagnose', check: () => page.locator('.solana-toolchain-card').first().waitFor({ timeout: 30000 }) },
+  ]
+
+  for (const tab of tabs) {
+    await page.locator('.solana-view-tab').evaluateAll((nodes, expected) => {
+      for (const node of nodes) {
+        const text = node.querySelector('.solana-view-tab-label')?.textContent?.trim()
+        if (text === expected) {
+          node.scrollIntoView({ block: 'center' })
+          node.click()
+          return true
+        }
+      }
+      return false
+    }, tab.name)
+    await page.waitForFunction((expectedTab) => {
+      const activeTab = document.querySelector('.solana-view-tab.active')
+      const activeLabel = activeTab?.querySelector('.solana-view-tab-label')?.textContent?.trim()
+      return activeLabel === expectedTab
+    }, tab.name, { timeout: 30000 })
+    await tab.check()
+  }
+
+  await page.keyboard.press('Escape')
+  await page.waitForFunction(() => !document.querySelector('.solana-toolbox'), { timeout: 30000 })
+}
+
+async function verifyTokenLaunchFlow(page) {
+  await openToolFromLauncher(page, 'Token Launch', '.token-launch-tool')
+  await page.waitForFunction(() => {
+    const body = document.body.textContent ?? ''
+    return body.includes('Step 1')
+      && body.includes('Check readiness and recent launches')
+      && body.includes('Step 2')
+      && body.includes('Save protocol config once')
+      && body.includes('Recommended flow')
+  }, { timeout: 30000 })
+  await page.waitForFunction(() => {
+    const body = document.body.textContent ?? ''
+    return body.includes('Pump live now') && body.includes('Launch Token')
+  }, { timeout: 30000 })
+  await page.keyboard.press('Escape')
+  await page.waitForFunction(() => !document.querySelector('.token-launch-tool'), { timeout: 30000 })
+}
+
+async function verifyRecoverySurface(page) {
+  await openToolFromLauncher(page, 'Settings', '.settings-center')
+  await page.locator('[data-tab="setup"]').click()
+  await page.waitForFunction(() => {
+    const body = document.body.textContent ?? ''
+    return body.includes('Re-run Setup Wizard') && body.includes('Reset UI Layout')
+  }, { timeout: 30000 })
+}
+
+async function run() {
+  const cdpPort = await getFreePort()
+  electronProcess = spawn(electronBinary, [mainEntry], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      DAEMON_SMOKE_TEST: '1',
+      DAEMON_SMOKE_CDP_PORT: String(cdpPort),
+      DAEMON_USER_DATA_DIR: userDataDir,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  electronProcess.stdout.on('data', (chunk) => process.stdout.write(chunk))
+  electronProcess.stderr.on('data', (chunk) => process.stderr.write(chunk))
+
+  await waitForPort(cdpPort)
+  browser = await chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`)
+
+  const page = await getPage()
+  attachPageDiagnostics(page)
+  await waitForAppReady(page)
+
+  await verifyFirstLaunchOnboarding(page)
+  await seedWorkflowState(page)
+  await page.reload()
+  await waitForAppReady(page)
+  await page.waitForSelector('.project-tab.active', { timeout: 30000 })
+
+  await verifyWalletJourney(page)
+  await verifySolanaWorkflowTabs(page)
+  await verifyTokenLaunchFlow(page)
+  await verifyRecoverySurface(page)
+
+  assert.equal(rendererFailures.length, 0, `renderer failures detected:\n${rendererFailures.join('\n')}`)
+}
+
+try {
+  await run()
+  console.log('Workflow journey smoke passed')
+} finally {
+  await browser?.close().catch(() => {})
+  if (electronProcess && electronProcess.exitCode === null) {
+    electronProcess.kill('SIGTERM')
+    await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        electronProcess.kill('SIGKILL')
+        resolve()
+      }, 5000)
+      electronProcess.once('exit', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  }
+  rmSync(userDataDir, { recursive: true, force: true })
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { useWalletStore } from './store/wallet'
 import { usePluginStore } from './store/plugins'
 import { useEmailStore } from './store/email'
 import { useSolanaToolboxStore } from './store/solanaToolbox'
+import { useWorkflowShellStore } from './store/workflowShell'
 import { SolanaOnboardingBanner } from './components/SolanaOnboarding/SolanaOnboardingBanner'
 import { useSplitter } from './hooks/useSplitter'
 import { useProjects } from './hooks/useProjects'
@@ -56,8 +57,8 @@ function App() {
   const tourActive = useOnboardingStore((s) => s.tourActive)
   const showTourOffer = useOnboardingStore((s) => s.showTourOffer)
   const centerMode = useUIStore((s) => s.centerMode)
-  const drawerOpen = useUIStore((s) => s.drawerOpen)
-  const launchWizardOpen = useUIStore((s) => s.launchWizardOpen)
+  const drawerOpen = useWorkflowShellStore((s) => s.drawerOpen)
+  const launchWizardOpen = useWorkflowShellStore((s) => s.launchWizardOpen)
   const [showExplorer, setShowExplorer] = useState(true)
   const [showRightPanel, setShowRightPanel] = useState(true)
   const [showAgentLauncher, setShowAgentLauncher] = useState(false)
@@ -316,7 +317,7 @@ function App() {
         toggleRightPanel: () => setShowRightPanel((v) => !v),
         openAgentLauncher: () => setShowAgentLauncher(true),
         toggleExplorer: () => setShowExplorer((v) => !v),
-        setDrawerTool: (tool) => useUIStore.getState().setDrawerTool(tool),
+        setDrawerTool: (tool) => useWorkflowShellStore.getState().setDrawerTool(tool),
         toggleBrowserTab: () => useUIStore.getState().toggleBrowserTab(),
         toggleDashboardTab: () => useUIStore.getState().toggleDashboardTab(),
       }),
@@ -333,7 +334,7 @@ function App() {
           <span>DAEMON recovered from {crashWarningCount} errors in the last hour.</span>
           <button
             className="crash-warning-link"
-            onClick={() => { useUIStore.getState().setDrawerTool('settings'); setCrashWarningCount(null) }}
+            onClick={() => { useWorkflowShellStore.getState().setDrawerTool('settings'); setCrashWarningCount(null) }}
           >
             View crash log
           </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -317,7 +317,8 @@ function App() {
         toggleRightPanel: () => setShowRightPanel((v) => !v),
         openAgentLauncher: () => setShowAgentLauncher(true),
         toggleExplorer: () => setShowExplorer((v) => !v),
-        setDrawerTool: (tool) => useWorkflowShellStore.getState().setDrawerTool(tool),
+        openWorkspaceTool: (tool) => useUIStore.getState().openWorkspaceTool(tool),
+        closeDrawer: () => useWorkflowShellStore.getState().closeDrawer(),
         toggleBrowserTab: () => useUIStore.getState().toggleBrowserTab(),
         toggleDashboardTab: () => useUIStore.getState().toggleDashboardTab(),
       }),
@@ -334,7 +335,7 @@ function App() {
           <span>DAEMON recovered from {crashWarningCount} errors in the last hour.</span>
           <button
             className="crash-warning-link"
-            onClick={() => { useWorkflowShellStore.getState().setDrawerTool('settings'); setCrashWarningCount(null) }}
+            onClick={() => { useUIStore.getState().openWorkspaceTool('settings'); setCrashWarningCount(null) }}
           >
             View crash log
           </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -317,6 +317,14 @@ function App() {
         toggleRightPanel: () => setShowRightPanel((v) => !v),
         openAgentLauncher: () => setShowAgentLauncher(true),
         toggleExplorer: () => setShowExplorer((v) => !v),
+        returnToEditor: () => {
+          const ui = useUIStore.getState()
+          ui.setCenterMode('canvas')
+          ui.setBrowserTabActive(false)
+          ui.setDashboardTabActive(false)
+          ui.setActiveWorkspaceTool(null)
+          useWorkflowShellStore.getState().closeDrawer()
+        },
         openWorkspaceTool: (tool) => useUIStore.getState().openWorkspaceTool(tool),
         closeDrawer: () => useWorkflowShellStore.getState().closeDrawer(),
         toggleBrowserTab: () => useUIStore.getState().toggleBrowserTab(),

--- a/src/components/CommandDrawer/CommandDrawer.tsx
+++ b/src/components/CommandDrawer/CommandDrawer.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback, useMemo, Suspense, type Compo
 import { useUIStore } from '../../store/ui'
 import { usePluginStore } from '../../store/plugins'
 import { useWorkspaceProfileStore } from '../../store/workspaceProfile'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { PLUGIN_REGISTRY } from '../../plugins/registry'
 import { PanelErrorBoundary } from '../ErrorBoundary'
 import { lazyNamedWithReload, lazyWithReload } from '../../utils/lazyWithReload'
@@ -314,13 +315,13 @@ function ToolFallback({ tool }: { tool?: DrawerTool | null }) {
 export const TOOL_DND_MIME = 'application/x-daemon-tool'
 
 export function CommandDrawer() {
-  const drawerOpen = useUIStore((s) => s.drawerOpen)
-  const drawerTool = useUIStore((s) => s.drawerTool)
-  const drawerFullscreen = useUIStore((s) => s.drawerFullscreen)
+  const drawerOpen = useWorkflowShellStore((s) => s.drawerOpen)
+  const drawerTool = useWorkflowShellStore((s) => s.drawerTool)
+  const drawerFullscreen = useWorkflowShellStore((s) => s.drawerFullscreen)
   const drawerToolOrder = useUIStore((s) => s.drawerToolOrder)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
-  const closeDrawer = useUIStore((s) => s.closeDrawer)
-  const toggleDrawerFullscreen = useUIStore((s) => s.toggleDrawerFullscreen)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
+  const closeDrawer = useWorkflowShellStore((s) => s.closeDrawer)
+  const toggleDrawerFullscreen = useWorkflowShellStore((s) => s.toggleDrawerFullscreen)
 
   const [search, setSearch] = useState('')
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null)
@@ -400,7 +401,7 @@ export function CommandDrawer() {
       e.preventDefault()
       e.stopPropagation()
       if (drawerTool) {
-        useUIStore.setState({ drawerTool: null, drawerFullscreen: false })
+        useWorkflowShellStore.getState().setDrawerTool(null)
       } else {
         closeDrawer()
       }
@@ -469,7 +470,7 @@ export function CommandDrawer() {
       <div className="drawer-header">
         {activeTool ? (
           <>
-            <button className="drawer-back" onClick={() => useUIStore.setState({ drawerTool: null, drawerFullscreen: false })} title="Back to tools">
+            <button className="drawer-back" onClick={() => useWorkflowShellStore.getState().setDrawerTool(null)} title="Back to tools">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                 <path d="M15 18l-6-6 6-6"/>
               </svg>

--- a/src/components/CommandDrawer/CommandDrawer.tsx
+++ b/src/components/CommandDrawer/CommandDrawer.tsx
@@ -1,10 +1,9 @@
-import { useState, useRef, useEffect, useCallback, useMemo, Suspense, type ComponentType, type DragEvent } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo, type ComponentType, type DragEvent } from 'react'
 import { useUIStore } from '../../store/ui'
 import { usePluginStore } from '../../store/plugins'
 import { useWorkspaceProfileStore } from '../../store/workspaceProfile'
 import { useWorkflowShellStore } from '../../store/workflowShell'
 import { PLUGIN_REGISTRY } from '../../plugins/registry'
-import { PanelErrorBoundary } from '../ErrorBoundary'
 import { lazyNamedWithReload, lazyWithReload } from '../../utils/lazyWithReload'
 import './CommandDrawer.css'
 
@@ -302,26 +301,14 @@ function getDrawerTools(toolVisibility: Record<string, boolean>): DrawerTool[] {
   })
 }
 
-function ToolFallback({ tool }: { tool?: DrawerTool | null }) {
-  return (
-    <div className="drawer-loading">
-      <div className="drawer-loading-title">{tool?.name ?? 'Loading tool'}</div>
-      <div className="drawer-loading-copy">Preparing panel...</div>
-    </div>
-  )
-}
-
 // Shared MIME type for tool drag-and-drop (drawer <-> sidebar)
 export const TOOL_DND_MIME = 'application/x-daemon-tool'
 
 export function CommandDrawer() {
   const drawerOpen = useWorkflowShellStore((s) => s.drawerOpen)
-  const drawerTool = useWorkflowShellStore((s) => s.drawerTool)
-  const drawerFullscreen = useWorkflowShellStore((s) => s.drawerFullscreen)
   const drawerToolOrder = useUIStore((s) => s.drawerToolOrder)
-  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
+  const openWorkspaceTool = useUIStore((s) => s.openWorkspaceTool)
   const closeDrawer = useWorkflowShellStore((s) => s.closeDrawer)
-  const toggleDrawerFullscreen = useWorkflowShellStore((s) => s.toggleDrawerFullscreen)
 
   const [search, setSearch] = useState('')
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null)
@@ -357,13 +344,13 @@ export function CommandDrawer() {
 
   // Focus search input when drawer opens in grid mode
   useEffect(() => {
-    if (drawerOpen && !drawerTool) {
+    if (drawerOpen) {
       setTimeout(() => searchRef.current?.focus(), 50)
     }
-  }, [drawerOpen, drawerTool])
+  }, [drawerOpen])
 
   useEffect(() => {
-    if (!drawerOpen || drawerTool) return
+    if (!drawerOpen) return
     const visibleToolIds = filteredTools
       .slice(0, 8)
       .map((tool) => tool.id)
@@ -392,7 +379,7 @@ export function CommandDrawer() {
       cancelled = true
       window.clearTimeout(timeoutId)
     }
-  }, [drawerOpen, drawerTool, filteredTools])
+  }, [drawerOpen, filteredTools])
 
   // Esc to close or go back to grid
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -400,13 +387,9 @@ export function CommandDrawer() {
       if (document.querySelector('.agent-launcher-overlay, .palette-overlay')) return
       e.preventDefault()
       e.stopPropagation()
-      if (drawerTool) {
-        useWorkflowShellStore.getState().setDrawerTool(null)
-      } else {
-        closeDrawer()
-      }
+      closeDrawer()
     }
-  }, [drawerTool, closeDrawer])
+  }, [closeDrawer])
 
   useEffect(() => {
     if (!drawerOpen) return
@@ -417,14 +400,14 @@ export function CommandDrawer() {
   const handleSearchKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && filteredTools.length > 0) {
       e.preventDefault()
-      setDrawerTool(filteredTools[0].id)
+      openWorkspaceTool(filteredTools[0].id)
       setSearch('')
     }
   }
 
   const handleToolClick = (toolId: string) => {
     preloadToolPanel(toolId)
-    setDrawerTool(toolId)
+    openWorkspaceTool(toolId)
     setSearch('')
   }
 
@@ -462,44 +445,18 @@ export function CommandDrawer() {
 
   if (!drawerOpen) return null
 
-  const activeTool = drawerTool ? allTools.find(t => t.id === drawerTool) : null
-
   return (
-    <div className={`command-drawer${drawerFullscreen ? ' command-drawer--fullscreen' : ''}`} ref={drawerRef}>
+    <div className="command-drawer" ref={drawerRef}>
       {/* Header */}
       <div className="drawer-header">
-        {activeTool ? (
-          <>
-            <button className="drawer-back" onClick={() => useWorkflowShellStore.getState().setDrawerTool(null)} title="Back to tools">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <path d="M15 18l-6-6 6-6"/>
-              </svg>
-            </button>
-            <span className="drawer-title">{activeTool.name}</span>
-          </>
-        ) : (
-          <input
-            ref={searchRef}
-            className="drawer-search"
-            placeholder="Search tools..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            onKeyDown={handleSearchKeyDown}
-          />
-        )}
-        {activeTool && (
-          <button className="drawer-fullscreen" onClick={toggleDrawerFullscreen} title={drawerFullscreen ? 'Exit fullscreen' : 'Fullscreen'}>
-            {drawerFullscreen ? (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="14" y1="10" x2="21" y2="3"/><line x1="3" y1="21" x2="10" y2="14"/>
-              </svg>
-            ) : (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/>
-              </svg>
-            )}
-          </button>
-        )}
+        <input
+          ref={searchRef}
+          className="drawer-search"
+          placeholder="Search tools..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={handleSearchKeyDown}
+        />
         <button className="drawer-close" onClick={closeDrawer} title="Close (Esc)">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
@@ -509,25 +466,17 @@ export function CommandDrawer() {
 
       {/* Content */}
       <div className="drawer-content">
-        {activeTool ? (
-            <PanelErrorBoundary fallbackLabel="Tool crashed — press Esc to go back">
-            <Suspense fallback={<ToolFallback tool={activeTool} />}>
-              <activeTool.component />
-            </Suspense>
-          </PanelErrorBoundary>
-        ) : (
-          <DrawerGrid
-            tools={filteredTools}
-            search={search}
-            dragOverIdx={dragOverIdx}
-            onToolClick={handleToolClick}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            onCardDragOver={handleCardDragOver}
-            onCardDragLeave={() => setDragOverIdx(null)}
-            onCardDrop={handleCardDrop}
-          />
-        )}
+        <DrawerGrid
+          tools={filteredTools}
+          search={search}
+          dragOverIdx={dragOverIdx}
+          onToolClick={handleToolClick}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onCardDragOver={handleCardDragOver}
+          onCardDragLeave={() => setDragOverIdx(null)}
+          onCardDrop={handleCardDrop}
+        />
       </div>
     </div>
   )

--- a/src/components/CommandPalette/commands.ts
+++ b/src/components/CommandPalette/commands.ts
@@ -16,6 +16,7 @@ interface CommandDeps {
   toggleRightPanel: VoidCallback
   openAgentLauncher: VoidCallback
   toggleExplorer: VoidCallback
+  returnToEditor: VoidCallback
   openWorkspaceTool: (tool: string) => void
   closeDrawer: VoidCallback
   toggleBrowserTab?: VoidCallback
@@ -29,6 +30,7 @@ export function buildCommands(deps: CommandDeps): Command[] {
     toggleRightPanel,
     openAgentLauncher,
     toggleExplorer,
+    returnToEditor,
     openWorkspaceTool,
     closeDrawer,
     toggleBrowserTab,
@@ -121,7 +123,7 @@ export function buildCommands(deps: CommandDeps): Command[] {
       id: 'nav:main-view',
       label: 'Return to Editor',
       category: 'Navigation',
-      action: () => closeDrawer(),
+      action: () => returnToEditor(),
     },
 
     // View

--- a/src/components/CommandPalette/commands.ts
+++ b/src/components/CommandPalette/commands.ts
@@ -16,7 +16,8 @@ interface CommandDeps {
   toggleRightPanel: VoidCallback
   openAgentLauncher: VoidCallback
   toggleExplorer: VoidCallback
-  setDrawerTool: (tool: string | null) => void
+  openWorkspaceTool: (tool: string) => void
+  closeDrawer: VoidCallback
   toggleBrowserTab?: VoidCallback
   toggleDashboardTab?: VoidCallback
 }
@@ -28,7 +29,8 @@ export function buildCommands(deps: CommandDeps): Command[] {
     toggleRightPanel,
     openAgentLauncher,
     toggleExplorer,
-    setDrawerTool,
+    openWorkspaceTool,
+    closeDrawer,
     toggleBrowserTab,
     toggleDashboardTab,
   } = deps
@@ -52,74 +54,74 @@ export function buildCommands(deps: CommandDeps): Command[] {
       id: 'nav:git',
       label: 'Open Git Panel',
       category: 'Navigation',
-      action: () => setDrawerTool('git'),
+      action: () => openWorkspaceTool('git'),
     },
     {
       id: 'nav:deploy',
       label: 'Open Deploy Panel',
       category: 'Navigation',
-      action: () => setDrawerTool('deploy'),
+      action: () => openWorkspaceTool('deploy'),
     },
     {
       id: 'nav:email',
       label: 'Open Email',
       category: 'Navigation',
-      action: () => setDrawerTool('email'),
+      action: () => openWorkspaceTool('email'),
     },
     {
       id: 'nav:env',
       label: 'Open Env Manager',
       category: 'Navigation',
-      action: () => setDrawerTool('env'),
+      action: () => openWorkspaceTool('env'),
     },
     {
       id: 'nav:wallet',
       label: 'Open Wallet Panel',
       category: 'Navigation',
-      action: () => setDrawerTool('wallet'),
+      action: () => openWorkspaceTool('wallet'),
     },
     {
       id: 'nav:starter',
       label: 'New Project from Template',
       category: 'Navigation',
-      action: () => setDrawerTool('starter'),
+      action: () => openWorkspaceTool('starter'),
     },
     {
       id: 'nav:settings',
       label: 'Open Settings',
       shortcut: 'Ctrl+,',
       category: 'Navigation',
-      action: () => setDrawerTool('settings'),
+      action: () => openWorkspaceTool('settings'),
     },
     {
       id: 'nav:ports',
       label: 'Open Ports',
       category: 'Navigation',
-      action: () => setDrawerTool('ports'),
+      action: () => openWorkspaceTool('ports'),
     },
     {
       id: 'nav:process',
       label: 'Open Processes',
       category: 'Navigation',
-      action: () => setDrawerTool('processes'),
+      action: () => openWorkspaceTool('processes'),
     },
     {
       id: 'nav:plugins',
       label: 'Open Plugins',
       category: 'Navigation',
-      action: () => setDrawerTool('plugins'),
+      action: () => openWorkspaceTool('plugins'),
     },
     {
       id: 'nav:recovery',
       label: 'Open Recovery',
       category: 'Navigation',
-      action: () => setDrawerTool('recovery'),
+      action: () => openWorkspaceTool('recovery'),
     },
     {
       id: 'nav:main-view',
       label: 'Return to Editor',
       category: 'Navigation',
-      action: () => setDrawerTool(null),
+      action: () => closeDrawer(),
     },
 
     // View

--- a/src/components/QuickView/EmailQuickView.tsx
+++ b/src/components/QuickView/EmailQuickView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type RefObject } from 'react'
 import { useEmailStore } from '../../store/email'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { QuickView } from './QuickView'
 
 interface EmailQuickViewProps {
@@ -18,7 +19,7 @@ function relativeTime(timestamp: number): string {
 export function EmailQuickView({ triggerRef }: EmailQuickViewProps) {
   const isOpen = useUIStore((s) => s.emailQuickViewOpen)
   const closeAll = useUIStore((s) => s.closeAllQuickViews)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
 
   const accounts = useEmailStore((s) => s.accounts)
   const messages = useEmailStore((s) => s.messages)

--- a/src/components/QuickView/EmailQuickView.tsx
+++ b/src/components/QuickView/EmailQuickView.tsx
@@ -38,7 +38,7 @@ export function EmailQuickView({ triggerRef }: EmailQuickViewProps) {
 
   const navigateToEmail = () => {
     closeAll()
-    setDrawerTool('email')
+    useUIStore.getState().openWorkspaceTool('email')
   }
 
   const handleCompose = () => {

--- a/src/components/QuickView/WalletQuickView.tsx
+++ b/src/components/QuickView/WalletQuickView.tsx
@@ -473,7 +473,7 @@ export function WalletQuickView({ triggerRef }: WalletQuickViewProps) {
 
   const navigateToWallet = () => {
     closeAll()
-    setDrawerTool('wallet')
+    useUIStore.getState().openWorkspaceTool('wallet')
   }
 
   const goBack = useCallback(() => setMode('overview'), [])

--- a/src/components/QuickView/WalletQuickView.tsx
+++ b/src/components/QuickView/WalletQuickView.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, type RefObject } from 'react'
 import { useWalletStore } from '../../store/wallet'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { formatCompactUsd } from '../../utils/format'
 import { QuickView } from './QuickView'
 
@@ -465,7 +466,7 @@ function mergeWithCommon(
 export function WalletQuickView({ triggerRef }: WalletQuickViewProps) {
   const isOpen = useUIStore((s) => s.walletQuickViewOpen)
   const closeAll = useUIStore((s) => s.closeAllQuickViews)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const dashboard = useWalletStore((s) => s.dashboard)
 
   const [mode, setMode] = useState<QuickViewMode>('overview')

--- a/src/components/SolanaOnboarding/SolanaOnboardingBanner.tsx
+++ b/src/components/SolanaOnboarding/SolanaOnboardingBanner.tsx
@@ -1,5 +1,6 @@
 import { useUIStore } from '../../store/ui'
 import { useSolanaToolboxStore } from '../../store/solanaToolbox'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import './SolanaOnboardingBanner.css'
 
 const FRAMEWORK_LABELS: Record<string, string> = {
@@ -12,7 +13,7 @@ export function SolanaOnboardingBanner() {
   const projectInfo = useSolanaToolboxStore((s) => s.projectInfo)
   const dismissed = useSolanaToolboxStore((s) => s.dismissed)
   const dismiss = useSolanaToolboxStore((s) => s.dismiss)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
   const toggleMcp = useSolanaToolboxStore((s) => s.toggleMcp)
   const mcps = useSolanaToolboxStore((s) => s.mcps)

--- a/src/components/SolanaOnboarding/SolanaOnboardingBanner.tsx
+++ b/src/components/SolanaOnboarding/SolanaOnboardingBanner.tsx
@@ -46,7 +46,7 @@ export function SolanaOnboardingBanner() {
             Enable Suggested MCPs
           </button>
         )}
-        <button className="solana-onboarding-btn" onClick={() => { setDrawerTool('solana-toolbox'); dismiss() }}>
+        <button className="solana-onboarding-btn" onClick={() => { useUIStore.getState().openWorkspaceTool('solana-toolbox'); dismiss() }}>
           Open Solana Toolbox
         </button>
         <button className="solana-onboarding-btn dismiss" onClick={dismiss}>

--- a/src/hooks/useAppShortcuts.ts
+++ b/src/hooks/useAppShortcuts.ts
@@ -67,7 +67,7 @@ export function useAppShortcuts({
         }
       } else if ((e.ctrlKey || e.metaKey) && e.key === ',') {
         e.preventDefault()
-        useWorkflowShellStore.getState().setDrawerTool('settings')
+        useUIStore.getState().openWorkspaceTool('settings')
       } else if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
         e.preventDefault()
         useWorkflowShellStore.getState().toggleDrawer()

--- a/src/hooks/useAppShortcuts.ts
+++ b/src/hooks/useAppShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, type Dispatch, type SetStateAction } from 'react'
 import { useUIStore } from '../store/ui'
+import { useWorkflowShellStore } from '../store/workflowShell'
 
 interface UseAppShortcutsOptions {
   setPaletteMode: Dispatch<SetStateAction<'commands' | 'files' | null>>
@@ -66,10 +67,10 @@ export function useAppShortcuts({
         }
       } else if ((e.ctrlKey || e.metaKey) && e.key === ',') {
         e.preventDefault()
-        useUIStore.getState().setDrawerTool('settings')
+        useWorkflowShellStore.getState().setDrawerTool('settings')
       } else if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
         e.preventDefault()
-        useUIStore.getState().toggleDrawer()
+        useWorkflowShellStore.getState().toggleDrawer()
       }
     }
     window.addEventListener('keydown', handleKeyDown)

--- a/src/panels/BrowserMode/BrowserMode.css
+++ b/src/panels/BrowserMode/BrowserMode.css
@@ -3,27 +3,121 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  background: var(--bg);
 }
 
-/* Toolbar */
+.browser-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.01);
+}
+
+.browser-toolbar-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.browser-local-strip {
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+
+.browser-local-refresh,
+.browser-local-target {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--s5);
+  border-radius: 8px;
+  background: var(--s2);
+  color: var(--t1);
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.browser-local-refresh:hover,
+.browser-local-target:hover {
+  background: var(--s3);
+  border-color: rgba(62, 207, 142, 0.2);
+}
+
+.browser-local-target.active {
+  color: var(--green);
+  border-color: rgba(62, 207, 142, 0.32);
+  background: rgba(62, 207, 142, 0.1);
+}
+
+.browser-inspect-strip {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+
+.browser-inspect-status {
+  display: inline-flex;
+  gap: 10px;
+  color: var(--t3);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.browser-inspect-selector {
+  min-width: 0;
+  color: var(--t2);
+  font-family: var(--font-code);
+  font-size: 12px;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.browser-local-strip--secondary {
+  padding-top: 2px;
+}
+
+.browser-local-target--suggested {
+  color: var(--t2);
+}
+
+.browser-local-hint {
+  color: var(--t3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
 .browser-toolbar {
   display: flex;
   align-items: center;
-  gap: 4px;
-  height: 40px;
-  padding: 0 8px;
+  gap: 6px;
+  min-height: 46px;
+  padding: 8px 10px;
   background: var(--s1);
-  border-bottom: 1px solid var(--s5);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
   flex-shrink: 0;
 }
 
 .browser-url {
   flex: 1;
-  height: 26px;
-  padding: 0 8px;
+  height: 32px;
+  padding: 0 10px;
   background: var(--s2);
   border: 1px solid var(--s5);
-  border-radius: var(--radius-sm);
+  border-radius: 8px;
   color: var(--t1);
   font-size: 12px;
   font-family: var(--font-code);
@@ -31,23 +125,23 @@
 }
 
 .browser-url:focus-visible {
-  border-color: var(--focus); box-shadow: var(--focus-ring);
+  border-color: var(--focus);
+  box-shadow: var(--focus-ring);
 }
 
 .browser-url::placeholder {
   color: var(--t4);
 }
 
-/* Nav buttons */
 .browser-nav-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 32px;
+  height: 32px;
   background: var(--s2);
   border: 1px solid var(--s5);
-  border-radius: var(--radius-sm);
+  border-radius: 8px;
   color: var(--t2);
   cursor: pointer;
   transition: background var(--transition-fast), color var(--transition-fast);
@@ -76,10 +170,9 @@
   color: var(--green);
 }
 
-/* Status dot */
 .browser-status-dot {
-  width: 5px;
-  height: 5px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
   margin: 0 4px;
@@ -101,12 +194,12 @@
   background: var(--red);
 }
 
-/* Webview area */
 .browser-webview-area {
   flex: 1;
   position: relative;
   overflow: hidden;
   background: var(--bg);
+  min-height: 0;
 }
 
 .browser-webview {
@@ -114,293 +207,22 @@
   height: 100%;
 }
 
-/* Splitter */
-.browser-splitter {
-  height: 4px;
-  background: var(--s5);
-  cursor: row-resize;
-  flex-shrink: 0;
-  transition: background var(--transition-fast);
-}
+@media (max-width: 980px) {
+  .browser-toolbar {
+    flex-wrap: wrap;
+  }
 
-.browser-splitter:hover {
-  background: var(--green-dim);
-}
+  .browser-url {
+    order: 2;
+    width: 100%;
+    flex-basis: 100%;
+  }
 
-/* Agent panel */
-.browser-terminal-area {
-  min-height: 100px;
-  overflow: hidden;
-  background: var(--bg);
-  flex-shrink: 0;
-}
+  .browser-inspect-strip {
+    grid-template-columns: 1fr;
+  }
 
-.browser-agent {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  background: var(--bg);
-}
-
-.browser-agent__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 28px;
-  padding: 0 10px;
-  background: var(--s1);
-  border-bottom: 1px solid var(--s3);
-  flex-shrink: 0;
-}
-
-.browser-agent__title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 11px;
-  color: var(--t1);
-  font-weight: 500;
-  letter-spacing: 0.3px;
-}
-
-.browser-agent__dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-}
-
-.browser-agent__dot--starting { background: var(--amber); }
-.browser-agent__dot--ready { background: var(--green); }
-.browser-agent__dot--offline { background: var(--red); }
-
-.browser-agent__dot--thinking {
-  background: var(--amber);
-  animation: browser-agent-pulse 1s ease-in-out infinite;
-}
-
-@keyframes browser-agent-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
-}
-
-.browser-agent__status {
-  font-size: 10px;
-  color: var(--t3);
-}
-
-/* Chat messages area */
-.browser-agent__messages {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  padding: 8px 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.browser-agent__empty {
-  color: var(--t3);
-  font-size: 11px;
-  text-align: center;
-  padding: 24px 12px;
-}
-
-.browser-agent__msg {
-  max-width: 90%;
-  padding: 6px 10px;
-  border-radius: 6px;
-  font-size: 12px;
-  line-height: 1.5;
-  word-break: break-word;
-  white-space: pre-wrap;
-}
-
-.browser-agent__msg--user {
-  align-self: flex-end;
-  background: var(--s3);
-  color: var(--t1);
-  border-bottom-right-radius: 2px;
-}
-
-.browser-agent__msg--agent {
-  align-self: flex-start;
-  background: var(--s1);
-  border: 1px solid var(--s3);
-  color: var(--t1);
-  border-bottom-left-radius: 2px;
-}
-
-.browser-agent__msg--system {
-  align-self: center;
-  background: transparent;
-  color: var(--t3);
-  font-size: 10px;
-  padding: 2px 8px;
-}
-
-.browser-agent__msg--inspect {
-  align-self: flex-start;
-  background: var(--s2);
-  border-left: 2px solid var(--green-dim, #2a7a55);
-  color: var(--t2);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  padding: 4px 8px;
-  word-break: break-all;
-}
-
-.browser-agent__msg-label {
-  font-size: 9px;
-  color: var(--t3);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: 2px;
-}
-
-.browser-agent__msg-text {
-  font-family: inherit;
-}
-
-/* Thinking dots */
-.browser-agent__thinking-dots {
-  display: flex;
-  gap: 4px;
-  padding: 4px 0;
-}
-
-.browser-agent__thinking-dots span {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: var(--t3);
-  animation: browser-dot-bounce 1.2s ease-in-out infinite;
-}
-
-.browser-agent__thinking-dots span:nth-child(2) { animation-delay: 0.15s; }
-.browser-agent__thinking-dots span:nth-child(3) { animation-delay: 0.3s; }
-
-@keyframes browser-dot-bounce {
-  0%, 80%, 100% { opacity: 0.3; transform: translateY(0); }
-  40% { opacity: 1; transform: translateY(-3px); }
-}
-
-/* Input bar */
-.browser-agent__input-bar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
-  background: var(--s1);
-  border-top: 1px solid var(--s3);
-  flex-shrink: 0;
-}
-
-.browser-agent__input {
-  flex: 1;
-  height: 32px;
-  padding: 0 10px;
-  background: var(--s2);
-  border: 1px solid var(--s5);
-  border-radius: 8px;
-  color: var(--t1);
-  font-size: 12px;
-  font-family: inherit;
-  outline: none;
-  transition: border-color 0.15s;
-}
-
-.browser-agent__input:focus-visible {
-  border-color: var(--focus); box-shadow: var(--focus-ring);
-}
-
-.browser-agent__input::placeholder {
-  color: var(--t3);
-}
-
-.browser-agent__send {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: var(--s3);
-  border: 1px solid var(--s5);
-  border-radius: 8px;
-  color: var(--t2);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-  flex-shrink: 0;
-  padding: 0;
-}
-
-.browser-agent__send:hover {
-  background: var(--s4);
-  color: var(--t1);
-}
-
-.browser-agent__send:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-}
-
-/* Empty state */
-.browser-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  gap: 8px;
-  color: var(--t3);
-  font-size: 12px;
-}
-
-.browser-empty__title {
-  font-size: 14px;
-  color: var(--t2);
-}
-
-.browser-empty__hint {
-  font-size: 11px;
-  color: var(--t4);
-  font-family: var(--font-code);
-  padding: 4px 8px;
-  background: var(--s2);
-  border-radius: var(--radius-sm);
-}
-
-/* Error state */
-.browser-error {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  gap: 8px;
-  color: var(--red);
-  font-size: 12px;
-}
-
-.browser-error__message {
-  font-size: 11px;
-  color: var(--t3);
-  max-width: 400px;
-  text-align: center;
-}
-
-.browser-error__retry {
-  margin-top: 4px;
-  padding: 5px 14px;
-  background: var(--s3);
-  border: 1px solid var(--s5);
-  border-radius: var(--radius-sm);
-  color: var(--t1);
-  font-size: 11px;
-  cursor: pointer;
-  transition: background var(--transition-fast);
-}
-
-.browser-error__retry:hover {
-  background: var(--s4);
+  .browser-inspect-status {
+    white-space: normal;
+  }
 }

--- a/src/panels/BrowserMode/BrowserMode.tsx
+++ b/src/panels/BrowserMode/BrowserMode.tsx
@@ -1,32 +1,46 @@
-import { useRef, useCallback } from 'react'
+import { useRef, useCallback, useMemo, useState, useEffect } from 'react'
+import { daemon } from '../../lib/daemonBridge'
 import { useBrowserStore } from '../../store/browser'
 import { PluginErrorBoundary } from '../../components/ErrorBoundary'
+import { useNotificationsStore } from '../../store/notifications'
 import { BrowserToolbar } from './BrowserToolbar'
 import { BrowserWebview, BrowserWebviewHandle } from './BrowserWebview'
 import './BrowserMode.css'
 
-// Browser mode now renders ONLY the toolbar + webview.
-// The terminal below (shared xterm.js panel) handles agent interaction.
-// This removes the duplicate BrowserAgentTerminal chat widget.
+type LocalTarget = {
+  label: string
+  url: string
+  meta?: string
+}
+
+const COMMON_DEV_PORTS = new Set([3000, 3001, 4173, 4321, 5000, 5173, 8000, 8080, 8787])
+const DEV_PROCESS_PATTERN = /(node|bun|vite|next|react|wrangler|python|deno|php|ruby|go|serve|http-server|astro|nuxt|svelte)/i
+
+function normalizeUrl(url: string) {
+  return url.replace(/\/+$/, '')
+}
 
 export function BrowserMode() {
   const webviewRef = useRef<BrowserWebviewHandle>(null)
+  const [registeredTargets, setRegisteredTargets] = useState<LocalTarget[]>([])
+  const [discoveredTargets, setDiscoveredTargets] = useState<LocalTarget[]>([])
+  const [registeredLoading, setRegisteredLoading] = useState(false)
+  const [discoveryLoading, setDiscoveryLoading] = useState(false)
+  const [lastCopiedTimestamp, setLastCopiedTimestamp] = useState<number | null>(null)
 
   const currentUrl = useBrowserStore((s) => s.currentUrl)
   const isInspectMode = useBrowserStore((s) => s.isInspectMode)
   const loadStatus = useBrowserStore((s) => s.loadStatus)
   const canGoBack = useBrowserStore((s) => s.canGoBack)
   const canGoForward = useBrowserStore((s) => s.canGoForward)
+  const inspectorResults = useBrowserStore((s) => s.inspectorResults)
   const setUrl = useBrowserStore((s) => s.setUrl)
   const setInspectMode = useBrowserStore((s) => s.setInspectMode)
 
-  const handleNavigate = useCallback(
-    (url: string) => {
-      setUrl(url)
-      webviewRef.current?.navigate(url)
-    },
-    [setUrl]
-  )
+  const handleNavigate = useCallback((url: string) => {
+    setUrl(url)
+    webviewRef.current?.navigate(url)
+  }, [setUrl])
 
   const handleBack = useCallback(() => {
     webviewRef.current?.goBack()
@@ -50,20 +64,172 @@ export function BrowserMode() {
     }
   }, [isInspectMode, setInspectMode])
 
+  const loadRegisteredTargets = useCallback(async () => {
+    setRegisteredLoading(true)
+    try {
+      const res = await window.daemon.ports.registered()
+      if (!res.ok || !res.data) {
+        setRegisteredTargets([])
+        return
+      }
+
+      const nextTargets = [...res.data]
+        .filter((entry) => entry.port >= 1024)
+        .map((entry) => ({
+          label: entry.serviceName || `Local app :${entry.port}`,
+          url: `http://127.0.0.1:${entry.port}`,
+          meta: entry.projectName !== 'Unknown' ? entry.projectName : undefined,
+        }))
+        .filter((entry, index, list) => list.findIndex((candidate) => candidate.url === entry.url) === index)
+        .sort((a, b) => a.label.localeCompare(b.label))
+
+      setRegisteredTargets(nextTargets)
+    } finally {
+      setRegisteredLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadRegisteredTargets()
+  }, [loadRegisteredTargets])
+
+  const loadDiscoveredTargets = useCallback(async () => {
+    setDiscoveryLoading(true)
+    try {
+      const res = await window.daemon.ports.scan()
+      if (!res.ok || !res.data) {
+        setDiscoveredTargets([])
+        return
+      }
+
+      const registeredUrls = new Set(registeredTargets.map((target) => normalizeUrl(target.url)))
+      const nextTargets = [...res.data]
+        .filter((entry) => entry.port >= 1024)
+        .filter((entry) => COMMON_DEV_PORTS.has(entry.port) || DEV_PROCESS_PATTERN.test(entry.processName ?? ''))
+        .map((entry) => ({
+          label: entry.processName ? `${entry.processName} :${entry.port}` : `Suggested app :${entry.port}`,
+          url: `http://127.0.0.1:${entry.port}`,
+        }))
+        .filter((entry) => !registeredUrls.has(normalizeUrl(entry.url)))
+        .filter((entry, index, list) => list.findIndex((candidate) => candidate.url === entry.url) === index)
+        .sort((a, b) => a.url.localeCompare(b.url))
+        .slice(0, 6)
+
+      setDiscoveredTargets(nextTargets)
+    } finally {
+      setDiscoveryLoading(false)
+    }
+  }, [registeredTargets])
+
+  const latestInspectResult = inspectorResults.length > 0 ? inspectorResults[inspectorResults.length - 1] : null
+  const statusLabel = loadStatus === 'loaded'
+    ? 'Ready'
+    : loadStatus === 'loading'
+      ? 'Loading'
+      : loadStatus === 'error'
+        ? 'Needs attention'
+        : 'Idle'
+
+  const inspectSummary = useMemo(() => {
+    if (!latestInspectResult) {
+      return isInspectMode
+        ? 'Click any element and the selector will copy automatically.'
+        : 'Turn on inspect to copy selectors from the page.'
+    }
+    const label = latestInspectResult.text?.trim() || latestInspectResult.tagName.toLowerCase()
+    return `Copied selector for ${label}`
+  }, [isInspectMode, latestInspectResult])
+
+  useEffect(() => {
+    if (!latestInspectResult?.selector) return
+    if (latestInspectResult.timestamp === lastCopiedTimestamp) return
+
+    let cancelled = false
+    void daemon.env.copyValue(latestInspectResult.selector)
+      .then(async (res) => {
+        if (!res.ok) {
+          await navigator.clipboard.writeText(latestInspectResult.selector)
+        }
+        if (cancelled) return
+        setLastCopiedTimestamp(latestInspectResult.timestamp)
+        const label = latestInspectResult.text?.trim() || latestInspectResult.tagName.toLowerCase()
+        useNotificationsStore.getState().pushSuccess(`Copied selector for ${label}`, 'Browser')
+      })
+      .catch(() => {
+        if (cancelled) return
+        useNotificationsStore.getState().pushError('Failed to copy selector', 'Browser')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [lastCopiedTimestamp, latestInspectResult])
+
+  const currentLocation = normalizeUrl(currentUrl)
+
   return (
     <div className="browser-mode">
-      <BrowserToolbar
-        url={currentUrl}
-        onNavigate={handleNavigate}
-        onBack={handleBack}
-        onForward={handleForward}
-        onReload={handleReload}
-        isInspectMode={isInspectMode}
-        onToggleInspect={handleToggleInspect}
-        loadStatus={loadStatus}
-        canGoBack={canGoBack}
-        canGoForward={canGoForward}
-      />
+      <section className="browser-shell">
+        <div className="browser-toolbar-row">
+          <BrowserToolbar
+            url={currentUrl}
+            onNavigate={handleNavigate}
+            onBack={handleBack}
+            onForward={handleForward}
+            onReload={handleReload}
+            isInspectMode={isInspectMode}
+            onToggleInspect={handleToggleInspect}
+            loadStatus={loadStatus}
+            canGoBack={canGoBack}
+            canGoForward={canGoForward}
+          />
+          <div className="browser-local-strip">
+            <button className="browser-local-refresh" onClick={() => void loadRegisteredTargets()} title="Refresh tracked local apps">
+              {registeredLoading ? 'Refreshing...' : 'Tracked apps'}
+            </button>
+            {registeredTargets.map((target) => (
+              <button
+                key={target.url}
+                className={`browser-local-target${currentLocation === normalizeUrl(target.url) ? ' active' : ''}`}
+                onClick={() => handleNavigate(target.url)}
+                title={target.meta ? `${target.meta} · ${target.url}` : target.url}
+              >
+                {target.label}
+              </button>
+            ))}
+            <button className="browser-local-refresh" onClick={() => void loadDiscoveredTargets()} title="Scan for likely local dev servers">
+              {discoveryLoading ? 'Scanning...' : 'Scan suggestions'}
+            </button>
+          </div>
+          {discoveredTargets.length > 0 && (
+            <div className="browser-local-strip browser-local-strip--secondary">
+              {discoveredTargets.map((target) => (
+                <button
+                  key={target.url}
+                  className={`browser-local-target browser-local-target--suggested${currentLocation === normalizeUrl(target.url) ? ' active' : ''}`}
+                  onClick={() => handleNavigate(target.url)}
+                  title={target.url}
+                >
+                  {target.label}
+                </button>
+              ))}
+            </div>
+          )}
+          {registeredTargets.length === 0 && discoveredTargets.length === 0 && !registeredLoading && !discoveryLoading && (
+            <div className="browser-local-hint">
+              Start local apps inside DAEMON to keep them tracked here. Use suggestions only when you need to discover an external dev server.
+            </div>
+          )}
+        </div>
+
+        <div className="browser-inspect-strip">
+          <div className="browser-inspect-status">
+            <span>{statusLabel}</span>
+            <span>{isInspectMode ? 'Inspect on' : 'Inspect off'}</span>
+          </div>
+          <div className="browser-inspect-selector">{inspectSummary}</div>
+        </div>
+      </section>
 
       <div className="browser-webview-area" style={{ flex: 1 }}>
         <PluginErrorBoundary>

--- a/src/panels/ClaudePanel/AriaChat.tsx
+++ b/src/panels/ClaudePanel/AriaChat.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useAriaStore } from '../../store/aria'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useBrowserStore } from '../../store/browser'
 import { AriaPresence } from './AriaPresence'
 import type { AriaAction, AriaMessage } from '../../../electron/shared/types'
@@ -126,7 +127,7 @@ export function AriaChat() {
   const sendMessage = useAriaStore((s) => s.sendMessage)
   const clearMessages = useAriaStore((s) => s.clearMessages)
   const loadHistory = useAriaStore((s) => s.loadHistory)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
 
   const [input, setInput] = useState('')
   const [isExpanded, setIsExpanded] = useState(false)

--- a/src/panels/ClaudePanel/AriaChat.tsx
+++ b/src/panels/ClaudePanel/AriaChat.tsx
@@ -127,7 +127,7 @@ export function AriaChat() {
   const sendMessage = useAriaStore((s) => s.sendMessage)
   const clearMessages = useAriaStore((s) => s.clearMessages)
   const loadHistory = useAriaStore((s) => s.loadHistory)
-  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
+  const toggleDrawer = useWorkflowShellStore((s) => s.toggleDrawer)
 
   const [input, setInput] = useState('')
   const [isExpanded, setIsExpanded] = useState(false)
@@ -194,9 +194,32 @@ export function AriaChat() {
 
   const handleAction = useCallback((action: AriaAction) => {
     switch (action.type) {
-      case 'switch_panel':
-        setDrawerTool(action.value === 'claude' ? null : action.value)
+      case 'switch_panel': {
+        const ui = useUIStore.getState()
+        const panel = action.value
+        if (panel === 'claude') {
+          ui.setRightPanelTab('claude')
+          break
+        }
+        if (panel === 'tools') {
+          toggleDrawer()
+          break
+        }
+        if (panel === 'terminal') {
+          ui.setCenterMode('canvas')
+          ui.setBrowserTabActive(false)
+          ui.setDashboardTabActive(false)
+          ui.setActiveWorkspaceTool(null)
+          break
+        }
+
+        const panelMap: Record<string, string> = {
+          process: 'processes',
+          images: 'image-editor',
+        }
+        ui.openWorkspaceTool(panelMap[panel] ?? panel)
         break
+      }
       case 'open_file': {
         const activeProjectId = useUIStore.getState().activeProjectId
         if (activeProjectId) {
@@ -233,7 +256,7 @@ export function AriaChat() {
         break
       }
     }
-  }, [setDrawerTool])
+  }, [toggleDrawer])
 
   const hasMessages = messages.length > 0 || isLoading
   const showChamber = !hasMessages

--- a/src/panels/Colosseum/HackathonPanel.css
+++ b/src/panels/Colosseum/HackathonPanel.css
@@ -5,14 +5,45 @@
   flex-direction: column;
   height: 100%;
   overflow-y: auto;
-  padding: 8px;
-  gap: 8px;
+  padding: 0 20px 28px;
+  gap: 16px;
+  background: var(--bg);
 }
 
-.hackathon-header {
+.hackathon-workspace-bar {
+  padding: 18px 0 14px;
+  border-bottom: 1px solid var(--s4);
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.008));
+}
+
+.hackathon-workspace-copy {
   display: flex;
-  align-items: center;
-  gap: 5px;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hackathon-workspace-kicker,
+.hackathon-section-title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+
+.hackathon-workspace-title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.08;
+  color: var(--t1);
+}
+
+.hackathon-workspace-subtitle {
+  margin: 0;
+  max-width: 720px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--t3);
 }
 
 .hackathon-header-label {
@@ -48,23 +79,19 @@
 .hackathon-connect {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
 .hackathon-desc {
-  font-size: 11px;
+  margin: 0;
+  font-size: 12px;
   color: var(--t3);
-  line-height: 1.4;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  line-height: 1.55;
 }
 
 .hackathon-input-row {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .hackathon-input {
@@ -150,19 +177,32 @@
 /* Active hackathon card */
 
 .hackathon-card {
-  background: var(--s1);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 8px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.012));
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
 .hackathon-card-title {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--t4);
+}
+
+.hackathon-card-value {
+  font-size: 20px;
+  line-height: 1.1;
   color: var(--t1);
+}
+
+.hackathon-card-detail {
+  font-size: 12px;
+  color: var(--t3);
 }
 
 .hackathon-countdown {
@@ -183,15 +223,6 @@
 }
 
 /* Checklist */
-
-.hackathon-section-title {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  color: var(--t3);
-  margin-top: 2px;
-}
 
 .hackathon-checklist {
   display: flex;
@@ -226,7 +257,6 @@
 
 .hackathon-search-form {
   display: flex;
-  flex-direction: column;
   gap: 6px;
 }
 
@@ -234,8 +264,6 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-height: 360px;
-  overflow-y: auto;
 }
 
 .hackathon-result-card {
@@ -290,7 +318,6 @@
 
 .hackathon-actions {
   display: flex;
-  flex-direction: column;
   gap: 6px;
 }
 
@@ -310,4 +337,28 @@
   font-size: 11px;
   color: var(--t4);
   padding: 8px 0;
+}
+
+.hackathon-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+@media (max-width: 980px) {
+  .hackathon-panel {
+    padding: 0 16px 24px;
+  }
+
+  .hackathon-workspace-title {
+    font-size: 18px;
+  }
+
+  .hackathon-summary-grid,
+  .hackathon-input-row,
+  .hackathon-search-form,
+  .hackathon-actions {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
 }

--- a/src/panels/Colosseum/HackathonPanel.tsx
+++ b/src/panels/Colosseum/HackathonPanel.tsx
@@ -168,46 +168,54 @@ export function HackathonPanel() {
   if (!isConfigured) {
     return (
       <div className="hackathon-panel">
-        <div className="hackathon-header">
-          <span className="hackathon-dot disconnected" />
-          <span className="hackathon-header-label">COLOSSEUM</span>
+        <div className="hackathon-workspace-bar">
+          <div className="hackathon-workspace-copy">
+            <span className="hackathon-workspace-kicker">Build week</span>
+            <h2 className="hackathon-workspace-title">Turn hackathon prep into a real workspace</h2>
+            <p className="hackathon-workspace-subtitle">
+              Connect Colosseum once, keep a submission checklist in-app, and jump straight into research when you need it.
+            </p>
+          </div>
         </div>
 
         <div className="hackathon-connect">
-          <p className="hackathon-desc">
-            Connect to research 5,400+ hackathon projects and track your submission.
-          </p>
+          <div className="hackathon-card">
+            <span className="hackathon-card-title">Connect Colosseum</span>
+            <p className="hackathon-desc">
+              Research 5,400+ projects, keep deadline pressure visible, and work from one place instead of bouncing to the Arena manually.
+            </p>
 
-          <div className="hackathon-input-row">
-            <input
-              type="password"
-              className="hackathon-input"
-              placeholder="Copilot PAT"
-              value={patInput}
-              onChange={(e) => setPatInput(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') handleConnect() }}
-            />
-            <button
-              className="hackathon-btn"
-              onClick={handleConnect}
-              disabled={connecting || !patInput.trim()}
+            <div className="hackathon-input-row">
+              <input
+                type="password"
+                className="hackathon-input"
+                placeholder="Copilot PAT"
+                value={patInput}
+                onChange={(e) => setPatInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleConnect() }}
+              />
+              <button
+                className="hackathon-btn"
+                onClick={handleConnect}
+                disabled={connecting || !patInput.trim()}
+              >
+                {connecting ? 'Connecting...' : 'Connect'}
+              </button>
+            </div>
+
+
+            <span
+              className="hackathon-link"
+              onClick={() => {
+                useBrowserStore.getState().setUrl('https://arena.colosseum.org/copilot')
+                useUIStore.getState().openBrowserTab()
+              }}
             >
-              {connecting ? 'Connecting...' : 'Connect'}
-            </button>
+              Get a token at arena.colosseum.org/copilot
+            </span>
+
+            {error && <div className="hackathon-error">{error}</div>}
           </div>
-
-
-          <span
-            className="hackathon-link"
-            onClick={() => {
-              useBrowserStore.getState().setUrl('https://arena.colosseum.org/copilot')
-              useUIStore.getState().openBrowserTab()
-            }}
-          >
-            Get a token at arena.colosseum.org/copilot
-          </span>
-
-          {error && <div className="hackathon-error">{error}</div>}
         </div>
       </div>
     )
@@ -218,23 +226,36 @@ export function HackathonPanel() {
 
   return (
     <div className="hackathon-panel">
-      <div className="hackathon-header">
-        <span className="hackathon-dot connected" />
-        <span className="hackathon-header-label">COLOSSEUM</span>
-        <span className="hackathon-header-status">Connected</span>
+      <div className="hackathon-workspace-bar">
+        <div className="hackathon-workspace-copy">
+          <span className="hackathon-workspace-kicker">Build week</span>
+          <h2 className="hackathon-workspace-title">Keep hackathon momentum visible</h2>
+          <p className="hackathon-workspace-subtitle">
+            Track deadline pressure, research comparable projects, and jump from planning to Arena without leaving DAEMON.
+          </p>
+        </div>
       </div>
 
-      {/* Active hackathon card */}
-      <div className="hackathon-card">
-        <span className="hackathon-card-title">Frontier</span>
-        {countdown && (
-          <span className={`hackathon-countdown ${countdown.urgency}`}>
-            {countdown.text}
-          </span>
-        )}
+      <div className="hackathon-summary-grid">
+        <div className="hackathon-card">
+          <span className="hackathon-card-title">Arena status</span>
+          <strong className="hackathon-card-value">Connected</strong>
+          <span className="hackathon-card-detail">Colosseum research is available</span>
+        </div>
+        <div className="hackathon-card">
+          <span className="hackathon-card-title">Active hackathon</span>
+          <strong className="hackathon-card-value">Frontier</strong>
+          <span className="hackathon-card-detail">Current working target</span>
+        </div>
+        <div className="hackathon-card">
+          <span className="hackathon-card-title">Deadline</span>
+          <strong className={`hackathon-card-value ${countdown?.urgency ?? 'normal'}`}>
+            {countdown?.text ?? 'No deadline'}
+          </strong>
+          <span className="hackathon-card-detail">{completedCount}/{CHECKLIST_ITEMS.length} checklist items done</span>
+        </div>
       </div>
 
-      {/* Submission checklist */}
       <span className="hackathon-section-title">Submission Checklist ({completedCount}/{CHECKLIST_ITEMS.length})</span>
       <div className="hackathon-checklist">
         {CHECKLIST_ITEMS.map((item) => (
@@ -252,7 +273,6 @@ export function HackathonPanel() {
         ))}
       </div>
 
-      {/* Research search */}
       <span className="hackathon-section-title">Research</span>
       <form className="hackathon-search-form" onSubmit={handleSearch}>
         <input
@@ -301,10 +321,9 @@ export function HackathonPanel() {
         </div>
       )}
 
-      {/* Quick actions */}
       <span className="hackathon-section-title">Quick Actions</span>
       <div className="hackathon-actions">
-        <button className="hackathon-btn-secondary" onClick={handleResearchAgent}>
+        <button className="hackathon-btn" onClick={handleResearchAgent}>
           Research Competition
         </button>
         <button className="hackathon-btn-secondary" onClick={handleOpenArena}>

--- a/src/panels/Dashboard/DashboardCanvas.tsx
+++ b/src/panels/Dashboard/DashboardCanvas.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useWalletStore } from '../../store/wallet'
 import { useDashboardData } from './useDashboardData'
 import { Sparkline } from './Sparkline'
@@ -250,7 +251,7 @@ export function DashboardCanvas() {
   const activeMint = useUIStore((s) => s.activeDashboardMint)
   const setActiveMint = useUIStore((s) => s.setActiveDashboardMint)
   const openTokenLaunch = useCallback(() => {
-    useUIStore.getState().setDrawerTool('token-launch')
+    useWorkflowShellStore.getState().setDrawerTool('token-launch')
   }, [])
 
   const dashboard = useWalletStore((s) => s.dashboard)

--- a/src/panels/Dashboard/DashboardCanvas.tsx
+++ b/src/panels/Dashboard/DashboardCanvas.tsx
@@ -251,7 +251,7 @@ export function DashboardCanvas() {
   const activeMint = useUIStore((s) => s.activeDashboardMint)
   const setActiveMint = useUIStore((s) => s.setActiveDashboardMint)
   const openTokenLaunch = useCallback(() => {
-    useWorkflowShellStore.getState().setDrawerTool('token-launch')
+    useUIStore.getState().openWorkspaceTool('token-launch')
   }, [])
 
   const dashboard = useWalletStore((s) => s.dashboard)

--- a/src/panels/Dashboard/DashboardMini.tsx
+++ b/src/panels/Dashboard/DashboardMini.tsx
@@ -144,7 +144,7 @@ export function DashboardMini() {
   }
 
   const openTokenLaunch = () => {
-    useWorkflowShellStore.getState().setDrawerTool('token-launch')
+    useUIStore.getState().openWorkspaceTool('token-launch')
   }
 
   if (tokens.length === 0) {

--- a/src/panels/Dashboard/DashboardMini.tsx
+++ b/src/panels/Dashboard/DashboardMini.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useWalletStore } from '../../store/wallet'
 import { useDashboardData } from './useDashboardData'
 import { Sparkline } from './Sparkline'
@@ -143,7 +144,7 @@ export function DashboardMini() {
   }
 
   const openTokenLaunch = () => {
-    useUIStore.getState().setDrawerTool('token-launch')
+    useWorkflowShellStore.getState().setDrawerTool('token-launch')
   }
 
   if (tokens.length === 0) {

--- a/src/panels/Editor/Editor.tsx
+++ b/src/panels/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useRef, useCallback, useState, useEffect, useMemo } from 'react'
+import { Suspense, useRef, useCallback, useState, useEffect, useMemo, type ComponentType, type LazyExoticComponent } from 'react'
 import MonacoEditor, { type OnMount, type BeforeMount, loader } from '@monaco-editor/react'
 import * as monaco from 'monaco-editor'
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
@@ -8,6 +8,7 @@ import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { useUIStore } from '../../store/ui'
 import { useWorkflowShellStore } from '../../store/workflowShell'
+import { usePluginStore } from '../../store/plugins'
 import { confirm } from '../../store/confirm'
 import { useNotificationsStore } from '../../store/notifications'
 import { AskClaudeWidget } from '../../components/AskClaudeWidget'
@@ -17,6 +18,8 @@ import { EditorTabs } from './EditorTabs'
 import { EditorBreadcrumbs } from './EditorBreadcrumbs'
 import { MarkdownTidyPreview } from './MarkdownTidyPreview'
 import { lazyNamedWithReload } from '../../utils/lazyWithReload'
+import { BUILTIN_TOOLS, TOOL_ICONS, TOOL_NAMES } from '../../components/CommandDrawer/CommandDrawer'
+import { PLUGIN_REGISTRY } from '../../plugins/registry'
 import './Editor.css'
 
 const BrowserMode = lazyNamedWithReload('browser-mode', () => import('../BrowserMode/BrowserMode'), (module) => module.BrowserMode)
@@ -81,9 +84,14 @@ export function EditorPanel() {
   const browserTabOpen = useUIStore((s) => s.browserTabOpen)
   const browserTabActive = useUIStore((s) => s.browserTabActive)
   const setBrowserTabActive = useUIStore((s) => s.setBrowserTabActive)
+  const workspaceToolTabs = useUIStore((s) => s.workspaceToolTabs)
+  const activeWorkspaceToolId = useUIStore((s) => s.activeWorkspaceToolId)
+  const setActiveWorkspaceTool = useUIStore((s) => s.setActiveWorkspaceTool)
+  const closeWorkspaceTool = useUIStore((s) => s.closeWorkspaceTool)
   const dashboardTabOpen = useUIStore((s) => s.dashboardTabOpen)
   const dashboardTabActive = useUIStore((s) => s.dashboardTabActive)
   const setDashboardTabActive = useUIStore((s) => s.setDashboardTabActive)
+  const plugins = usePluginStore((s) => s.plugins)
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
   const prevFilePathRef = useRef<string | null>(null)
   const activeFilePathRef = useRef<string | null>(null)
@@ -114,6 +122,42 @@ export function EditorPanel() {
     [activeFile?.path, activeProjectPath]
   )
   const isActiveFileMarkdown = isMarkdownFile(activeFile?.path)
+  const workspaceToolRegistry = useMemo(() => {
+    const toolMap = new Map<string, { name: string; component: LazyExoticComponent<ComponentType>; Icon: ComponentType<{ size?: number }> }>()
+    for (const tool of BUILTIN_TOOLS) {
+      toolMap.set(tool.id, {
+        name: tool.name,
+        component: tool.component,
+        Icon: TOOL_ICONS[tool.id] ?? tool.icon,
+      })
+    }
+    for (const plugin of plugins) {
+      if (!plugin.enabled) continue
+      const manifest = PLUGIN_REGISTRY[plugin.id]
+      if (!manifest) continue
+      toolMap.set(plugin.id, {
+        name: manifest.name,
+        component: manifest.component,
+        Icon: manifest.icon,
+      })
+    }
+    return toolMap
+  }, [plugins])
+  const workspaceToolTabMeta = useMemo(
+    () => workspaceToolTabs
+      .map((id) => {
+        const tool = workspaceToolRegistry.get(id)
+        if (!tool) return null
+        return {
+          id,
+          name: TOOL_NAMES[id] ?? tool.name,
+          Icon: tool.Icon,
+        }
+      })
+      .filter((tool): tool is { id: string; name: string; Icon: ComponentType<{ size?: number }> } => tool !== null),
+    [workspaceToolRegistry, workspaceToolTabs]
+  )
+  const activeWorkspaceTool = activeWorkspaceToolId ? workspaceToolRegistry.get(activeWorkspaceToolId) ?? null : null
 
   // Keep ref in sync so the onChange callback always has current path
   activeFilePathRef.current = activeFilePath
@@ -416,14 +460,16 @@ export function EditorPanel() {
   const handleBrowserTabClick = useCallback(() => {
     setBrowserTabActive(true)
     setDashboardTabActive(false)
+    setActiveWorkspaceTool(null)
   }, [setBrowserTabActive, setDashboardTabActive])
 
   const handleDashboardTabClick = useCallback(() => {
     setDashboardTabActive(true)
     setBrowserTabActive(false)
+    setActiveWorkspaceTool(null)
   }, [setDashboardTabActive, setBrowserTabActive])
 
-  const hasAnyPinnedTab = browserTabOpen || dashboardTabOpen
+  const hasAnyPinnedTab = browserTabOpen || dashboardTabOpen || workspaceToolTabs.length > 0
 
   // Show welcome when no project and no pinned tabs open
   if (!activeProjectId && !hasAnyPinnedTab) {
@@ -435,6 +481,10 @@ export function EditorPanel() {
     return (
       <div className="editor-panel">
         <EditorTabs
+          toolTabs={workspaceToolTabMeta}
+          activeToolId={activeWorkspaceToolId}
+          onSelectTool={setActiveWorkspaceTool}
+          onCloseTool={closeWorkspaceTool}
           files={[]}
           activeFilePath={null}
           savedFlash={null}
@@ -449,7 +499,11 @@ export function EditorPanel() {
         />
         <div className="editor-content">
           <Suspense fallback={<WorkspacePanelFallback />}>
-            {dashboardTabActive ? (
+            {activeWorkspaceTool ? (
+              <PanelErrorBoundary fallbackLabel={`${activeWorkspaceTool.name} crashed — reopen the tab to reload`}>
+                <activeWorkspaceTool.component />
+              </PanelErrorBoundary>
+            ) : dashboardTabActive ? (
               <DashboardCanvas />
             ) : (
               <PanelErrorBoundary fallbackLabel="Browser crashed — press Ctrl+Shift+B to reload">
@@ -469,6 +523,10 @@ export function EditorPanel() {
   return (
     <div className="editor-panel">
       <EditorTabs
+        toolTabs={workspaceToolTabMeta}
+        activeToolId={activeWorkspaceToolId}
+        onSelectTool={setActiveWorkspaceTool}
+        onCloseTool={closeWorkspaceTool}
         files={projectOpenFiles}
         activeFilePath={activeFilePath}
         savedFlash={savedFlash}
@@ -481,7 +539,15 @@ export function EditorPanel() {
         dashboardTabActive={dashboardTabActive}
         onDashboardTabClick={handleDashboardTabClick}
       />
-      {dashboardTabActive ? (
+      {activeWorkspaceTool ? (
+        <div className="editor-content">
+          <Suspense fallback={<WorkspacePanelFallback />}>
+            <PanelErrorBoundary fallbackLabel={`${activeWorkspaceTool.name} crashed — reopen the tab to reload`}>
+              <activeWorkspaceTool.component />
+            </PanelErrorBoundary>
+          </Suspense>
+        </div>
+      ) : dashboardTabActive ? (
         <div className="editor-content">
           <Suspense fallback={<WorkspacePanelFallback />}>
             <DashboardCanvas />
@@ -610,7 +676,7 @@ function ImagePreview({ filePath }: { filePath: string }) {
         {fileSize > 0 && <span className="image-preview-size">{formatFileSize(fileSize)}</span>}
         <button
           className="image-preview-edit"
-          onClick={() => useWorkflowShellStore.getState().setDrawerTool('image-editor')}
+          onClick={() => useUIStore.getState().openWorkspaceTool('image-editor')}
         >
           Edit in miniPaint
         </button>

--- a/src/panels/Editor/Editor.tsx
+++ b/src/panels/Editor/Editor.tsx
@@ -7,6 +7,7 @@ import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
 import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { confirm } from '../../store/confirm'
 import { useNotificationsStore } from '../../store/notifications'
 import { AskClaudeWidget } from '../../components/AskClaudeWidget'
@@ -609,7 +610,7 @@ function ImagePreview({ filePath }: { filePath: string }) {
         {fileSize > 0 && <span className="image-preview-size">{formatFileSize(fileSize)}</span>}
         <button
           className="image-preview-edit"
-          onClick={() => useUIStore.getState().setDrawerTool('image-editor')}
+          onClick={() => useWorkflowShellStore.getState().setDrawerTool('image-editor')}
         >
           Edit in miniPaint
         </button>

--- a/src/panels/Editor/EditorTabs.tsx
+++ b/src/panels/Editor/EditorTabs.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, useEffect, type MouseEvent as ReactMouseEvent } from 'react'
+import type { ComponentType } from 'react'
 
 interface OpenFile {
   path: string
@@ -8,6 +9,10 @@ interface OpenFile {
 }
 
 interface EditorTabsProps {
+  toolTabs: Array<{ id: string; name: string; Icon: ComponentType<{ size?: number }> }>
+  activeToolId: string | null
+  onSelectTool: (toolId: string) => void
+  onCloseTool: (toolId: string) => void
   files: OpenFile[]
   activeFilePath: string | null
   savedFlash: string | null
@@ -59,6 +64,10 @@ function GlobeIcon({ active }: { active: boolean }) {
 }
 
 export function EditorTabs({
+  toolTabs,
+  activeToolId,
+  onSelectTool,
+  onCloseTool,
   files,
   activeFilePath,
   savedFlash,
@@ -110,6 +119,35 @@ export function EditorTabs({
   return (
     <>
       <div className="editor-tabs">
+        {toolTabs.map(({ id, name, Icon }) => (
+          <button
+            key={id}
+            className={`editor-tab editor-tab-browser${activeToolId === id ? ' active' : ''}`}
+            onClick={() => onSelectTool(id)}
+            aria-label={`${name} tab`}
+          >
+            <Icon size={12} />
+            <span className="editor-tab-name">{name}</span>
+            <span
+              className="editor-tab-close"
+              role="button"
+              tabIndex={0}
+              aria-label={`Close ${name} tab`}
+              onClick={(e) => {
+                e.stopPropagation()
+                onCloseTool(id)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.stopPropagation()
+                  onCloseTool(id)
+                }
+              }}
+            >
+              &times;
+            </span>
+          </button>
+        ))}
         {browserTabOpen && (
           <>
             <button
@@ -134,13 +172,13 @@ export function EditorTabs({
             </button>
           </>
         )}
-        {(browserTabOpen || dashboardTabOpen) && files.length > 0 && (
+        {(toolTabs.length > 0 || browserTabOpen || dashboardTabOpen) && files.length > 0 && (
           <div className="editor-tab-browser-sep" />
         )}
         {files.map((file) => (
           <button
             key={file.path}
-            className={`editor-tab ${!browserTabActive && activeFilePath === file.path ? 'active' : ''} ${savedFlash === file.path ? 'saved' : ''}`}
+            className={`editor-tab ${!browserTabActive && !dashboardTabActive && !activeToolId && activeFilePath === file.path ? 'active' : ''} ${savedFlash === file.path ? 'saved' : ''}`}
             onClick={() => onSelectFile(file.projectId, file.path)}
             onContextMenu={(e) => handleTabContextMenu(e, file.projectId, file.path)}
           >

--- a/src/panels/Editor/EditorWelcome.tsx
+++ b/src/panels/Editor/EditorWelcome.tsx
@@ -63,7 +63,7 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
   }, [])
 
   const handleNewProject = useCallback(() => {
-    useWorkflowShellStore.getState().setDrawerTool('starter')
+    useUIStore.getState().openWorkspaceTool('starter')
   }, [])
 
   const handleOpenTerminal = useCallback(() => {
@@ -131,7 +131,7 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
                 <span className="editor-empty-shortcut">Ctrl+`</span>
               </button>
             ) : (
-              <button className="editor-empty-btn" onClick={() => useWorkflowShellStore.getState().setDrawerTool('settings')}>
+              <button className="editor-empty-btn" onClick={() => useUIStore.getState().openWorkspaceTool('settings')}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                   <circle cx="12" cy="12" r="3"/>
                   <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>

--- a/src/panels/Editor/EditorWelcome.tsx
+++ b/src/panels/Editor/EditorWelcome.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback, useEffect } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useAppActions } from '../../store/appActions'
 import daemonLogo from '../../assets/daemon-icon.png'
 
@@ -62,7 +63,7 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
   }, [])
 
   const handleNewProject = useCallback(() => {
-    useUIStore.getState().setDrawerTool('starter')
+    useWorkflowShellStore.getState().setDrawerTool('starter')
   }, [])
 
   const handleOpenTerminal = useCallback(() => {
@@ -130,7 +131,7 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
                 <span className="editor-empty-shortcut">Ctrl+`</span>
               </button>
             ) : (
-              <button className="editor-empty-btn" onClick={() => useUIStore.getState().setDrawerTool('settings')}>
+              <button className="editor-empty-btn" onClick={() => useWorkflowShellStore.getState().setDrawerTool('settings')}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                   <circle cx="12" cy="12" r="3"/>
                   <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>

--- a/src/panels/EnvManager/EnvManager.css
+++ b/src/panels/EnvManager/EnvManager.css
@@ -7,29 +7,38 @@
   overflow: hidden;
 }
 
-/* Header */
-.env-header {
+.env-workspace-bar {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  padding: 16px 24px 0;
+  gap: 16px;
+  padding: 20px 24px 0;
 }
 
-.env-header-left {
+.env-workspace-copy {
   display: flex;
-  align-items: baseline;
-  gap: 12px;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.env-workspace-kicker {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--green);
 }
 
 .env-title {
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 24px;
+  font-weight: 700;
   color: var(--t1);
   margin: 0;
+  line-height: 1.1;
 }
 
 .env-subtitle {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--t3);
 }
 
@@ -45,7 +54,38 @@
 .env-header-actions {
   display: flex;
   align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.env-stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 16px 24px 0;
+}
+
+.env-stat-card {
+  display: flex;
+  flex-direction: column;
   gap: 4px;
+  padding: 12px 14px;
+  border: 1px solid var(--s5);
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.012));
+}
+
+.env-stat-label {
+  font-size: 10px;
+  color: var(--t3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.env-stat-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--t1);
 }
 
 /* Search */
@@ -651,4 +691,15 @@
 .env-template-hint {
   font-size: 10px;
   color: var(--t3);
+}
+
+@media (max-width: 900px) {
+  .env-workspace-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .env-stats-row {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/panels/EnvManager/EnvManager.tsx
+++ b/src/panels/EnvManager/EnvManager.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { confirm } from '../../store/confirm'
 import { useNotificationsStore } from '../../store/notifications'
 import { Toggle } from '../../components/Toggle'
@@ -153,7 +154,7 @@ export function EnvManager() {
   const activeProjectId = useUIStore((s) => s.activeProjectId)
   const projects = useUIStore((s) => s.projects)
   const openFile = useUIStore((s) => s.openFile)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
 
   const [localKeys, setLocalKeys] = useState<UnifiedKey[]>([])
   const [vercelVars, setVercelVars] = useState<VercelEnvVar[]>([])

--- a/src/panels/EnvManager/EnvManager.tsx
+++ b/src/panels/EnvManager/EnvManager.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useUIStore } from '../../store/ui'
-import { useWorkflowShellStore } from '../../store/workflowShell'
 import { confirm } from '../../store/confirm'
 import { useNotificationsStore } from '../../store/notifications'
 import { Toggle } from '../../components/Toggle'
@@ -154,7 +153,6 @@ export function EnvManager() {
   const activeProjectId = useUIStore((s) => s.activeProjectId)
   const projects = useUIStore((s) => s.projects)
   const openFile = useUIStore((s) => s.openFile)
-  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
 
   const [localKeys, setLocalKeys] = useState<UnifiedKey[]>([])
   const [vercelVars, setVercelVars] = useState<VercelEnvVar[]>([])
@@ -223,6 +221,10 @@ export function EnvManager() {
   useEffect(() => { loadVercel() }, [loadVercel])
 
   const merged = useMemo(() => mergeVars(localKeys, vercelVars), [localKeys, vercelVars])
+  const activeProject = useMemo(
+    () => projects.find((project) => project.id === activeProjectId) ?? null,
+    [activeProjectId, projects]
+  )
 
   const filtered = merged.filter((m) => {
     if (filter && !m.key.toLowerCase().includes(filter.toLowerCase())) return false
@@ -250,7 +252,6 @@ export function EnvManager() {
     const res = await window.daemon.fs.readFile(filePath)
     if (res.ok && res.data && activeProjectId) {
       openFile({ path: res.data.path, name: filePath.split(/[\\/]/).pop() ?? '.env', content: res.data.content, projectId: activeProjectId })
-      setDrawerTool(null)
     }
   }
 
@@ -346,20 +347,41 @@ export function EnvManager() {
 
   return (
     <div className="env-center">
-      {/* Header */}
-      <div className="env-header">
-        <div className="env-header-left">
-          <h2 className="env-title">Environment Variables</h2>
+      <div className="env-workspace-bar">
+        <div className="env-workspace-copy">
+          <span className="env-workspace-kicker">Environment workspace</span>
+          <h2 className="env-title">Keep local and production config aligned</h2>
           <span className="env-subtitle">
-            {stats.localCount} local / {stats.prodCount} production / {stats.syncedCount} synced
+            {activeProject ? activeProject.name : 'No active project'} · {vercelLinked ? 'Vercel linked' : 'Local only'}
           </span>
         </div>
         <div className="env-header-actions">
+          <button className="env-btn" onClick={loadLocal}>Refresh local</button>
+          {vercelLinked && (
+            <button className="env-btn" onClick={loadVercel} disabled={loadingVercel}>
+              {loadingVercel ? 'Refreshing prod…' : 'Refresh prod'}
+            </button>
+          )}
           <label className="env-secrets-toggle">
             <Toggle checked={secretsOnly} onChange={setSecretsOnly} />
             <span>Secrets only</span>
           </label>
           <button className="env-btn env-add-btn" onClick={() => setAddingNew(true)}>+ Add</button>
+        </div>
+      </div>
+
+      <div className="env-stats-row">
+        <div className="env-stat-card">
+          <span className="env-stat-label">Local keys</span>
+          <strong className="env-stat-value">{stats.localCount}</strong>
+        </div>
+        <div className="env-stat-card">
+          <span className="env-stat-label">Production keys</span>
+          <strong className="env-stat-value">{stats.prodCount}</strong>
+        </div>
+        <div className="env-stat-card">
+          <span className="env-stat-label">Synced</span>
+          <strong className="env-stat-value">{stats.syncedCount}</strong>
         </div>
       </div>
 

--- a/src/panels/GitPanel/GitPanel.css
+++ b/src/panels/GitPanel/GitPanel.css
@@ -7,17 +7,91 @@
   overflow: hidden;
 }
 
-.git-header {
+.git-workflow-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px 24px 16px;
+  border-bottom: 1px solid var(--border);
+  background:
+    radial-gradient(circle at top right, rgba(62, 207, 142, 0.08), transparent 30%),
+    rgba(255, 255, 255, 0.01);
+}
+
+.git-workflow-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.git-workflow-copy {
+  max-width: 72ch;
+}
+
+.git-workflow-kicker {
+  font-size: var(--font-xs);
+  font-weight: 700;
+  color: var(--green);
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  margin-bottom: 6px;
+}
+
+.git-workflow-text {
+  margin: 8px 0 0;
+  color: var(--t3);
+  font-size: var(--font-md);
+  line-height: 1.5;
+}
+
+.git-workflow-topbar {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.git-workflow-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;
-  padding: 16px 24px;
-  border-bottom: 1px solid var(--border);
+}
+
+.git-workflow-metric {
+  padding: 12px 14px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(62, 207, 142, 0.1);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.git-workflow-metric-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--t4);
+}
+
+.git-workflow-metric-value {
+  margin-top: 8px;
+  color: var(--t1);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.git-workflow-metric-value--mono {
+  font-family: var(--font-code);
+  font-size: 13px;
+  color: var(--t2);
+  word-break: break-word;
 }
 
 .git-title {
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 26px;
+  line-height: 1.08;
+  font-weight: 700;
   color: var(--t1);
   margin: 0;
 }
@@ -67,14 +141,13 @@
 }
 
 .git-push-btn {
-  height: 28px;
-  padding: 0 14px;
+  height: 32px;
+  padding: 0 16px;
   font-size: 11px;
   color: var(--amber);
   background: var(--s2);
   border: 1px solid rgba(240, 180, 41, 0.25);
   border-radius: 4px;
-  margin-left: auto;
 }
 
 .git-push-btn:hover { background: rgba(240, 180, 41, 0.1); }
@@ -526,3 +599,25 @@
 .git-diff-line--del .git-diff-text { color: var(--red); }
 .git-diff-line--hunk .git-diff-text { color: var(--blue); }
 .git-diff-line:not(.git-diff-line--add):not(.git-diff-line--del):not(.git-diff-line--hunk) .git-diff-text { color: var(--t3); }
+
+@media (max-width: 1100px) {
+  .git-workflow-header,
+  .git-workflow-topbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .git-workflow-metrics {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .git-workflow-hero {
+    padding: 16px;
+  }
+
+  .git-workflow-metrics {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/panels/GitPanel/GitPanel.tsx
+++ b/src/panels/GitPanel/GitPanel.tsx
@@ -358,41 +358,51 @@ export function GitPanel() {
   const staged = files.filter((f) => f.staged)
   const unstaged = files.filter((f) => f.unstaged || f.untracked)
   const isWorkingInCopy = !!branch && branch !== 'main' && branch !== 'master'
+  const workingTreeLabel = files.length === 0 ? 'Clean' : `${unstaged.length} changes`
+  const deployLabel = deployStatus ? `${deployStatus.platform === 'vercel' ? 'Vercel' : 'Railway'} ${deployStatus.latestStatus ?? 'Linked'}` : 'No linked deploy'
 
   return (
     <div className="git-center">
-      {/* Header */}
-      <div className="git-header">
-        <h2 className="git-title">Git</h2>
-        <div className="git-branch-selector">
-          <select value={branch ?? ''} onChange={(e) => handleCheckout(e.target.value)}>
-            {branches.map((b) => (
-              <option key={b} value={b}>{b}</option>
-            ))}
-          </select>
-          <span className="git-branch-chevron" aria-hidden="true">▾</span>
-          {isWorkingInCopy && (
-            <div className="git-branch-safety-pill">
-              Working safely in a copy (Branch: {branch})
+      <section className="git-workflow-hero">
+        <div className="git-workflow-header">
+          <div className="git-workflow-copy">
+            <div className="git-workflow-kicker">Version Control</div>
+            <h2 className="git-title">Git workflow</h2>
+            <p className="git-workflow-text">
+              Read branch state first, stage deliberately, then commit and push from one surface without losing deploy context.
+            </p>
+          </div>
+
+          <div className="git-workflow-topbar">
+            <div className="git-branch-selector">
+              <select value={branch ?? ''} onChange={(e) => handleCheckout(e.target.value)}>
+                {branches.map((b) => (
+                  <option key={b} value={b}>{b}</option>
+                ))}
+              </select>
+              <span className="git-branch-chevron" aria-hidden="true">▾</span>
+              {isWorkingInCopy && (
+                <div className="git-branch-safety-pill">
+                  Working safely in a copy (Branch: {branch})
+                </div>
+              )}
             </div>
-          )}
-        </div>
-        <div className="git-add-menu-wrap">
-          <button
-            className="git-add-btn"
-            onClick={() => {
-              setShowAddMenu((prev) => !prev)
-              setShowCreateBranch(false)
-              setShowCreateTag(false)
-              setShowStashSave(false)
-            }}
-            aria-expanded={showAddMenu}
-            aria-haspopup="menu"
-          >
-            + Add
-          </button>
-          {showAddMenu && (
-            <div className="git-add-menu" role="menu">
+            <div className="git-add-menu-wrap">
+              <button
+                className="git-add-btn"
+                onClick={() => {
+                  setShowAddMenu((prev) => !prev)
+                  setShowCreateBranch(false)
+                  setShowCreateTag(false)
+                  setShowStashSave(false)
+                }}
+                aria-expanded={showAddMenu}
+                aria-haspopup="menu"
+              >
+                + Add
+              </button>
+              {showAddMenu && (
+                <div className="git-add-menu" role="menu">
               <button
                 className="git-add-option"
                 onClick={() => setShowCreateBranch((prev) => !prev)}
@@ -508,13 +518,34 @@ export function GitPanel() {
               {latestStashMessage && (
                 <div className="git-add-meta">Latest stash: {latestStashMessage}</div>
               )}
+                </div>
+              )}
             </div>
-          )}
+            <button className="git-push-btn" onClick={handlePush} disabled={pushing}>
+              {pushing ? 'Pushing...' : 'Push'}
+            </button>
+          </div>
         </div>
-        <button className="git-push-btn" onClick={handlePush} disabled={pushing}>
-          {pushing ? 'Pushing...' : 'Push'}
-        </button>
-      </div>
+
+        <div className="git-workflow-metrics">
+          <div className="git-workflow-metric">
+            <div className="git-workflow-metric-label">Branch</div>
+            <div className="git-workflow-metric-value git-workflow-metric-value--mono">{branch ?? 'Detached'}</div>
+          </div>
+          <div className="git-workflow-metric">
+            <div className="git-workflow-metric-label">Working tree</div>
+            <div className="git-workflow-metric-value">{workingTreeLabel}</div>
+          </div>
+          <div className="git-workflow-metric">
+            <div className="git-workflow-metric-label">Ready to commit</div>
+            <div className="git-workflow-metric-value">{staged.length} staged</div>
+          </div>
+          <div className="git-workflow-metric">
+            <div className="git-workflow-metric-label">Deploy link</div>
+            <div className="git-workflow-metric-value">{deployLabel}</div>
+          </div>
+        </div>
+      </section>
 
       {deployStatus && (() => {
         const dotColor = deployStatus.latestStatus === 'READY' ? 'var(--green)'
@@ -523,7 +554,7 @@ export function GitPanel() {
         return (
           <div
             style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 10px', margin: '0 16px', fontSize: 10, color: 'var(--t2)', background: 'var(--s2)', border: '1px solid var(--s5)', borderRadius: 4, cursor: 'pointer', alignSelf: 'flex-start' }}
-            onClick={() => useWorkflowShellStore.getState().setDrawerTool('deploy')}
+            onClick={() => useUIStore.getState().openWorkspaceTool('deploy')}
           >
             <span style={{ width: 5, height: 5, borderRadius: '50%', background: dotColor, flexShrink: 0 }} />
             <span>{deployStatus.platform === 'vercel' ? 'Vercel' : 'Railway'}: {deployStatus.latestStatus ?? 'Linked'}</span>

--- a/src/panels/GitPanel/GitPanel.tsx
+++ b/src/panels/GitPanel/GitPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useOnboardingStore } from '../../store/onboarding'
 import { confirm } from '../../store/confirm'
 import { useNotificationsStore } from '../../store/notifications'
@@ -522,7 +523,7 @@ export function GitPanel() {
         return (
           <div
             style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 10px', margin: '0 16px', fontSize: 10, color: 'var(--t2)', background: 'var(--s2)', border: '1px solid var(--s5)', borderRadius: 4, cursor: 'pointer', alignSelf: 'flex-start' }}
-            onClick={() => useUIStore.getState().setDrawerTool('deploy')}
+            onClick={() => useWorkflowShellStore.getState().setDrawerTool('deploy')}
           >
             <span style={{ width: 5, height: 5, borderRadius: '50%', background: dotColor, flexShrink: 0 }} />
             <span>{deployStatus.platform === 'vercel' ? 'Vercel' : 'Railway'}: {deployStatus.latestStatus ?? 'Linked'}</span>

--- a/src/panels/IconSidebar/IconSidebar.tsx
+++ b/src/panels/IconSidebar/IconSidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useMemo, useRef, type DragEvent } fro
 import { useUIStore } from '../../store/ui'
 import { usePluginStore } from '../../store/plugins'
 import { useWorkspaceProfileStore } from '../../store/workspaceProfile'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { BUILTIN_TOOLS, TOOL_ICONS, TOOL_NAMES, TOOL_COLORS, TOOL_DND_MIME, preloadToolPanel } from '../../components/CommandDrawer/CommandDrawer'
 import { PLUGIN_REGISTRY } from '../../plugins/registry'
 import './IconSidebar.css'
@@ -14,8 +15,8 @@ interface IconSidebarProps {
 }
 
 export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLauncher }: IconSidebarProps) {
-  const drawerOpen = useUIStore((s) => s.drawerOpen)
-  const drawerTool = useUIStore((s) => s.drawerTool)
+  const drawerOpen = useWorkflowShellStore((s) => s.drawerOpen)
+  const drawerTool = useWorkflowShellStore((s) => s.drawerTool)
   const browserTabActive = useUIStore((s) => s.browserTabActive)
   const pinnedTools = useUIStore((s) => s.pinnedTools)
   const isToolVisible = useWorkspaceProfileStore((s) => s.isToolVisible)
@@ -63,17 +64,17 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
   }, [toolMenuOpen])
 
   const handleExplorerClick = () => {
-    if (drawerOpen) useUIStore.getState().closeDrawer()
+    if (drawerOpen) useWorkflowShellStore.getState().closeDrawer()
     onToggleExplorer()
   }
 
   const handlePinnedToolClick = (toolId: string) => {
     if (toolId === 'browser') {
-      if (useUIStore.getState().drawerOpen) useUIStore.getState().closeDrawer()
+      if (useWorkflowShellStore.getState().drawerOpen) useWorkflowShellStore.getState().closeDrawer()
       useUIStore.getState().toggleBrowserTab()
       return
     }
-    const state = useUIStore.getState()
+    const state = useWorkflowShellStore.getState()
     if (state.drawerOpen && state.drawerTool === toolId) {
       state.closeDrawer()
     } else {
@@ -269,7 +270,7 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
       <div className="sidebar-divider" />
       <button
         className={`colosseum-icon-wrap${drawerTool === 'hackathon' ? ' active' : ''}`}
-        onClick={() => useUIStore.getState().setDrawerTool('hackathon')}
+        onClick={() => useWorkflowShellStore.getState().setDrawerTool('hackathon')}
         title="Hackathon (Colosseum)"
         aria-label="Hackathon"
       >
@@ -286,11 +287,11 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
       <button
         className={`sidebar-icon ${drawerOpen && !drawerTool ? 'active' : ''}`}
         onClick={() => {
-          const state = useUIStore.getState()
+          const state = useWorkflowShellStore.getState()
           if (state.drawerOpen && !state.drawerTool) {
             state.closeDrawer()
           } else {
-            useUIStore.setState({ drawerOpen: true, drawerTool: null })
+            state.toggleDrawer()
           }
         }}
         title="Tools (Ctrl+K)"

--- a/src/panels/IconSidebar/IconSidebar.tsx
+++ b/src/panels/IconSidebar/IconSidebar.tsx
@@ -18,6 +18,7 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
   const drawerOpen = useWorkflowShellStore((s) => s.drawerOpen)
   const drawerTool = useWorkflowShellStore((s) => s.drawerTool)
   const browserTabActive = useUIStore((s) => s.browserTabActive)
+  const activeWorkspaceToolId = useUIStore((s) => s.activeWorkspaceToolId)
   const pinnedTools = useUIStore((s) => s.pinnedTools)
   const isToolVisible = useWorkspaceProfileStore((s) => s.isToolVisible)
   const plugins = usePluginStore((s) => s.plugins)
@@ -69,18 +70,8 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
   }
 
   const handlePinnedToolClick = (toolId: string) => {
-    if (toolId === 'browser') {
-      if (useWorkflowShellStore.getState().drawerOpen) useWorkflowShellStore.getState().closeDrawer()
-      useUIStore.getState().toggleBrowserTab()
-      return
-    }
-    const state = useWorkflowShellStore.getState()
-    if (state.drawerOpen && state.drawerTool === toolId) {
-      state.closeDrawer()
-    } else {
-      preloadToolPanel(toolId)
-      state.setDrawerTool(toolId)
-    }
+    preloadToolPanel(toolId)
+    useUIStore.getState().toggleWorkspaceTool(toolId)
   }
 
   const handleAddToolClick = () => setToolMenuOpen((open) => !open)
@@ -200,7 +191,7 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
         const Icon = TOOL_ICONS[toolId] ?? PLUGIN_REGISTRY[toolId]?.icon
         const name = TOOL_NAMES[toolId] ?? PLUGIN_REGISTRY[toolId]?.name ?? toolId
         if (!Icon) return null
-        const isActive = toolId === 'browser' ? browserTabActive : (drawerOpen && drawerTool === toolId)
+        const isActive = toolId === 'browser' ? browserTabActive : activeWorkspaceToolId === toolId
         const color = TOOL_COLORS[toolId]
         return (
           <button
@@ -269,8 +260,8 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
       {/* Colosseum / Hackathon — opens in drawer */}
       <div className="sidebar-divider" />
       <button
-        className={`colosseum-icon-wrap${drawerTool === 'hackathon' ? ' active' : ''}`}
-        onClick={() => useWorkflowShellStore.getState().setDrawerTool('hackathon')}
+        className={`colosseum-icon-wrap${activeWorkspaceToolId === 'hackathon' ? ' active' : ''}`}
+        onClick={() => useUIStore.getState().openWorkspaceTool('hackathon')}
         title="Hackathon (Colosseum)"
         aria-label="Hackathon"
       >

--- a/src/panels/ImagePanel/ImagePanel.tsx
+++ b/src/panels/ImagePanel/ImagePanel.tsx
@@ -154,7 +154,7 @@ export function ImagePanel() {
   }
 
   const handleGoToSettings = () => {
-    useWorkflowShellStore.getState().setDrawerTool('settings')
+    useUIStore.getState().openWorkspaceTool('settings')
   }
 
   const handleSaveKey = async () => {

--- a/src/panels/ImagePanel/ImagePanel.tsx
+++ b/src/panels/ImagePanel/ImagePanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useImageStore } from '../../store/images'
 import './ImagePanel.css'
 
@@ -153,7 +154,7 @@ export function ImagePanel() {
   }
 
   const handleGoToSettings = () => {
-    useUIStore.getState().setDrawerTool('settings')
+    useWorkflowShellStore.getState().setDrawerTool('settings')
   }
 
   const handleSaveKey = async () => {

--- a/src/panels/LaunchWizard/LaunchWizard.tsx
+++ b/src/panels/LaunchWizard/LaunchWizard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useTokenLaunch } from './useTokenLaunch'
 import type { LaunchParams } from './useTokenLaunch'
 import './LaunchWizard.css'
@@ -55,7 +56,7 @@ function phaseIndex(phase: string): number {
 
 // ── Main component ─────────────────────────────────────────────
 export function LaunchWizard() {
-  const closeLaunchWizard = useUIStore((s) => s.closeLaunchWizard)
+  const closeLaunchWizard = useWorkflowShellStore((s) => s.closeLaunchWizard)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
   const overlayRef = useRef<HTMLDivElement>(null)
 

--- a/src/panels/PortsPanel/PortsPanel.css
+++ b/src/panels/PortsPanel/PortsPanel.css
@@ -2,82 +2,266 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow-y: auto;
+  background: var(--bg);
+  overflow: hidden;
 }
 
-.ports-empty {
-  font-size: 11px;
+.ports-workspace-bar {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--s4);
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.008));
+}
+
+.ports-workspace-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.ports-workspace-kicker,
+.ports-section-kicker {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+
+.ports-workspace-title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.08;
+  color: var(--t1);
+}
+
+.ports-workspace-subtitle {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
   color: var(--t3);
-  padding: 8px 0;
+  max-width: 720px;
 }
 
-.port-row {
+.ports-workspace-actions {
+  display: flex;
+  align-items: flex-start;
+}
+
+.ports-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 20px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.ports-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.ports-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.012));
+}
+
+.ports-stat-card.warn {
+  border-color: color-mix(in srgb, var(--amber) 35%, var(--s4));
+}
+
+.ports-stat-label {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--t4);
+}
+
+.ports-stat-value {
+  font-size: 26px;
+  line-height: 1;
+  color: var(--t1);
+}
+
+.ports-stat-detail {
+  font-size: 12px;
+  color: var(--t3);
+}
+
+.ports-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ports-section-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ports-section-title {
+  margin: 4px 0 0;
+  font-size: 20px;
+  line-height: 1.1;
+  color: var(--t1);
+}
+
+.ports-section-count {
+  font-size: 12px;
+  color: var(--t3);
+  font-family: var(--font-code);
+}
+
+.ports-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ports-row-card,
+.ports-empty-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+}
+
+.ports-row-card.ghost {
+  opacity: 0.92;
+}
+
+.ports-empty-card {
+  color: var(--t3);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.ports-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.ports-row-titleline {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 0;
-  border-bottom: 1px solid var(--border);
-  transition: all var(--transition-fast);
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
-.port-row:last-child { border-bottom: none; }
+.ports-row-titleline strong {
+  font-size: 18px;
+  color: var(--t1);
+  font-family: var(--font-code);
+}
 
-.port-dot {
-  width: 5px;
-  height: 5px;
+.ports-row-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: var(--t3);
+}
+
+.ports-service-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--green) 22%, var(--s4));
+  background: color-mix(in srgb, var(--green) 9%, transparent);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--green);
+}
+
+.ports-service-pill.muted {
+  border-color: var(--s5);
+  background: var(--s2);
+  color: var(--t3);
+}
+
+.ports-status-dot {
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
-.port-dot.live { background: var(--success); }
-.port-dot.dead { background: var(--t3); }
-.port-dot.warning { background: var(--warning); }
+.ports-status-dot.live { background: var(--green); }
+.ports-status-dot.dead { background: var(--t4); }
+.ports-status-dot.warning { background: var(--amber); }
 
-.port-number {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--t1);
-  font-family: var(--font-code);
-  width: 50px;
+.ports-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex-shrink: 0;
 }
 
-.port-service {
+.ports-row-note {
   font-size: 11px;
-  color: var(--t2);
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  color: var(--t4);
   white-space: nowrap;
 }
 
-.port-project {
-  font-size: 10px;
-  color: var(--t3);
-  flex-shrink: 0;
-}
-
-.port-process {
-  font-size: 11px;
-  color: var(--t2);
-  flex: 1;
-}
-
-.port-btn {
-  height: 20px;
-  padding: 0 6px;
-  font-size: 9px;
+.ports-btn {
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-size: 12px;
   color: var(--t2);
   background: var(--s2);
-  border-radius: 3px;
-  flex-shrink: 0;
+  border: 1px solid var(--s5);
+  cursor: pointer;
 }
 
-.port-btn:hover { background: var(--hover-bg); color: var(--t1); }
-
-.port-btn.danger:hover {
-  background: rgba(140, 74, 74, 0.2);
-  color: var(--error);
+.ports-btn:hover {
+  background: var(--s3);
+  color: var(--t1);
 }
 
-.port-row.ghost { opacity: 0.8; }
+.ports-btn.danger {
+  color: var(--red);
+}
+
+.ports-btn.danger:hover {
+  background: rgba(239, 83, 80, 0.1);
+}
+
+@media (max-width: 980px) {
+  .ports-workspace-bar {
+    flex-direction: column;
+  }
+
+  .ports-workspace-title {
+    font-size: 18px;
+  }
+
+  .ports-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ports-row-card,
+  .ports-empty-card {
+    flex-direction: column;
+  }
+}

--- a/src/panels/PortsPanel/PortsPanel.tsx
+++ b/src/panels/PortsPanel/PortsPanel.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect, useCallback, memo } from 'react'
-import { CollapsibleSection } from '../../components/CollapsibleSection'
+import { useState, useEffect, useCallback, useMemo, memo } from 'react'
 import { confirm } from '../../store/confirm'
 import { useNotificationsStore } from '../../store/notifications'
 import './PortsPanel.css'
@@ -20,6 +19,9 @@ interface GhostPort {
   processName: string | null
 }
 
+const PROTECTED_PROCESS_PATTERN = /^(lsass|wininit|services|svchost|csrss|smss|dwm|fontdrvhost|memory compression|system)$/i
+const DEV_PROCESS_PATTERN = /(node|bun|deno|python|uv|ruby|go|java|next|vite|webpack|turbo|cargo|rust|npm|pnpm|yarn|electron|daemon|php|apache|nginx|postgres|mysql|redis)/i
+
 export const PortsPanel = memo(function PortsPanel() {
   const [registered, setRegistered] = useState<RegisteredPort[]>([])
   const [ghosts, setGhosts] = useState<GhostPort[]>([])
@@ -35,11 +37,12 @@ export const PortsPanel = memo(function PortsPanel() {
 
   useEffect(() => {
     load()
-    // Slow background poll while we work toward main-side push events.
-    // Manual refresh button covers the immediate-feedback case.
     const interval = setInterval(load, 30000)
     const unsubscribe = window.daemon.events.on('port:changed', () => load())
-    return () => { clearInterval(interval); unsubscribe() }
+    return () => {
+      clearInterval(interval)
+      unsubscribe()
+    }
   }, [load])
 
   const handleKill = async (port: number) => {
@@ -59,52 +62,154 @@ export const PortsPanel = memo(function PortsPanel() {
     setTimeout(load, 500)
   }
 
+  const dedupedRegistered = useMemo(() => {
+    const byPort = new Map<number, RegisteredPort & { projectNames: string[] }>()
+    for (const entry of registered) {
+      const existing = byPort.get(entry.port)
+      if (!existing) {
+        byPort.set(entry.port, {
+          ...entry,
+          projectNames: entry.projectName ? [entry.projectName] : [],
+        })
+        continue
+      }
+      existing.isListening = existing.isListening || entry.isListening
+      existing.pid = existing.pid ?? entry.pid
+      if (entry.projectName && !existing.projectNames.includes(entry.projectName)) {
+        existing.projectNames.push(entry.projectName)
+      }
+    }
+    return Array.from(byPort.values())
+  }, [registered])
+
+  const safeGhosts = useMemo(
+    () => ghosts.filter((ghost) => !PROTECTED_PROCESS_PATTERN.test(ghost.processName ?? '')).slice(0, 24),
+    [ghosts],
+  )
+
+  const livePorts = dedupedRegistered.filter((p) => p.isListening)
+  const attachedProjects = new Set(registered.map((p) => p.projectId)).size
+
   return (
     <div className="ports-panel">
-      <div className="panel-header">
-        Ports
-        <button
-          className="panel-header-action"
-          onClick={() => load()}
-          title="Refresh"
-          aria-label="Refresh ports"
-        >
-          ↻
-        </button>
+      <div className="ports-workspace-bar">
+        <div className="ports-workspace-copy">
+          <span className="ports-workspace-kicker">Local routing</span>
+          <h2 className="ports-workspace-title">Know what is actually running</h2>
+          <p className="ports-workspace-subtitle">
+            Registered dev servers come first. Ghost listeners are separated so you can clean up noise without guessing.
+          </p>
+        </div>
+        <div className="ports-workspace-actions">
+          <button className="ports-btn" onClick={() => load()}>
+            Refresh
+          </button>
+        </div>
       </div>
 
-      <CollapsibleSection title="Registered" count={registered.length} defaultOpen>
-        {registered.length === 0 ? (
-          <div className="ports-empty">No ports detected. Start a dev server to see active ports here.</div>
-        ) : (
-          registered.map((p) => (
-            <div key={`${p.port}-${p.projectId}`} className="port-row">
-              <span className={`port-dot ${p.isListening ? 'live' : 'dead'}`} title={p.isListening ? 'Port listening' : 'Port not responding'} />
-              <span className="port-number">:{p.port}</span>
-              <span className="port-service">{p.serviceName}</span>
-              <span className="port-project">{p.projectName}</span>
-              {p.isListening && (
-                <button className="port-btn" onClick={() => handleKill(p.port)}>Kill</button>
-              )}
-            </div>
-          ))
-        )}
-      </CollapsibleSection>
+      <div className="ports-body">
+        <div className="ports-summary-grid">
+          <StatCard label="Tracked ports" value={dedupedRegistered.length} detail={`${livePorts.length} responding`} />
+          <StatCard label="Active projects" value={attachedProjects} detail="with registered services" />
+          <StatCard label="Ghost listeners" value={safeGhosts.length} detail={safeGhosts.length > 0 ? 'reviewable' : 'all clear'} warn={safeGhosts.length > 0} />
+        </div>
 
-      <CollapsibleSection title="Ghost Servers" count={ghosts.length} defaultOpen={ghosts.length > 0}>
-        {ghosts.length === 0 ? (
-          <div className="ports-empty">No ghost servers</div>
-        ) : (
-          ghosts.map((g) => (
-            <div key={g.port} className="port-row ghost">
-              <span className="port-dot warning" title="Ghost server — unregistered process on port" />
-              <span className="port-number">:{g.port}</span>
-              <span className="port-process">{g.processName ?? `PID ${g.pid}`}</span>
-              <button className="port-btn danger" onClick={() => handleKill(g.port)}>Kill</button>
+        <section className="ports-section">
+          <div className="ports-section-head">
+            <div>
+              <div className="ports-section-kicker">Registered</div>
+              <h3 className="ports-section-title">Tracked app endpoints</h3>
             </div>
-          ))
-        )}
-      </CollapsibleSection>
+            <span className="ports-section-count">{dedupedRegistered.length}</span>
+          </div>
+
+          {dedupedRegistered.length === 0 ? (
+            <div className="ports-empty-card">
+              No tracked ports yet. Start a local app through DAEMON or register a service to keep it in the browser workflow.
+            </div>
+          ) : (
+            <div className="ports-list">
+              {dedupedRegistered.map((port) => (
+                <article key={`${port.port}-${port.projectId}`} className="ports-row-card">
+                  <div className="ports-row-main">
+                    <div className="ports-row-titleline">
+                      <span className={`ports-status-dot ${port.isListening ? 'live' : 'dead'}`} />
+                      <strong>:{port.port}</strong>
+                      <span className="ports-service-pill">{port.serviceName}</span>
+                    </div>
+                    <div className="ports-row-meta">
+                      <span>{port.projectNames.join(', ') || port.projectName}</span>
+                      <span>{port.pid ? `PID ${port.pid}` : 'PID unknown'}</span>
+                      <span>{port.isListening ? 'Responding' : 'Not responding'}</span>
+                    </div>
+                  </div>
+                  <div className="ports-row-actions">
+                    {port.isListening && (
+                      <button className="ports-btn danger" onClick={() => handleKill(port.port)}>
+                        Kill
+                      </button>
+                    )}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="ports-section">
+          <div className="ports-section-head">
+            <div>
+              <div className="ports-section-kicker">Untracked</div>
+              <h3 className="ports-section-title">Ghost listeners</h3>
+            </div>
+            <span className="ports-section-count">{safeGhosts.length}</span>
+          </div>
+
+          {safeGhosts.length === 0 ? (
+            <div className="ports-empty-card">No user-actionable ghost listeners detected.</div>
+          ) : (
+            <div className="ports-list">
+              {safeGhosts.map((ghost) => {
+                const canKill = DEV_PROCESS_PATTERN.test(ghost.processName ?? '') && !PROTECTED_PROCESS_PATTERN.test(ghost.processName ?? '')
+                return (
+                <article key={ghost.port} className="ports-row-card ghost">
+                  <div className="ports-row-main">
+                    <div className="ports-row-titleline">
+                      <span className="ports-status-dot warning" />
+                      <strong>:{ghost.port}</strong>
+                      <span className="ports-service-pill muted">{ghost.processName ?? 'Unknown process'}</span>
+                    </div>
+                    <div className="ports-row-meta">
+                      <span>{ghost.address}</span>
+                      <span>PID {ghost.pid}</span>
+                      {!canKill && <span>review in Task Manager</span>}
+                    </div>
+                  </div>
+                  <div className="ports-row-actions">
+                    {canKill ? (
+                      <button className="ports-btn danger" onClick={() => handleKill(ghost.port)}>
+                        Kill
+                      </button>
+                    ) : (
+                      <span className="ports-row-note">Protected</span>
+                    )}
+                  </div>
+                </article>
+              )})}
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   )
 })
+
+function StatCard({ label, value, detail, warn = false }: { label: string; value: number; detail: string; warn?: boolean }) {
+  return (
+    <div className={`ports-stat-card${warn ? ' warn' : ''}`}>
+      <span className="ports-stat-label">{label}</span>
+      <strong className="ports-stat-value">{value}</strong>
+      <span className="ports-stat-detail">{detail}</span>
+    </div>
+  )
+}

--- a/src/panels/ProcessManager/ProcessManager.css
+++ b/src/panels/ProcessManager/ProcessManager.css
@@ -2,135 +2,265 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow-y: auto;
-  background-image: var(--surface-gradient-subtle);
+  overflow: hidden;
+  background: var(--bg);
 }
 
-.process-empty {
-  font-size: 11px;
+.process-workspace-bar {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--s4);
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.008));
+}
+
+.process-workspace-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.process-workspace-kicker,
+.process-section-kicker {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+
+.process-workspace-title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.08;
+  color: var(--t1);
+}
+
+.process-workspace-subtitle {
+  margin: 0;
+  max-width: 720px;
+  font-size: 12px;
+  line-height: 1.55;
   color: var(--t3);
-  padding: 8px 0;
 }
 
-.process-row {
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border);
-  transition: all var(--transition-fast);
+.process-workspace-actions {
+  display: flex;
+  align-items: flex-start;
 }
 
-.process-row:last-child {
-  border-bottom: none;
+.process-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 20px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.process-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.process-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.012));
+}
+
+.process-stat-card.warn {
+  border-color: color-mix(in srgb, var(--amber) 35%, var(--s4));
+}
+
+.process-stat-label {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--t4);
+}
+
+.process-stat-value {
+  font-size: 26px;
+  line-height: 1;
+  color: var(--t1);
+}
+
+.process-stat-detail {
+  font-size: 12px;
+  color: var(--t3);
+}
+
+.process-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.process-section-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.process-section-title {
+  margin: 4px 0 0;
+  font-size: 20px;
+  line-height: 1.1;
+  color: var(--t1);
+}
+
+.process-section-count {
+  font-size: 12px;
+  color: var(--t3);
+  font-family: var(--font-code);
+}
+
+.process-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.process-row-card,
+.process-empty-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+}
+
+.process-row-card.orphan {
+  opacity: 0.92;
+}
+
+.process-empty-card {
+  color: var(--t3);
+  font-size: 12px;
+  line-height: 1.55;
 }
 
 .process-row-main {
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.process-row-titleline {
+  display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .process-dot {
-  width: 5px;
-  height: 5px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
-.process-dot.healthy { background: var(--success); }
-.process-dot.warning { background: var(--warning); }
-.process-dot.critical { background: var(--error); }
+.process-dot.healthy { background: var(--green); }
+.process-dot.warning { background: var(--amber); }
+.process-dot.critical { background: var(--red); }
 
 .process-name {
-  font-size: 12px;
+  font-size: 16px;
+  line-height: 1.2;
   color: var(--t1);
-  font-weight: 500;
-  flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+.process-kind,
+.process-model {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .process-kind {
-  font-size: 9px;
-  padding: 1px 4px;
-  border-radius: 3px;
-  flex-shrink: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
-
-.process-kind--shell {
+  border: 1px solid var(--s5);
+  background: var(--s2);
   color: var(--t3);
-  background: var(--s4);
 }
 
 .process-kind--agent {
+  border-color: color-mix(in srgb, var(--blue) 35%, var(--s4));
+  background: color-mix(in srgb, var(--blue) 10%, transparent);
   color: var(--blue);
-  background: rgba(96, 165, 250, 0.1);
 }
 
 .process-model {
-  font-size: 9px;
+  border: 1px solid var(--s5);
+  background: rgba(255,255,255,0.03);
   color: var(--t3);
-  padding: 1px 4px;
-  background: var(--s4);
-  border-radius: 3px;
-  flex-shrink: 0;
 }
 
-.process-mem {
-  font-size: 11px;
-  color: var(--t2);
-  font-family: var(--font-code);
-  flex-shrink: 0;
-}
-
-.process-row-sub {
+.process-row-meta {
   display: flex;
-  gap: 8px;
-  font-size: 10px;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 11px;
   color: var(--t3);
-  margin-top: 2px;
-  padding-left: 11px;
 }
 
-/* Memory Bar */
 .memory-bar {
-  height: 6px;
+  height: 7px;
   background: var(--s4);
-  border-radius: 2px;
-  margin: 4px 0;
+  border-radius: 999px;
   overflow: hidden;
 }
 
 .memory-bar-fill {
   height: 100%;
-  border-radius: 2px;
+  border-radius: 999px;
   transition: width var(--transition-normal) ease;
 }
 
-.memory-bar-fill.healthy { background: var(--success); }
-.memory-bar-fill.warning { background: var(--warning); }
-.memory-bar-fill.critical { background: var(--error); }
+.memory-bar-fill.healthy { background: var(--green); }
+.memory-bar-fill.warning { background: var(--amber); }
+.memory-bar-fill.critical { background: var(--red); }
 
-/* Actions */
 .process-actions {
   display: flex;
-  gap: 4px;
-  margin-top: 4px;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .process-btn {
-  height: 22px;
-  padding: 0 8px;
-  font-size: 10px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-size: 12px;
   color: var(--t2);
   background: var(--s2);
-  border-radius: 3px;
+  border: 1px solid var(--s5);
+  cursor: pointer;
 }
 
 .process-btn:hover {
-  background: var(--hover-bg);
+  background: var(--s3);
   color: var(--t1);
 }
 
@@ -140,18 +270,23 @@
 
 .process-btn.danger:hover {
   background: rgba(239, 83, 80, 0.1);
-  color: var(--red);
 }
 
-/* Total */
-.process-total {
-  font-size: 10px;
-  color: var(--t3);
-  padding: 6px 0;
-  font-family: var(--font-code);
-}
+@media (max-width: 980px) {
+  .process-workspace-bar {
+    flex-direction: column;
+  }
 
-/* Orphan rows */
-.process-row.orphan {
-  opacity: 0.7;
+  .process-workspace-title {
+    font-size: 18px;
+  }
+
+  .process-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .process-row-card,
+  .process-empty-card {
+    flex-direction: column;
+  }
 }

--- a/src/panels/ProcessManager/ProcessManager.tsx
+++ b/src/panels/ProcessManager/ProcessManager.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect, useCallback, memo } from 'react'
 import { useUIStore } from '../../store/ui'
-import { useWorkflowShellStore } from '../../store/workflowShell'
-import { CollapsibleSection } from '../../components/CollapsibleSection'
 import { confirm } from '../../store/confirm'
 import { useNotificationsStore } from '../../store/notifications'
 import type { ProcessInfo, OrphanProcess } from '../../../electron/shared/types'
@@ -18,7 +16,6 @@ export const ProcessManager = memo(function ProcessManager() {
   const [orphans, setOrphans] = useState<OrphanProcess[]>([])
   const setActiveTerminal = useUIStore((s) => s.setActiveTerminal)
   const setActiveProject = useUIStore((s) => s.setActiveProject)
-  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
 
   const load = useCallback(async () => {
     const [procRes, orphanRes] = await Promise.all([
@@ -59,46 +56,67 @@ export const ProcessManager = memo(function ProcessManager() {
       setActiveProject(proc.projectId, proc.projectPath)
       setActiveTerminal(proc.projectId, proc.id)
     }
-    setDrawerTool(null) // Close drawer to reveal main view
   }
 
   const totalMemory = processes.reduce((s, p) => s + p.memory, 0)
+  const agentCount = processes.filter((p) => p.kind === 'agent').length
+  const shellCount = processes.filter((p) => p.kind === 'shell').length
 
   return (
     <div className="process-panel">
-      <div className="panel-header">
-        Processes
-        <button
-          className="panel-header-action"
-          onClick={() => load()}
-          title="Refresh"
-          aria-label="Refresh processes"
-        >
-          ↻
-        </button>
+      <div className="process-workspace-bar">
+        <div className="process-workspace-copy">
+          <span className="process-workspace-kicker">Runtime control</span>
+          <h2 className="process-workspace-title">Keep live sessions under control</h2>
+          <p className="process-workspace-subtitle">
+            Focus the exact terminal you need, spot heavy sessions quickly, and clean up orphans before they drift.
+          </p>
+        </div>
+        <div className="process-workspace-actions">
+          <button className="process-btn" onClick={() => load()}>
+            Refresh
+          </button>
+        </div>
       </div>
 
-      <CollapsibleSection title="Active Sessions" count={processes.length} defaultOpen>
+      <div className="process-body">
+        <div className="process-summary-grid">
+          <StatCard label="Active sessions" value={processes.length} detail={`${agentCount} agents · ${shellCount} shells`} />
+          <StatCard label="Total memory" value={formatMB(totalMemory)} detail="across tracked sessions" />
+          <StatCard label="Orphans" value={String(orphans.length)} detail={orphans.length > 0 ? 'needs cleanup' : 'all clear'} warn={orphans.length > 0} />
+        </div>
+
+        <section className="process-section">
+          <div className="process-section-head">
+            <div>
+              <div className="process-section-kicker">Active</div>
+              <h3 className="process-section-title">Live sessions</h3>
+            </div>
+            <span className="process-section-count">{processes.length}</span>
+          </div>
+
         {processes.length === 0 ? (
-          <div className="process-empty">No active sessions</div>
+          <div className="process-empty-card">No active sessions.</div>
         ) : (
-          <>
+          <div className="process-list">
             {processes.map((proc) => (
-              <div key={proc.id} className="process-row">
+              <article key={proc.id} className="process-row-card">
                 <div className="process-row-main">
-                  <span className={`process-dot ${memoryLevel(proc.memory)}`} />
-                  <span className="process-name">{proc.name}</span>
-                  <span className={`process-kind process-kind--${proc.kind}`}>{proc.kind}</span>
-                  {proc.model && (
-                    <span className="process-model">{MODEL_SHORT[proc.model] ?? '?'}</span>
-                  )}
-                  <span className="process-mem">{formatMB(proc.memory)}</span>
+                  <div className="process-row-titleline">
+                    <span className={`process-dot ${memoryLevel(proc.memory)}`} />
+                    <strong className="process-name">{proc.name}</strong>
+                    <span className={`process-kind process-kind--${proc.kind}`}>{proc.kind}</span>
+                    {proc.model && (
+                      <span className="process-model">{MODEL_SHORT[proc.model] ?? '?'}</span>
+                    )}
+                  </div>
+                  <div className="process-row-meta">
+                    {proc.projectName && <span>{proc.projectName}</span>}
+                    <span>{formatUptime(proc.startedAt)}</span>
+                    <span>{formatMB(proc.memory)}</span>
+                  </div>
+                  <MemoryBar memory={proc.memory} />
                 </div>
-                <div className="process-row-sub">
-                  {proc.projectName && <span>{proc.projectName}</span>}
-                  <span>{formatUptime(proc.startedAt)}</span>
-                </div>
-                <MemoryBar memory={proc.memory} />
                 <div className="process-actions">
                   <button className="process-btn" onClick={() => handleFocus(proc)} title="Focus terminal">
                     Focus
@@ -107,41 +125,61 @@ export const ProcessManager = memo(function ProcessManager() {
                     Kill
                   </button>
                 </div>
-              </div>
+              </article>
             ))}
-            <div className="process-total">
-              Total: {formatMB(totalMemory)} across {processes.length} session{processes.length !== 1 ? 's' : ''}
-            </div>
-          </>
+          </div>
         )}
-      </CollapsibleSection>
+        </section>
 
-      <CollapsibleSection title="Orphaned" count={orphans.length} defaultOpen={orphans.length > 0}>
-        {orphans.length === 0 ? (
-          <div className="process-empty">No orphaned processes</div>
-        ) : (
-          orphans.map((proc) => (
-            <div key={proc.pid} className="process-row orphan">
-              <div className="process-row-main">
-                <span className="process-dot critical" />
-                <span className="process-name">{proc.name}</span>
-                <span className="process-mem">{formatMB(proc.memory)}</span>
-              </div>
-              <div className="process-row-sub">
-                <span>PID {proc.pid}</span>
-              </div>
-              <div className="process-actions">
-                <button className="process-btn danger" onClick={() => handleKill(proc.pid)}>
-                  Kill
-                </button>
-              </div>
+        <section className="process-section">
+          <div className="process-section-head">
+            <div>
+              <div className="process-section-kicker">Cleanup</div>
+              <h3 className="process-section-title">Orphaned processes</h3>
             </div>
-          ))
+            <span className="process-section-count">{orphans.length}</span>
+          </div>
+
+        {orphans.length === 0 ? (
+          <div className="process-empty-card">No orphaned processes.</div>
+        ) : (
+          <div className="process-list">
+            {orphans.map((proc) => (
+              <article key={proc.pid} className="process-row-card orphan">
+                <div className="process-row-main">
+                  <div className="process-row-titleline">
+                    <span className="process-dot critical" />
+                    <strong className="process-name">{proc.name}</strong>
+                  </div>
+                  <div className="process-row-meta">
+                    <span>PID {proc.pid}</span>
+                    <span>{formatMB(proc.memory)}</span>
+                  </div>
+                </div>
+                <div className="process-actions">
+                  <button className="process-btn danger" onClick={() => handleKill(proc.pid)}>
+                    Kill
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
         )}
-      </CollapsibleSection>
+        </section>
+      </div>
     </div>
   )
 })
+
+function StatCard({ label, value, detail, warn = false }: { label: string; value: string | number; detail: string; warn?: boolean }) {
+  return (
+    <div className={`process-stat-card${warn ? ' warn' : ''}`}>
+      <span className="process-stat-label">{label}</span>
+      <strong className="process-stat-value">{value}</strong>
+      <span className="process-stat-detail">{detail}</span>
+    </div>
+  )
+}
 
 function MemoryBar({ memory }: { memory: number }) {
   const mb = memory / (1024 * 1024)

--- a/src/panels/ProcessManager/ProcessManager.tsx
+++ b/src/panels/ProcessManager/ProcessManager.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, memo } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { CollapsibleSection } from '../../components/CollapsibleSection'
 import { confirm } from '../../store/confirm'
 import { useNotificationsStore } from '../../store/notifications'
@@ -17,7 +18,7 @@ export const ProcessManager = memo(function ProcessManager() {
   const [orphans, setOrphans] = useState<OrphanProcess[]>([])
   const setActiveTerminal = useUIStore((s) => s.setActiveTerminal)
   const setActiveProject = useUIStore((s) => s.setActiveProject)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
 
   const load = useCallback(async () => {
     const [procRes, orphanRes] = await Promise.all([

--- a/src/panels/ProjectStarter/ProjectStarter.tsx
+++ b/src/panels/ProjectStarter/ProjectStarter.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import './ProjectStarter.css'
 
 // --- Template definitions ---
@@ -289,7 +290,7 @@ export function ProjectStarter() {
   const setActiveProject = useUIStore((s) => s.setActiveProject)
   const setProjects = useUIStore((s) => s.setProjects)
   const projects = useUIStore((s) => s.projects)
-  const closeDrawer = useUIStore((s) => s.closeDrawer)
+  const closeDrawer = useWorkflowShellStore((s) => s.closeDrawer)
 
   const [wizard, setWizard] = useState<WizardState>({
     step: 'templates',

--- a/src/panels/SessionRegistry/SessionHistory.css
+++ b/src/panels/SessionRegistry/SessionHistory.css
@@ -4,12 +4,50 @@
   gap: 0;
   height: 100%;
   overflow: hidden;
+  background: var(--bg);
+}
+
+.sr-workspace-bar {
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--s4);
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.008));
+}
+
+.sr-workspace-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.sr-workspace-kicker {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+
+.sr-workspace-title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.08;
+  color: var(--t1);
+}
+
+.sr-workspace-subtitle {
+  margin: 0;
+  max-width: 720px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--t3);
 }
 
 .sr-stats {
   display: flex;
-  gap: 0;
-  border-bottom: 1px solid var(--border);
+  gap: 12px;
+  padding: 18px 20px 0;
+  border-bottom: none;
   flex-shrink: 0;
 }
 
@@ -17,36 +55,36 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 10px 8px;
-  border-right: 1px solid var(--border);
-}
-
-.sr-stat:last-child {
-  border-right: none;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.012));
 }
 
 .sr-stat-value {
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 26px;
+  font-weight: 700;
   color: var(--t1);
   font-family: 'JetBrains Mono', monospace;
 }
 
 .sr-stat-label {
-  font-size: 9px;
-  letter-spacing: 0.06em;
+  font-size: 10px;
+  letter-spacing: 0.08em;
   color: var(--t3);
   text-transform: uppercase;
-  margin-top: 2px;
 }
 
 .sr-error {
-  padding: 6px 12px;
+  margin: 16px 20px 0;
+  padding: 10px 12px;
   font-size: 11px;
   color: var(--red);
   background: color-mix(in srgb, var(--red) 8%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--red) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--red) 20%, transparent);
+  border-radius: 10px;
   flex-shrink: 0;
 }
 
@@ -54,9 +92,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
+  margin: 16px 20px 0;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--green) 18%, transparent);
   background: color-mix(in srgb, var(--green) 4%, transparent);
+  border-radius: 12px;
   flex-shrink: 0;
 }
 
@@ -90,6 +130,7 @@
 .sr-list {
   flex: 1;
   overflow-y: auto;
+  padding: 18px 20px 28px;
 }
 
 .sr-empty {
@@ -98,19 +139,26 @@
   color: var(--t3);
   text-align: center;
   line-height: 1.5;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
 }
 
 .sr-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
-  transition: background 0.1s;
+  padding: 14px;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+  transition: background 0.1s, border-color 0.1s;
+  margin-bottom: 12px;
 }
 
 .sr-row:hover {
   background: var(--s2);
+  border-color: var(--s5);
 }
 
 .sr-row--active {
@@ -119,8 +167,8 @@
 
 .sr-row-left {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  align-items: flex-start;
+  gap: 10px;
   min-width: 0;
 }
 
@@ -168,7 +216,7 @@
 .sr-row-meta {
   font-size: 10px;
   color: var(--t3);
-  margin-top: 1px;
+  margin-top: 4px;
 }
 
 .sr-row-right {
@@ -176,6 +224,8 @@
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .sr-model-badge {
@@ -283,6 +333,27 @@
   outline: none;
   width: 140px;
   font-family: inherit;
+}
+
+@media (max-width: 980px) {
+  .sr-workspace-title {
+    font-size: 18px;
+  }
+
+  .sr-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sr-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .sr-row-right {
+    width: 100%;
+    justify-content: flex-start;
+  }
 }
 
 .sr-action-btn {

--- a/src/panels/SessionRegistry/SessionHistory.tsx
+++ b/src/panels/SessionRegistry/SessionHistory.tsx
@@ -278,14 +278,30 @@ export function SessionHistory() {
   }, [activeProjectId, load])
 
   const unpublishedCount = profile?.unpublishedCount ?? 0
+  const activeCount = sessions.filter((s) => s.status === 'active' && (!s.terminal_id || terminals.some((t) => t.id === s.terminal_id))).length
+  const completedCount = sessions.filter((s) => s.status === 'completed').length
 
   return (
     <div className="session-history">
+      <div className="sr-workspace-bar">
+        <div className="sr-workspace-copy">
+          <span className="sr-workspace-kicker">Agent memory</span>
+          <h2 className="sr-workspace-title">Track what is still running and what is worth publishing</h2>
+          <p className="sr-workspace-subtitle">
+            Sessions should be easy to resume, relaunch, rename, and publish without scanning a terminal graveyard.
+          </p>
+        </div>
+      </div>
+
       {profile && (
         <div className="sr-stats">
           <div className="sr-stat">
-            <span className="sr-stat-value">{profile.totalSessions}</span>
-            <span className="sr-stat-label">sessions</span>
+            <span className="sr-stat-value">{activeCount}</span>
+            <span className="sr-stat-label">active now</span>
+          </div>
+          <div className="sr-stat">
+            <span className="sr-stat-value">{completedCount}</span>
+            <span className="sr-stat-label">completed</span>
           </div>
           <div className="sr-stat">
             <span className="sr-stat-value">{profile.projectsCount}</span>
@@ -293,7 +309,7 @@ export function SessionHistory() {
           </div>
           <div className="sr-stat">
             <span className="sr-stat-value">{Math.round(profile.totalDuration / 60000)}m</span>
-            <span className="sr-stat-label">total time</span>
+            <span className="sr-stat-label">logged time</span>
           </div>
         </div>
       )}

--- a/src/panels/SettingsPanel/SettingsPanel.css
+++ b/src/panels/SettingsPanel/SettingsPanel.css
@@ -302,6 +302,65 @@
   color: var(--t3);
 }
 
+.settings-setup-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.012));
+}
+
+.settings-setup-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-version-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--green) 22%, var(--s4));
+  background: color-mix(in srgb, var(--green) 9%, transparent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--green);
+}
+
+.settings-setup-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.settings-setup-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 12px;
+  border: 1px solid var(--s5);
+  border-radius: 10px;
+  background: var(--s1);
+}
+
+.settings-setup-meta-label {
+  font-size: 9px;
+  color: var(--t4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.settings-setup-meta strong {
+  font-size: 14px;
+  color: var(--t1);
+}
+
 /* Crashes */
 .settings-crash-stats {
   display: flex;
@@ -448,4 +507,23 @@
   background: var(--green-glow);
   border-color: var(--green);
   color: var(--green);
+}
+
+@media (max-width: 900px) {
+  .settings-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settings-search {
+    max-width: none;
+  }
+
+  .settings-tabs {
+    overflow-x: auto;
+  }
+
+  .settings-setup-meta-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/panels/SettingsPanel/SettingsPanel.tsx
+++ b/src/panels/SettingsPanel/SettingsPanel.tsx
@@ -10,6 +10,13 @@ import './SettingsPanel.css'
 
 
 type SettingsTab = 'keys' | 'integrations' | 'agents' | 'display' | 'setup' | 'crashes'
+interface AppMeta {
+  version: string
+  electronVersion: string
+  platform: string
+  updateChannel: string
+  releaseUrl: string
+}
 
 interface SecureKeyEntry {
   key_name: string
@@ -49,7 +56,7 @@ function findTabForQuery(query: string): SettingsTab | null {
 
 export function SettingsPanel() {
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
-  const [tab, setTab] = useState<SettingsTab>('keys')
+  const [tab, setTab] = useState<SettingsTab>('setup')
   const [search, setSearch] = useState('')
 
   const handleSearchChange = (value: string) => {
@@ -576,6 +583,15 @@ function CrashesSection() {
 
 function SetupSection() {
   const [resettingLayout, setResettingLayout] = useState(false)
+  const [appMeta, setAppMeta] = useState<AppMeta | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    window.daemon.settings.getAppMeta().then((res) => {
+      if (!cancelled && res.ok && res.data) setAppMeta(res.data)
+    }).catch(() => {})
+    return () => { cancelled = true }
+  }, [])
 
   const handleRerunWizard = async () => {
     const freshProgress = { profile: 'pending' as const, claude: 'pending' as const, gmail: 'pending' as const, vercel: 'pending' as const, railway: 'pending' as const, tour: 'pending' as const }
@@ -610,6 +626,41 @@ function SetupSection() {
 
   return (
     <div className="settings-section">
+      {appMeta && (
+        <div className="settings-setup-card">
+          <div className="settings-setup-card-head">
+            <div>
+              <div className="settings-section-label">Release Status</div>
+              <div className="settings-section-desc">
+                Keep recovery and update trust surfaces in one place.
+              </div>
+            </div>
+            <span className="settings-version-pill">v{appMeta.version}</span>
+          </div>
+
+          <div className="settings-setup-meta-grid">
+            <div className="settings-setup-meta">
+              <span className="settings-setup-meta-label">App</span>
+              <strong>DAEMON {appMeta.version}</strong>
+            </div>
+            <div className="settings-setup-meta">
+              <span className="settings-setup-meta-label">Electron</span>
+              <strong>{appMeta.electronVersion}</strong>
+            </div>
+            <div className="settings-setup-meta">
+              <span className="settings-setup-meta-label">Channel</span>
+              <strong>{appMeta.updateChannel}</strong>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button className="settings-btn" onClick={() => window.daemon.feedback.openUrl(appMeta.releaseUrl)}>
+              Open Latest Release
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="settings-section-desc">
         Re-run the setup wizard or take the app tour again.
       </div>
@@ -617,9 +668,9 @@ function SetupSection() {
         <button className="settings-btn primary" onClick={handleRerunWizard}>
           Re-run Setup Wizard
         </button>
-        <button className="settings-btn" onClick={handleStartTour}>
-          Take App Tour
-        </button>
+          <button className="settings-btn" onClick={handleStartTour}>
+            Take App Tour
+          </button>
         <button className="settings-btn danger" onClick={handleResetLayout} disabled={resettingLayout}>
           {resettingLayout ? 'Resetting...' : 'Reset UI Layout'}
         </button>

--- a/src/panels/SolanaToolbox/ConnectedServices.tsx
+++ b/src/panels/SolanaToolbox/ConnectedServices.tsx
@@ -3,6 +3,7 @@ import type { SolanaMcpEntry } from '../../store/solanaToolbox'
 const MCP_TAGS: Record<string, string> = {
   helius: 'RPC',
   'solana-mcp-server': 'TOOLS',
+  'phantom-docs': 'WALLET',
   'payai-mcp-server': 'PAY',
   'x402-mcp': 'PAY',
 }

--- a/src/panels/SolanaToolbox/LaunchpadSettingsSection.tsx
+++ b/src/panels/SolanaToolbox/LaunchpadSettingsSection.tsx
@@ -94,23 +94,40 @@ export function LaunchpadSettingsSection({
 
   return (
     <section className="solana-launchpad-settings">
-      <div className="solana-launchpad-settings-header">
-        <div>
-          {!embedded && <div className="solana-token-launch-kicker">Launchpad Settings</div>}
-          <h2 className="solana-token-launch-title">{embedded ? 'Launchpad config' : 'Enable LaunchLab and DBC in-app'}</h2>
-          <p className="solana-launchpad-settings-copy">
-            {embedded
-              ? 'Store protocol config once and let the unified launch flow pick it up automatically.'
-              : 'Store protocol config once, keep env fallback in place, and let the unified Token Launch tool resolve readiness from DAEMON state.'}
-          </p>
+      {!embedded && (
+        <div className="solana-launchpad-settings-header">
+          <div>
+            <div className="solana-token-launch-kicker">Launchpad Settings</div>
+            <h2 className="solana-token-launch-title">Enable LaunchLab and DBC in-app</h2>
+            <p className="solana-launchpad-settings-copy">
+              Store protocol config once, keep env fallback in place, and let the unified Token Launch tool resolve readiness from DAEMON state.
+            </p>
+          </div>
+          <div className="solana-token-launch-actions">
+            <button className="sol-btn" onClick={() => { void load() }} disabled={loading || saving}>Reload</button>
+            <button className="sol-btn green" onClick={handleSave} disabled={loading || saving || !isDirty}>
+              {saving ? 'Saving...' : 'Save Settings'}
+            </button>
+          </div>
         </div>
-        <div className="solana-token-launch-actions">
-          <button className="sol-btn" onClick={() => { void load() }} disabled={loading || saving}>Reload</button>
-          <button className="sol-btn green" onClick={handleSave} disabled={loading || saving || !isDirty}>
-            {saving ? 'Saving...' : 'Save Settings'}
-          </button>
+      )}
+
+      {embedded && (
+        <div className="solana-launchpad-settings-compact-head">
+          <div>
+            <div className="solana-token-launch-card-title">Launchpad config</div>
+            <div className="solana-token-launch-card-copy">
+              Save the protocol config once here and the launch flow will pick it up automatically.
+            </div>
+          </div>
+          <div className="solana-token-launch-actions">
+            <button className="sol-btn" onClick={() => { void load() }} disabled={loading || saving}>Reload</button>
+            <button className="sol-btn green" onClick={handleSave} disabled={loading || saving || !isDirty}>
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="solana-launchpad-settings-grid">
         <div className="solana-launchpad-settings-card">

--- a/src/panels/SolanaToolbox/ProtocolPacksSection.tsx
+++ b/src/panels/SolanaToolbox/ProtocolPacksSection.tsx
@@ -25,20 +25,29 @@ export function ProtocolPacksSection() {
       <div className="solana-protocol-grid">
         {SOLANA_PROTOCOL_PACKS.map((pack) => (
           <section key={pack.id} className="solana-protocol-card">
-            <div className="solana-runtime-title-row">
-              <span className="solana-runtime-label">{pack.label}</span>
-              <span className={`solana-ecosystem-status ${pack.status}`}>{pack.status === 'native' ? 'Native' : 'Guided'}</span>
+            <div className="solana-protocol-card-head">
+              <div>
+                <div className="solana-protocol-name">{pack.label}</div>
+                <div className="solana-protocol-status-line">
+                  <span className={`solana-ecosystem-status ${pack.status}`}>{pack.status === 'native' ? 'Native' : 'Guided'}</span>
+                </div>
+              </div>
             </div>
             <div className="solana-runtime-detail">{pack.kickoff}</div>
-            <div className="solana-protocol-hint">{pack.installHint}</div>
-            <div className="solana-protocol-actions">
-              <button className="sol-btn" onClick={() => copyText(pack.skill)}>
-                {copied === pack.skill ? 'Copied Skill' : 'Copy Skill'}
-              </button>
-              <button className="sol-btn" onClick={() => copyText(pack.installHint)}>
-                {copied === pack.installHint ? 'Copied Install' : 'Copy Install'}
-              </button>
-              <a className="sol-btn" href={pack.docsUrl} target="_blank" rel="noreferrer">
+            <div className="solana-protocol-snippet">
+              <div className="solana-protocol-snippet-label">First move</div>
+              <code className="solana-protocol-hint">{pack.installHint}</code>
+            </div>
+            <div className="solana-protocol-footer">
+              <div className="solana-protocol-actions">
+                <button className="sol-btn" onClick={() => copyText(pack.skill)}>
+                  {copied === pack.skill ? 'Copied Skill' : 'Copy Skill'}
+                </button>
+                <button className="sol-btn" onClick={() => copyText(pack.installHint)}>
+                  {copied === pack.installHint ? 'Copied Install' : 'Copy Install'}
+                </button>
+              </div>
+              <a className="solana-protocol-doc-link" href={pack.docsUrl} target="_blank" rel="noreferrer">
                 Docs
               </a>
             </div>

--- a/src/panels/SolanaToolbox/SolanaToolbox.css
+++ b/src/panels/SolanaToolbox/SolanaToolbox.css
@@ -126,6 +126,14 @@
   gap: 12px;
 }
 
+.solana-launchpad-settings-compact-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
 .solana-launchpad-settings-card {
   background: var(--s1);
   border: 1px solid var(--s5);
@@ -256,7 +264,7 @@
 
 .solana-token-launch-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
 
@@ -268,13 +276,28 @@
   box-shadow: var(--shadow-lifted);
 }
 
+.solana-token-launch-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
 .solana-token-launch-card-title {
   font-size: var(--font-sm);
   font-weight: 700;
   color: var(--t2);
   text-transform: uppercase;
   letter-spacing: 1.5px;
-  margin-bottom: 12px;
+}
+
+.solana-token-launch-card-copy {
+  margin-top: 6px;
+  max-width: 52ch;
+  font-size: var(--font-sm);
+  line-height: 1.45;
+  color: var(--t4);
 }
 
 .solana-launchpad-list,
@@ -402,7 +425,7 @@
 
 .solana-protocol-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
 
@@ -426,8 +449,29 @@
   border: 1px solid rgba(62, 207, 142, 0.12);
   background: rgba(62, 207, 142, 0.03);
   border-radius: var(--radius-lg);
-  padding: 14px;
-  min-height: 172px;
+  padding: 16px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.solana-protocol-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.solana-protocol-name {
+  font-size: 18px;
+  line-height: 1.15;
+  font-weight: 700;
+  color: var(--t1);
+}
+
+.solana-protocol-status-line {
+  margin-top: 8px;
 }
 
 .solana-runtime-title-row {
@@ -469,18 +513,52 @@
 }
 
 .solana-protocol-hint {
-  margin-top: 12px;
   font-size: var(--font-sm);
   color: var(--t2);
   font-family: var(--font-code);
   word-break: break-word;
+  display: block;
+}
+
+.solana-protocol-snippet {
+  padding: 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.solana-protocol-snippet-label {
+  margin-bottom: 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--t4);
 }
 
 .solana-protocol-actions {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
-  margin-top: 12px;
+}
+
+.solana-protocol-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.solana-protocol-doc-link {
+  color: var(--green);
+  font-size: var(--font-sm);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.solana-protocol-doc-link:hover {
+  text-decoration: underline;
 }
 
 .solana-runtime-troubleshooting {
@@ -537,6 +615,19 @@
   .solana-ecosystem-grid,
   .solana-split {
     grid-template-columns: 1fr;
+  }
+
+  .solana-launchpad-settings-compact-head,
+  .solana-token-launch-card-head,
+  .solana-protocol-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .solana-token-launch-card-head .sol-btn,
+  .solana-launchpad-settings-compact-head .sol-btn,
+  .solana-protocol-actions .sol-btn {
+    width: 100%;
   }
 }
 

--- a/src/panels/SolanaToolbox/SolanaToolbox.css
+++ b/src/panels/SolanaToolbox/SolanaToolbox.css
@@ -10,6 +10,84 @@
     var(--surface-gradient-subtle);
 }
 
+.solana-workflow-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.solana-workflow-header {
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid rgba(62, 207, 142, 0.06);
+}
+
+.solana-workflow-title {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.08;
+  color: var(--t1);
+}
+
+.solana-workflow-copy {
+  margin: 10px 0 0;
+  max-width: 72ch;
+  color: var(--t3);
+  font-size: var(--font-md);
+  line-height: 1.5;
+}
+
+.solana-view-tabs {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  padding: 0 20px 18px;
+}
+
+.solana-view-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 14px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--s5);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--t2);
+  text-align: left;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.solana-view-tab:hover {
+  border-color: rgba(62, 207, 142, 0.18);
+  background: rgba(62, 207, 142, 0.04);
+}
+
+.solana-view-tab.active {
+  border-color: rgba(62, 207, 142, 0.24);
+  background:
+    radial-gradient(circle at top right, rgba(62, 207, 142, 0.12), transparent 45%),
+    rgba(62, 207, 142, 0.05);
+  box-shadow: var(--shadow-lifted);
+}
+
+.solana-view-tab-label {
+  font-size: var(--font-md);
+  font-weight: 700;
+  color: var(--t1);
+}
+
+.solana-view-tab-summary {
+  font-size: var(--font-sm);
+  line-height: 1.45;
+  color: var(--t4);
+}
+
+.solana-view-panel {
+  display: flex;
+  flex-direction: column;
+}
+
 /* ── Validator zone (full width) ── */
 .solana-validator-zone {
   padding: 16px;
@@ -429,6 +507,10 @@
 }
 
 @media (max-width: 1100px) {
+  .solana-view-tabs {
+    grid-template-columns: 1fr;
+  }
+
   .solana-token-launch-header,
   .solana-launchpad-settings-header,
   .solana-launchpad-row,

--- a/src/panels/SolanaToolbox/SolanaToolbox.css
+++ b/src/panels/SolanaToolbox/SolanaToolbox.css
@@ -548,6 +548,16 @@
   justify-content: space-between;
   gap: 12px;
   margin-top: auto;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.solana-protocol-card .solana-runtime-detail {
+  margin-top: 0;
+}
+
+.solana-protocol-actions .sol-btn {
+  min-width: 0;
 }
 
 .solana-protocol-doc-link {

--- a/src/panels/SolanaToolbox/SolanaToolbox.tsx
+++ b/src/panels/SolanaToolbox/SolanaToolbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useUIStore } from '../../store/ui'
 import { useSolanaToolboxStore } from '../../store/solanaToolbox'
 import { EnvironmentBar } from './EnvironmentBar'
@@ -12,7 +12,36 @@ import { ProtocolPacksSection } from './ProtocolPacksSection'
 import { scaffoldX402, scaffoldMpp } from './scaffolding'
 import './SolanaToolbox.css'
 
+const SOLANA_VIEWS = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    summary: 'Runtime, validator, and project state',
+  },
+  {
+    id: 'connect',
+    label: 'Connect',
+    summary: 'Providers, MCPs, and wallet paths',
+  },
+  {
+    id: 'build',
+    label: 'Build',
+    summary: 'Scaffolds, skills, and payment setup',
+  },
+  {
+    id: 'integrate',
+    label: 'Integrate',
+    summary: 'Protocol packs and ecosystem coverage',
+  },
+  {
+    id: 'diagnose',
+    label: 'Diagnose',
+    summary: 'Toolchain readiness and environment checks',
+  },
+] as const
+
 export function SolanaToolbox() {
+  const [activeView, setActiveView] = useState<(typeof SOLANA_VIEWS)[number]['id']>('overview')
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
   const mcps = useSolanaToolboxStore((s) => s.mcps)
@@ -48,40 +77,86 @@ export function SolanaToolbox() {
   return (
     <div className="solana-toolbox">
       <EnvironmentBar info={projectInfo} validator={validator} mcps={mcps} toolchain={toolchain} />
-      <div className="solana-validator-zone">
-        <ValidatorCard />
-      </div>
 
-      <div className="solana-validator-zone">
-        <ToolchainSection toolchain={toolchain} />
-      </div>
+      <section className="solana-workflow-shell">
+        <div className="solana-workflow-header">
+          <div>
+            <div className="solana-token-launch-kicker">Solana Workspace</div>
+            <h1 className="solana-workflow-title">Choose the task you need right now</h1>
+            <p className="solana-workflow-copy">
+              Keep DAEMON focused on the next Solana job instead of making you scroll through one oversized toolbox page.
+            </p>
+          </div>
+        </div>
 
-      <div className="solana-split">
-        <ConnectedServices
-          mcps={mcps}
-          projectPath={activeProjectPath}
-          onToggle={toggleMcp}
-        />
-        <CapabilitiesSection
-          mcps={mcps}
-          projectPath={activeProjectPath}
-          onToggle={toggleMcp}
-          onScaffoldX402={handleScaffoldX402}
-          onScaffoldMpp={handleScaffoldMpp}
-        />
-      </div>
+        <div className="solana-view-tabs" role="tablist" aria-label="Solana workflow views">
+          {SOLANA_VIEWS.map((view) => (
+            <button
+              key={view.id}
+              type="button"
+              role="tab"
+              aria-selected={activeView === view.id}
+              className={`solana-view-tab${activeView === view.id ? ' active' : ''}`}
+              onClick={() => setActiveView(view.id)}
+            >
+              <span className="solana-view-tab-label">{view.label}</span>
+              <span className="solana-view-tab-summary">{view.summary}</span>
+            </button>
+          ))}
+        </div>
 
-      <div className="solana-validator-zone">
-        <RuntimeStackSection />
-      </div>
+        <div className="solana-view-panel">
+          {activeView === 'overview' && (
+            <>
+              <div className="solana-validator-zone">
+                <ValidatorCard />
+              </div>
+              <div className="solana-validator-zone">
+                <RuntimeStackSection />
+              </div>
+            </>
+          )}
 
-      <div className="solana-validator-zone">
-        <ProtocolPacksSection />
-      </div>
+          {activeView === 'connect' && (
+            <div className="solana-validator-zone">
+              <ConnectedServices
+                mcps={mcps}
+                projectPath={activeProjectPath}
+                onToggle={toggleMcp}
+              />
+            </div>
+          )}
 
-      <div className="solana-validator-zone">
-        <EcosystemSection />
-      </div>
+          {activeView === 'build' && (
+            <div className="solana-validator-zone">
+              <CapabilitiesSection
+                mcps={mcps}
+                projectPath={activeProjectPath}
+                onToggle={toggleMcp}
+                onScaffoldX402={handleScaffoldX402}
+                onScaffoldMpp={handleScaffoldMpp}
+              />
+            </div>
+          )}
+
+          {activeView === 'integrate' && (
+            <>
+              <div className="solana-validator-zone">
+                <ProtocolPacksSection />
+              </div>
+              <div className="solana-validator-zone">
+                <EcosystemSection />
+              </div>
+            </>
+          )}
+
+          {activeView === 'diagnose' && (
+            <div className="solana-validator-zone">
+              <ToolchainSection toolchain={toolchain} />
+            </div>
+          )}
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/panels/SolanaToolbox/TokenLaunchSection.tsx
+++ b/src/panels/SolanaToolbox/TokenLaunchSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 
 function truncateMiddle(value: string, head = 6, tail = 6) {
   if (value.length <= head + tail + 3) return value
@@ -26,8 +26,8 @@ export function TokenLaunchSection({
   embedded?: boolean
   onRefreshRequested?: () => void
 }) {
-  const launchWizardOpen = useUIStore((s) => s.launchWizardOpen)
-  const openLaunchWizard = useUIStore((s) => s.openLaunchWizard)
+  const launchWizardOpen = useWorkflowShellStore((s) => s.launchWizardOpen)
+  const openLaunchWizard = useWorkflowShellStore((s) => s.openLaunchWizard)
 
   const [launchpads, setLaunchpads] = useState<LaunchpadDefinition[]>([])
   const [launches, setLaunches] = useState<LaunchedToken[]>([])

--- a/src/panels/SolanaToolbox/TokenLaunchSection.tsx
+++ b/src/panels/SolanaToolbox/TokenLaunchSection.tsx
@@ -68,35 +68,53 @@ export function TokenLaunchSection({
 
   return (
     <section className={`solana-token-launch ${embedded ? 'embedded' : ''}`}>
-      <div className="solana-token-launch-header">
-        <div>
-          {!embedded && <div className="solana-token-launch-kicker">Token Launch</div>}
-          <h2 className="solana-token-launch-title">
-            {embedded ? 'Live launchpads and recent launches' : 'One launch surface for Solana token launches'}
-          </h2>
-          <p className="solana-token-launch-copy">
-            {embedded
-              ? 'Keep launch availability and recent history visible while the main CTA stays at the tool level.'
-              : 'Launch from one Solana workflow, monitor protocol readiness, and keep wallet-linked launch history in one place.'}
-          </p>
+      {!embedded && (
+        <div className="solana-token-launch-header">
+          <div>
+            <div className="solana-token-launch-kicker">Token Launch</div>
+            <h2 className="solana-token-launch-title">One launch surface for Solana token launches</h2>
+            <p className="solana-token-launch-copy">
+              Launch from one Solana workflow, monitor protocol readiness, and keep wallet-linked launch history in one place.
+            </p>
+          </div>
+          <div className="solana-token-launch-actions">
+            <button className="sol-btn green" onClick={openLaunchWizard}>Open Launcher</button>
+            <button
+              className="sol-btn"
+              onClick={() => {
+                onRefreshRequested?.()
+                void reload()
+              }}
+            >
+              Refresh
+            </button>
+          </div>
         </div>
-        <div className="solana-token-launch-actions">
-          <button className="sol-btn green" onClick={openLaunchWizard}>Open Launcher</button>
-          <button
-            className="sol-btn"
-            onClick={() => {
-              onRefreshRequested?.()
-              void reload()
-            }}
-          >
-            Refresh
-          </button>
-        </div>
-      </div>
+      )}
 
       <div className="solana-token-launch-grid">
         <div className="solana-token-launch-card">
-          <div className="solana-token-launch-card-title">Launchpads</div>
+          <div className="solana-token-launch-card-head">
+            <div>
+              <div className="solana-token-launch-card-title">Launchpads</div>
+              {embedded && (
+                <div className="solana-token-launch-card-copy">
+                  Live protocol availability stays here so the main tool CTA always has context.
+                </div>
+              )}
+            </div>
+            {embedded && (
+              <button
+                className="sol-btn"
+                onClick={() => {
+                  onRefreshRequested?.()
+                  void reload()
+                }}
+              >
+                Refresh
+              </button>
+            )}
+          </div>
           <div className="solana-launchpad-list">
             {launchpads.map((launchpad) => (
               <div key={launchpad.id} className={`solana-launchpad-row ${launchpad.enabled ? 'enabled' : 'planned'}`}>
@@ -125,7 +143,16 @@ export function TokenLaunchSection({
         </div>
 
         <div className="solana-token-launch-card">
-          <div className="solana-token-launch-card-title">Recent Launches</div>
+          <div className="solana-token-launch-card-head">
+            <div>
+              <div className="solana-token-launch-card-title">Recent Launches</div>
+              {embedded && (
+                <div className="solana-token-launch-card-copy">
+                  Wallet-linked launch history gives you the quickest handoff back into post-launch work.
+                </div>
+              )}
+            </div>
+          </div>
           {loading ? (
             <div className="solana-empty">Loading launches...</div>
           ) : launches.length === 0 ? (

--- a/src/panels/SolanaToolbox/catalog.ts
+++ b/src/panels/SolanaToolbox/catalog.ts
@@ -52,6 +52,12 @@ export const SOLANA_MCP_CATALOG: Record<string, SolanaCatalogMcpEntry> = {
     description: 'Program deployment, account inspection, and Solana docs tooling.',
     category: 'rpc',
   },
+  'phantom-docs': {
+    label: 'Phantom Docs',
+    description: 'Official Phantom Connect SDK MCP for wallet connection, signing, and Portal guidance.',
+    category: 'wallets',
+    docsUrl: 'https://docs.phantom.com/resources/mcp-server',
+  },
   'payai-mcp-server': {
     label: 'PayAI',
     description: 'x402 payment protocol via the PayAI facilitator.',
@@ -107,10 +113,11 @@ export const SOLANA_INTEGRATION_CATALOG: SolanaIntegrationEntry[] = [
     id: 'phantom-connect',
     label: 'Phantom Connect',
     area: 'Wallets',
-    kind: 'SDK',
-    status: 'guided',
-    description: 'First-class wallet connectivity for Solana desktop and web flows.',
-    docsUrl: 'https://docs.phantom.com/sdks/browser-sdk',
+    kind: 'MCP',
+    status: 'native',
+    description: 'Official Phantom Connect SDK docs MCP plus starter guidance for wallet connection and signing flows.',
+    docsUrl: 'https://docs.phantom.com/resources/mcp-server',
+    mcpName: 'phantom-docs',
     skill: '/phantom-connect',
   },
   {

--- a/src/panels/SolanaToolbox/scaffolding.ts
+++ b/src/panels/SolanaToolbox/scaffolding.ts
@@ -1,4 +1,5 @@
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 
 /** Dispatch scaffold prompts to the Solana Agent via terminal */
 
@@ -6,7 +7,7 @@ async function spawnAndShowAgent(projectId: string, prompt: string, taskLabel: s
   const state = useUIStore.getState()
 
   // Close drawer so terminal is visible
-  state.closeDrawer()
+  useWorkflowShellStore.getState().closeDrawer()
 
   const res = await window.daemon.terminal.spawnAgent({
     agentId: 'solana-agent',

--- a/src/panels/StatusBar/StatusBar.tsx
+++ b/src/panels/StatusBar/StatusBar.tsx
@@ -109,7 +109,6 @@ function TerminalCount() {
 
 function ValidatorStatus() {
   const validator = useSolanaToolboxStore((s) => s.validator)
-  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
 
   if (validator.status === 'stopped') return null
 
@@ -120,7 +119,7 @@ function ValidatorStatus() {
   return (
     <span
       className={`${styles.item} ${styles.clickable}`}
-      onClick={() => setDrawerTool('solana-toolbox')}
+      onClick={() => useUIStore.getState().openWorkspaceTool('solana-toolbox')}
       title="Open Solana Toolbox"
     >
       <span style={{ display: 'inline-block', width: 5, height: 5, borderRadius: '50%', background: color, marginRight: 4 }} />
@@ -131,7 +130,6 @@ function ValidatorStatus() {
 
 function GitBranch() {
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
-  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const [branch, setBranch] = useState<string | null>(null)
 
   useEffect(() => {
@@ -145,7 +143,7 @@ function GitBranch() {
   return (
     <span
       className={`${styles.item} ${styles.branch} ${styles.clickable}`}
-      onClick={() => setDrawerTool('git')}
+      onClick={() => useUIStore.getState().openWorkspaceTool('git')}
       title="Open Git panel"
     >
       {branch}
@@ -156,6 +154,7 @@ function GitBranch() {
 function BugReportButton({ showLabel }: { showLabel: boolean }) {
   const [open, setOpen] = useState(false)
   const drawerTool = useWorkflowShellStore((s) => s.drawerTool)
+  const activeWorkspaceToolId = useUIStore((s) => s.activeWorkspaceToolId)
 
   return (
     <>
@@ -175,7 +174,7 @@ function BugReportButton({ showLabel }: { showLabel: boolean }) {
       <BugReportModal
         open={open}
         onClose={() => setOpen(false)}
-        activePanel={drawerTool ?? undefined}
+        activePanel={activeWorkspaceToolId ?? drawerTool ?? undefined}
       />
     </>
   )
@@ -245,7 +244,6 @@ function ClaudeStatus() {
 }
 
 function HackathonCountdown() {
-  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const [label, setLabel] = useState<string | null>(null)
   const [urgency, setUrgency] = useState<'normal' | 'warning' | 'urgent'>('normal')
 
@@ -285,7 +283,7 @@ function HackathonCountdown() {
   return (
     <button
       className={`${styles.hackathonBtn} ${colorClass}`}
-      onClick={() => setDrawerTool('hackathon')}
+      onClick={() => useUIStore.getState().openWorkspaceTool('hackathon')}
       title="Hackathon deadline"
     >
       {label}

--- a/src/panels/StatusBar/StatusBar.tsx
+++ b/src/panels/StatusBar/StatusBar.tsx
@@ -5,6 +5,7 @@ import { useWalletStore } from '../../store/wallet'
 import { useEmailStore } from '../../store/email'
 import { useOnboardingStore } from '../../store/onboarding'
 import { useSolanaToolboxStore } from '../../store/solanaToolbox'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useShellLayout } from '../../hooks/useShellLayout'
 import { daemon } from '../../lib/daemonBridge'
 import { formatCompactUsd } from '../../utils/format'
@@ -108,7 +109,7 @@ function TerminalCount() {
 
 function ValidatorStatus() {
   const validator = useSolanaToolboxStore((s) => s.validator)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
 
   if (validator.status === 'stopped') return null
 
@@ -130,7 +131,7 @@ function ValidatorStatus() {
 
 function GitBranch() {
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const [branch, setBranch] = useState<string | null>(null)
 
   useEffect(() => {
@@ -154,7 +155,7 @@ function GitBranch() {
 
 function BugReportButton({ showLabel }: { showLabel: boolean }) {
   const [open, setOpen] = useState(false)
-  const drawerTool = useUIStore((s) => s.drawerTool)
+  const drawerTool = useWorkflowShellStore((s) => s.drawerTool)
 
   return (
     <>
@@ -244,7 +245,7 @@ function ClaudeStatus() {
 }
 
 function HackathonCountdown() {
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const [label, setLabel] = useState<string | null>(null)
   const [urgency, setUrgency] = useState<'normal' | 'warning' | 'urgent'>('normal')
 

--- a/src/panels/Terminal/AgentGrid.tsx
+++ b/src/panels/Terminal/AgentGrid.tsx
@@ -3,6 +3,7 @@ import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useNotificationsStore } from '../../store/notifications'
 
 type ProviderId = 'claude' | 'codex'
@@ -343,10 +344,10 @@ function CellErrorView({
 
   if (error.code === 'NO_PROVIDER_AUTH') {
     cta = 'Open Settings'
-    action = () => useUIStore.getState().setDrawerTool('settings')
+    action = () => useWorkflowShellStore.getState().setDrawerTool('settings')
   } else if (error.code === 'NOT_AUTHENTICATED') {
     cta = 'Open Settings'
-    action = () => useUIStore.getState().setDrawerTool('settings')
+    action = () => useWorkflowShellStore.getState().setDrawerTool('settings')
   } else if (error.code === 'CLI_NOT_INSTALLED') {
     cta = 'Install CLI'
     action = async () => {

--- a/src/panels/Terminal/AgentGrid.tsx
+++ b/src/panels/Terminal/AgentGrid.tsx
@@ -344,10 +344,10 @@ function CellErrorView({
 
   if (error.code === 'NO_PROVIDER_AUTH') {
     cta = 'Open Settings'
-    action = () => useWorkflowShellStore.getState().setDrawerTool('settings')
+    action = () => useUIStore.getState().openWorkspaceTool('settings')
   } else if (error.code === 'NOT_AUTHENTICATED') {
     cta = 'Open Settings'
-    action = () => useWorkflowShellStore.getState().setDrawerTool('settings')
+    action = () => useUIStore.getState().openWorkspaceTool('settings')
   } else if (error.code === 'CLI_NOT_INSTALLED') {
     cta = 'Install CLI'
     action = async () => {

--- a/src/panels/Terminal/Terminal.tsx
+++ b/src/panels/Terminal/Terminal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useMemo, useState } from 'react'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { getEmbeddedProviderStartupCommand } from '../../../electron/shared/providerLaunch'
 import { TerminalTabs } from './TerminalTabs'
 import { TerminalInstance } from './TerminalInstance'
@@ -19,7 +20,7 @@ export function TerminalPanel() {
   const addTerminal = useUIStore((s) => s.addTerminal)
   const removeTerminal = useUIStore((s) => s.removeTerminal)
   const setActiveTerminal = useUIStore((s) => s.setActiveTerminal)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const centerMode = useUIStore((s) => s.centerMode)
   const setCenterMode = useUIStore((s) => s.setCenterMode)
   const activeProjectId = useUIStore((s) => s.activeProjectId)

--- a/src/panels/TokenLaunchTool/TokenLaunchTool.css
+++ b/src/panels/TokenLaunchTool/TokenLaunchTool.css
@@ -110,19 +110,7 @@
   line-height: 1.5;
 }
 
-.token-launch-tool-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
-  gap: 18px;
-  min-height: 0;
-}
-
-.token-launch-tool-main,
-.token-launch-tool-side {
-  min-width: 0;
-}
-
-.token-launch-tool-side {
+.token-launch-tool-flow {
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -190,13 +178,8 @@
     align-items: stretch;
   }
 
-  .token-launch-tool-highlight-grid,
-  .token-launch-tool-layout {
+  .token-launch-tool-highlight-grid {
     grid-template-columns: 1fr;
-  }
-
-  .token-launch-tool-side {
-    gap: 16px;
   }
 }
 

--- a/src/panels/TokenLaunchTool/TokenLaunchTool.css
+++ b/src/panels/TokenLaunchTool/TokenLaunchTool.css
@@ -21,6 +21,9 @@
     rgba(255, 255, 255, 0.02);
   box-shadow: var(--shadow-lifted);
   overflow: hidden;
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
 }
 
 .token-launch-tool-header {
@@ -116,6 +119,8 @@
   flex-direction: column;
   gap: 18px;
   max-width: 1120px;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .token-launch-tool-zone-head {

--- a/src/panels/TokenLaunchTool/TokenLaunchTool.css
+++ b/src/panels/TokenLaunchTool/TokenLaunchTool.css
@@ -62,6 +62,7 @@
   display: flex;
   gap: 10px;
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .token-launch-tool-zone {
@@ -74,7 +75,7 @@
 
 .token-launch-tool-highlight-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 12px;
   padding: 0 22px 22px;
 }
@@ -114,6 +115,7 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
+  max-width: 1120px;
 }
 
 .token-launch-tool-zone-head {
@@ -178,8 +180,8 @@
     align-items: stretch;
   }
 
-  .token-launch-tool-highlight-grid {
-    grid-template-columns: 1fr;
+  .token-launch-tool-actions .sol-btn {
+    width: 100%;
   }
 }
 

--- a/src/panels/TokenLaunchTool/TokenLaunchTool.tsx
+++ b/src/panels/TokenLaunchTool/TokenLaunchTool.tsx
@@ -1,13 +1,13 @@
 import { useMemo, useState } from 'react'
 import { LaunchpadSettingsSection } from '../SolanaToolbox/LaunchpadSettingsSection'
 import { TokenLaunchSection } from '../SolanaToolbox/TokenLaunchSection'
-import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import '../SolanaToolbox/SolanaToolbox.css'
 import './TokenLaunchTool.css'
 
 export function TokenLaunchTool() {
   const [launchpadRefreshNonce, setLaunchpadRefreshNonce] = useState(0)
-  const openLaunchWizard = useUIStore((s) => s.openLaunchWizard)
+  const openLaunchWizard = useWorkflowShellStore((s) => s.openLaunchWizard)
 
   const highlights = useMemo(() => ([
     {

--- a/src/panels/TokenLaunchTool/TokenLaunchTool.tsx
+++ b/src/panels/TokenLaunchTool/TokenLaunchTool.tsx
@@ -61,52 +61,48 @@ export function TokenLaunchTool() {
         </div>
       </section>
 
-      <div className="token-launch-tool-layout">
-        <div className="token-launch-tool-main">
-          <div className="token-launch-tool-zone token-launch-tool-zone-main">
-            <div className="token-launch-tool-zone-head">
-              <div>
-                <div className="token-launch-tool-zone-kicker">Workflow</div>
-                <div className="token-launch-tool-zone-title">Launch, monitor, and hand off from one place</div>
-                <p className="token-launch-tool-zone-copy">
-                  Use one entry point for launchpad availability, recent launches, and the flow that opens your token in-app after send.
-                </p>
-              </div>
+      <div className="token-launch-tool-flow">
+        <section className="token-launch-tool-zone token-launch-tool-zone-main">
+          <div className="token-launch-tool-zone-head">
+            <div>
+              <div className="token-launch-tool-zone-kicker">Step 1</div>
+              <div className="token-launch-tool-zone-title">Check readiness and recent launches</div>
+              <p className="token-launch-tool-zone-copy">
+                Keep launchpad status, launch history, and the main launch CTA together so the workflow always has one obvious next action.
+              </p>
             </div>
-            <TokenLaunchSection
-              refreshNonce={launchpadRefreshNonce}
-              embedded
-              onRefreshRequested={() => setLaunchpadRefreshNonce((nonce) => nonce + 1)}
-            />
           </div>
+          <TokenLaunchSection
+            refreshNonce={launchpadRefreshNonce}
+            embedded
+            onRefreshRequested={() => setLaunchpadRefreshNonce((nonce) => nonce + 1)}
+          />
+        </section>
+
+        <section className="token-launch-tool-zone token-launch-tool-zone-side">
+          <div className="token-launch-tool-zone-head">
+            <div>
+              <div className="token-launch-tool-zone-kicker">Step 2</div>
+              <div className="token-launch-tool-zone-title">Save protocol config once</div>
+              <p className="token-launch-tool-zone-copy">
+                Keep LaunchLab and DBC config in-app so the launch workflow can resolve readiness without bouncing out to env setup.
+              </p>
+            </div>
+          </div>
+          <LaunchpadSettingsSection
+            embedded
+            onSettingsSaved={() => setLaunchpadRefreshNonce((nonce) => nonce + 1)}
+          />
+        </section>
+
+        <div className="token-launch-tool-note">
+          <div className="token-launch-tool-note-title">Recommended flow</div>
+          <ol className="token-launch-tool-note-list">
+            <li>Pick the wallet you want to launch from.</li>
+            <li>Confirm the launchpad is live and the config is saved.</li>
+            <li>Launch once, then open the token in Browser Mode for post-launch work.</li>
+          </ol>
         </div>
-
-        <aside className="token-launch-tool-side">
-          <div className="token-launch-tool-zone token-launch-tool-zone-side">
-            <div className="token-launch-tool-zone-head">
-              <div>
-                <div className="token-launch-tool-zone-kicker">Settings</div>
-                <div className="token-launch-tool-zone-title">Store protocol settings once</div>
-                <p className="token-launch-tool-zone-copy">
-                  Keep LaunchLab and DBC config in-app so the launch workflow can resolve readiness without bouncing you out to env setup.
-                </p>
-              </div>
-            </div>
-            <LaunchpadSettingsSection
-              embedded
-              onSettingsSaved={() => setLaunchpadRefreshNonce((nonce) => nonce + 1)}
-            />
-          </div>
-
-          <div className="token-launch-tool-note">
-            <div className="token-launch-tool-note-title">Recommended flow</div>
-            <ol className="token-launch-tool-note-list">
-              <li>Pick the wallet you want to launch from.</li>
-              <li>Run preflight and confirm the launchpad is live.</li>
-              <li>Launch once, then open the token in Browser Mode for post-launch work.</li>
-            </ol>
-          </div>
-        </aside>
       </div>
     </div>
   )

--- a/src/panels/Tools/ToolBrowser.tsx
+++ b/src/panels/Tools/ToolBrowser.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useToolsStore } from '../../store/tools'
 import { useUIStore } from '../../store/ui'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { ToolCard } from './ToolCard'
 import { ToolCreateDialog } from './ToolCreateDialog'
 import './ToolBrowser.css'
@@ -11,7 +12,7 @@ export function ToolBrowser() {
   const { tools, loaded, load, filter, setFilter, setActiveTool, runningToolIds } = useToolsStore()
   const openFile = useUIStore((s) => s.openFile)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
-  const setDrawerTool = useUIStore((s) => s.setDrawerTool)
+  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const [showCreate, setShowCreate] = useState(false)
 
   useEffect(() => { if (!loaded) load() }, [loaded, load])

--- a/src/panels/Tools/ToolBrowser.tsx
+++ b/src/panels/Tools/ToolBrowser.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useToolsStore } from '../../store/tools'
 import { useUIStore } from '../../store/ui'
-import { useWorkflowShellStore } from '../../store/workflowShell'
 import { ToolCard } from './ToolCard'
 import { ToolCreateDialog } from './ToolCreateDialog'
 import './ToolBrowser.css'
@@ -12,7 +11,6 @@ export function ToolBrowser() {
   const { tools, loaded, load, filter, setFilter, setActiveTool, runningToolIds } = useToolsStore()
   const openFile = useUIStore((s) => s.openFile)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
-  const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const [showCreate, setShowCreate] = useState(false)
 
   useEffect(() => { if (!loaded) load() }, [loaded, load])
@@ -26,7 +24,7 @@ export function ToolBrowser() {
     // Built-in tools navigate to their dedicated drawer tool
     const builtinTool = BUILTIN_DRAWER_TOOLS[toolId]
     if (builtinTool) {
-      setDrawerTool(builtinTool)
+      useUIStore.getState().openWorkspaceTool(builtinTool)
       return
     }
 
@@ -41,9 +39,8 @@ export function ToolBrowser() {
       useUIStore.getState().addTerminal(activeProjectId, termRes.data.id, tool?.name ?? 'Tool')
       await window.daemon.tools.markRunning(toolId, termRes.data.id, termRes.data.pid)
       useToolsStore.getState().addRunning(toolId)
-      setDrawerTool(null)
     }
-  }, [activeProjectId, tools, setDrawerTool])
+  }, [activeProjectId, tools])
 
   const handleEdit = useCallback(async (toolId: string) => {
     const res = await window.daemon.tools.get(toolId)
@@ -55,9 +52,8 @@ export function ToolBrowser() {
     const fileRes = await window.daemon.fs.readFile(filePath)
     if (fileRes.ok && fileRes.data) {
       openFile({ path: filePath, name: tool.entrypoint, content: fileRes.data.content, projectId: activeProjectId })
-      setDrawerTool(null)
     }
-  }, [activeProjectId, openFile, setDrawerTool])
+  }, [activeProjectId, openFile])
 
   const handleOpenFolder = useCallback(async (toolId: string) => {
     await window.daemon.tools.openFolder(toolId)

--- a/src/panels/WalletPanel/PnlHoldings.tsx
+++ b/src/panels/WalletPanel/PnlHoldings.tsx
@@ -14,6 +14,8 @@ interface HoldingInput {
 interface PnlHoldingsProps {
   walletAddress: string
   holdings: HoldingInput[]
+  onSwapHolding?: (mint: string) => void
+  onCopyMint?: (mint: string, symbol: string) => void
 }
 
 function formatUsd(v: number): string {
@@ -34,7 +36,7 @@ function formatPct(v: number): string {
   return v >= 0 ? `+${str}%` : `-${str}%`
 }
 
-export function PnlHoldings({ walletAddress, holdings }: PnlHoldingsProps) {
+export function PnlHoldings({ walletAddress, holdings, onSwapHolding, onCopyMint }: PnlHoldingsProps) {
   const [portfolio, setPortfolio] = useState<PnlPortfolio | null>(null)
   const [syncing, setSyncing] = useState(false)
   const [syncResult, setSyncResult] = useState<string | null>(null)
@@ -119,25 +121,37 @@ export function PnlHoldings({ walletAddress, holdings }: PnlHoldingsProps) {
         </div>
       )}
 
-      <div className="wallet-holdings">
+        <div className="wallet-holdings">
         {pnlHoldings.length > 0 ? pnlHoldings.map((h: PnlHolding) => (
-          <PnlRow key={h.mint} holding={h} />
+          <PnlRow key={h.mint} holding={h} onSwapHolding={onSwapHolding} onCopyMint={onCopyMint} />
         )) : holdings.map((h: HoldingInput) => (
-          <FallbackRow key={h.mint} holding={h} />
+          <FallbackRow key={h.mint} holding={h} onSwapHolding={onSwapHolding} onCopyMint={onCopyMint} />
         ))}
       </div>
     </section>
   )
 }
 
-function PnlRow({ holding }: { holding: PnlHolding }) {
+function PnlRow({ holding, onSwapHolding, onCopyMint }: {
+  holding: PnlHolding
+  onSwapHolding?: (mint: string) => void
+  onCopyMint?: (mint: string, symbol: string) => void
+}) {
   const hasPnl = holding.totalTrades > 0
 
   return (
     <div className="wallet-holding-row">
-      <div>
+      <div className="wallet-holding-main">
         <div className="wallet-label">{holding.symbol}</div>
         <div className="wallet-caption">{holding.amount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</div>
+        <div className="wallet-holding-actions">
+          {onSwapHolding && (
+            <button className="wallet-inline-link" onClick={() => onSwapHolding(holding.mint)}>Sell / Swap</button>
+          )}
+          {onCopyMint && (
+            <button className="wallet-inline-link" onClick={() => onCopyMint(holding.mint, holding.symbol)}>Copy mint</button>
+          )}
+        </div>
       </div>
       <div className="wallet-holding-value">
         <div>${formatUsd(holding.valueUsd)}</div>
@@ -156,12 +170,24 @@ function PnlRow({ holding }: { holding: PnlHolding }) {
   )
 }
 
-function FallbackRow({ holding }: { holding: HoldingInput }) {
+function FallbackRow({ holding, onSwapHolding, onCopyMint }: {
+  holding: HoldingInput
+  onSwapHolding?: (mint: string) => void
+  onCopyMint?: (mint: string, symbol: string) => void
+}) {
   return (
     <div className="wallet-holding-row">
-      <div>
+      <div className="wallet-holding-main">
         <div className="wallet-label">{holding.symbol}</div>
         <div className="wallet-caption">{holding.amount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</div>
+        <div className="wallet-holding-actions">
+          {onSwapHolding && (
+            <button className="wallet-inline-link" onClick={() => onSwapHolding(holding.mint)}>Sell / Swap</button>
+          )}
+          {onCopyMint && (
+            <button className="wallet-inline-link" onClick={() => onCopyMint(holding.mint, holding.symbol)}>Copy mint</button>
+          )}
+        </div>
       </div>
       <div className="wallet-holding-value">
         <div>${formatUsd(holding.valueUsd)}</div>

--- a/src/panels/WalletPanel/WalletPanel.css
+++ b/src/panels/WalletPanel/WalletPanel.css
@@ -14,6 +14,70 @@
   container-name: wallet;
 }
 
+.wallet-workspace-bar {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid var(--s4);
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.008));
+}
+
+.wallet-workspace-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.wallet-workspace-kicker {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+
+.wallet-workspace-title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.08;
+  color: var(--t1);
+}
+
+.wallet-workspace-subtitle {
+  font-size: 12px;
+  color: var(--t3);
+}
+
+.wallet-workspace-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(110px, 1fr));
+  gap: 10px;
+}
+
+.wallet-workspace-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--s5);
+  border-radius: 10px;
+  background: var(--s1);
+}
+
+.wallet-workspace-metric-label {
+  font-size: 9px;
+  color: var(--t4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.wallet-workspace-metric strong {
+  font-size: 16px;
+  color: var(--t1);
+}
+
 /* ── Tabs ── */
 
 .wallet-tabs {
@@ -237,6 +301,53 @@
   margin-top: 4px;
 }
 
+.wallet-portfolio-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.wallet-portfolio-primary {
+  display: flex;
+  flex-direction: column;
+}
+
+.wallet-portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.wallet-portfolio-card {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 12px;
+  border: 1px solid var(--s4);
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.012));
+}
+
+.wallet-portfolio-label {
+  font-size: 9px;
+  color: var(--t4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.wallet-portfolio-value {
+  font-size: 15px;
+  line-height: 1.2;
+  color: var(--t1);
+}
+
+.wallet-portfolio-meta {
+  font-size: 11px;
+  color: var(--t3);
+  line-height: 1.35;
+}
+
 /* ── Quick Actions (Send / Swap / Receive / Vault) ── */
 
 .wallet-quick-actions {
@@ -442,6 +553,34 @@
   display: flex;
   flex-direction: column;
   gap: 0;
+}
+
+.wallet-holding-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.wallet-holding-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.wallet-inline-link {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--green);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-ui);
+}
+
+.wallet-inline-link:hover {
+  color: var(--green-dim);
 }
 
 .wallet-row {
@@ -712,7 +851,56 @@
   opacity: 0.92;
 }
 
+.wallet-overview-grid,
+.wallet-move-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.wallet-overview-card,
+.wallet-move-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--s4);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.012));
+}
+
+.wallet-overview-card strong,
+.wallet-move-card strong {
+  font-size: 18px;
+  line-height: 1.2;
+  color: var(--t1);
+}
+
+.wallet-overview-card p,
+.wallet-move-card p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--t3);
+}
+
+.wallet-overview-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+
 @container wallet (max-width: 760px) {
+  .wallet-portfolio-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .wallet-portfolio-grid {
+    grid-template-columns: 1fr;
+  }
+
   .wallet-settings-layout {
     grid-template-columns: 1fr;
   }
@@ -736,6 +924,15 @@
   .wallet-actions-card-main,
   .wallet-actions-card-utility {
     width: 100%;
+  }
+
+  .wallet-overview-grid,
+  .wallet-move-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .wallet-quick-actions {
+    flex-wrap: wrap;
   }
 }
 
@@ -1415,6 +1612,20 @@
   font-size: 14px;
   font-weight: 600;
   color: var(--t1);
+}
+
+@container wallet (max-width: 760px) {
+  .wallet-workspace-bar {
+    flex-direction: column;
+  }
+
+  .wallet-workspace-title {
+    font-size: 18px;
+  }
+
+  .wallet-workspace-metrics {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ── Wallet tab group (settings import/generate toggle) ── */

--- a/src/panels/WalletPanel/WalletPanel.tsx
+++ b/src/panels/WalletPanel/WalletPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react'
 import { useUIStore } from '../../store/ui'
 import { useWalletStore } from '../../store/wallet'
+import { useWorkflowShellStore } from '../../store/workflowShell'
 import { WalletTab } from './tabs/WalletTab'
 import { AgentsTab } from './tabs/AgentsTab'
 import './WalletPanel.css'
@@ -11,8 +12,8 @@ export function WalletPanel() {
   const loading = useWalletStore((s) => s.loading)
   const activeTab = useWalletStore((s) => s.activeTab)
   const setActiveTab = useWalletStore((s) => s.setActiveTab)
-  const drawerFullscreen = useUIStore((s) => s.drawerFullscreen)
-  const toggleDrawerFullscreen = useUIStore((s) => s.toggleDrawerFullscreen)
+  const drawerFullscreen = useWorkflowShellStore((s) => s.drawerFullscreen)
+  const toggleDrawerFullscreen = useWorkflowShellStore((s) => s.toggleDrawerFullscreen)
 
   const load = useCallback(async () => {
     await useWalletStore.getState().refresh(activeProjectId)

--- a/src/panels/WalletPanel/WalletPanel.tsx
+++ b/src/panels/WalletPanel/WalletPanel.tsx
@@ -8,6 +8,7 @@ import './WalletPanel.css'
 
 export function WalletPanel() {
   const activeProjectId = useUIStore((s) => s.activeProjectId)
+  const projects = useUIStore((s) => s.projects)
   const dashboard = useWalletStore((s) => s.dashboard)
   const loading = useWalletStore((s) => s.loading)
   const activeTab = useWalletStore((s) => s.activeTab)
@@ -18,6 +19,11 @@ export function WalletPanel() {
   const load = useCallback(async () => {
     await useWalletStore.getState().refresh(activeProjectId)
   }, [activeProjectId])
+
+  const activeProject = projects.find((project) => project.id === activeProjectId) ?? null
+  const activeWalletName = dashboard?.activeWallet?.name ?? 'No active wallet'
+  const walletCount = dashboard?.portfolio.walletCount ?? 0
+  const transportLabel = dashboard?.heliusConfigured ? 'Helius connected' : 'Local mode'
 
   useEffect(() => { void load() }, [load])
   useEffect(() => useWalletStore.getState().subscribeFastPoll(), [])
@@ -65,6 +71,30 @@ export function WalletPanel() {
 
   return (
     <div className="wallet-panel">
+      <div className="wallet-workspace-bar">
+        <div className="wallet-workspace-copy">
+          <span className="wallet-workspace-kicker">Wallet workspace</span>
+          <h2 className="wallet-workspace-title">Move funds, inspect holdings, and act from one place</h2>
+          <span className="wallet-workspace-subtitle">
+            {activeProject ? activeProject.name : 'No active project'} · {activeWalletName}
+          </span>
+        </div>
+        <div className="wallet-workspace-metrics">
+          <div className="wallet-workspace-metric">
+            <span className="wallet-workspace-metric-label">Tracked</span>
+            <strong>{walletCount}</strong>
+          </div>
+          <div className="wallet-workspace-metric">
+            <span className="wallet-workspace-metric-label">Transport</span>
+            <strong>{transportLabel}</strong>
+          </div>
+          <div className="wallet-workspace-metric">
+            <span className="wallet-workspace-metric-label">Tab</span>
+            <strong>{activeTab === 'wallet' ? 'Wallet' : 'Agents'}</strong>
+          </div>
+        </div>
+      </div>
+
       {/* Tab bar */}
       <div className="wallet-tabs">
         <button

--- a/src/panels/WalletPanel/WalletReceiveView.tsx
+++ b/src/panels/WalletPanel/WalletReceiveView.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNotificationsStore } from '../../store/notifications'
 import './WalletPanel.css'
 
 interface WalletReceiveViewProps {
@@ -9,23 +10,18 @@ interface WalletReceiveViewProps {
 
 export function WalletReceiveView({ address, walletName, onBack }: WalletReceiveViewProps) {
   const [copied, setCopied] = useState(false)
+  const pushSuccess = useNotificationsStore((s) => s.pushSuccess)
+  const pushError = useNotificationsStore((s) => s.pushError)
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(address)
+    const res = await window.daemon.env.copyValue(address)
+    if (res.ok) {
       setCopied(true)
+      pushSuccess(`${walletName} address copied`, 'Wallet')
       setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Fallback for clipboard failures
-      const textarea = document.createElement('textarea')
-      textarea.value = address
-      document.body.appendChild(textarea)
-      textarea.select()
-      document.execCommand('copy')
-      document.body.removeChild(textarea)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      return
     }
+    pushError(res.error ?? 'Failed to copy wallet address', 'Wallet')
   }
 
   return (

--- a/src/panels/WalletPanel/WalletSettings.tsx
+++ b/src/panels/WalletPanel/WalletSettings.tsx
@@ -8,18 +8,7 @@ interface WalletSettingsProps {
   heliusConfigured: boolean
   jupiterConfigured: boolean
   infrastructure: WalletInfrastructureSettings
-  wallets: Array<{
-    id: string
-    name: string
-    address: string
-    isDefault: boolean
-    totalUsd: number
-    tokenCount: number
-  }>
-  keypairCache: Record<string, boolean>
-  activeProjectId: string | null
   error: string | null
-  genSuccess: string | null
   onToggleTape: (checked: boolean) => Promise<void>
   onToggleTitlebarWallet: (checked: boolean) => Promise<void>
   onSaveHelius: (key: string) => Promise<void>
@@ -27,15 +16,6 @@ interface WalletSettingsProps {
   onSaveJupiter: (key: string) => Promise<void>
   onDeleteJupiter: () => Promise<void>
   onSaveInfrastructure: (settings: WalletInfrastructureSettings) => Promise<void>
-  onAddWallet: (name: string, address: string) => Promise<void>
-  onGenerateWallet: (name: string) => Promise<void>
-  onClearGenSuccess: () => void
-  onSetDefault: (walletId: string) => Promise<void>
-  onAssignProject: (walletId: string) => Promise<void>
-  onDeleteWallet: (walletId: string) => Promise<void>
-  onOpenSend: (walletId: string, mode: 'sol' | 'token') => void
-  onExportKeyStart: (walletId: string) => void
-  renderWalletInline: (walletId: string) => React.ReactNode
 }
 
 export function WalletSettings({
@@ -44,11 +24,7 @@ export function WalletSettings({
   heliusConfigured,
   jupiterConfigured,
   infrastructure,
-  wallets,
-  keypairCache,
-  activeProjectId,
   error,
-  genSuccess,
   onToggleTape,
   onToggleTitlebarWallet,
   onSaveHelius,
@@ -56,22 +32,9 @@ export function WalletSettings({
   onSaveJupiter,
   onDeleteJupiter,
   onSaveInfrastructure,
-  onAddWallet,
-  onGenerateWallet,
-  onClearGenSuccess,
-  onSetDefault,
-  onAssignProject,
-  onDeleteWallet,
-  onOpenSend,
-  onExportKeyStart,
-  renderWalletInline,
 }: WalletSettingsProps) {
   const [heliusKey, setHeliusKey] = useState('')
   const [jupiterKey, setJupiterKey] = useState('')
-  const [createTab, setCreateTab] = useState<'import' | 'generate'>('import')
-  const [walletName, setWalletName] = useState('')
-  const [walletAddress, setWalletAddress] = useState('')
-  const [genName, setGenName] = useState('')
   const [draftInfra, setDraftInfra] = useState<WalletInfrastructureSettings>(infrastructure)
 
   useEffect(() => {
@@ -90,25 +53,12 @@ export function WalletSettings({
     setJupiterKey('')
   }
 
-  const handleAddWallet = async () => {
-    if (!walletName.trim() || !walletAddress.trim()) return
-    await onAddWallet(walletName.trim(), walletAddress.trim())
-    setWalletName('')
-    setWalletAddress('')
-  }
-
-  const handleGenerate = async () => {
-    if (!genName.trim()) return
-    await onGenerateWallet(genName.trim())
-    setGenName('')
-  }
-
   return (
     <section className="wallet-section wallet-settings-shell">
       <div className="wallet-section-header">
         <div>
-          <div className="wallet-section-title">Settings</div>
-          <div className="wallet-caption">Manage portfolio display, RPC access, and wallet operations from one place.</div>
+          <div className="wallet-section-title">Infrastructure</div>
+          <div className="wallet-caption">Keep wallet visibility, RPC routing, and execution services configured for the whole workspace.</div>
         </div>
       </div>
       {error && <div className="wallet-empty">{error}</div>}
@@ -118,7 +68,7 @@ export function WalletSettings({
           <div className="wallet-settings-card-head">
             <div>
               <div className="wallet-label">Display</div>
-              <div className="wallet-caption">Choose which portfolio signals stay visible across the shell.</div>
+              <div className="wallet-caption">Choose which wallet signals stay visible around the shell.</div>
             </div>
           </div>
 
@@ -142,9 +92,7 @@ export function WalletSettings({
           <div className="wallet-settings-card-head">
             <div>
               <div className="wallet-label">RPC Provider</div>
-              <div className="wallet-caption">
-                Choose how DAEMON resolves Solana RPC for wallet reads and transaction submission.
-              </div>
+              <div className="wallet-caption">Choose how DAEMON resolves Solana reads and transaction submission.</div>
             </div>
             <span className={`wallet-state-badge ${draftInfra.rpcProvider === 'helius' && heliusConfigured ? 'live' : 'muted'}`}>
               {draftInfra.rpcProvider.toUpperCase()}
@@ -213,9 +161,7 @@ export function WalletSettings({
           <div className="wallet-settings-card-head">
             <div>
               <div className="wallet-label">Swap Execution</div>
-              <div className="wallet-caption">
-                Configure the swap engine and wallet path used by DAEMON's trading flows.
-              </div>
+              <div className="wallet-caption">Configure the wallet path and submission route DAEMON uses for swaps and sends.</div>
             </div>
             <span className={`wallet-state-badge ${jupiterConfigured ? 'live' : 'muted'}`}>
               {jupiterConfigured ? 'Ready' : 'Key Missing'}
@@ -267,101 +213,7 @@ export function WalletSettings({
             )}
           </div>
         </div>
-
-        <div className="wallet-settings-card wallet-settings-card--full">
-          <div className="wallet-settings-card-head">
-            <div>
-              <div className="wallet-label">Create Wallet</div>
-              <div className="wallet-caption">Import an address for tracking or generate a fresh signing wallet inside DAEMON.</div>
-            </div>
-          </div>
-
-          <div className="wallet-tab-group wallet-create-tabs">
-            <button className={`wallet-tab ${createTab === 'import' ? 'active' : ''}`} onClick={() => { setCreateTab('import'); onClearGenSuccess() }}>Import</button>
-            <button className={`wallet-tab ${createTab === 'generate' ? 'active' : ''}`} onClick={() => { setCreateTab('generate'); onClearGenSuccess() }}>Generate</button>
-          </div>
-
-          {createTab === 'import' && (
-            <div className="wallet-form wallet-create-grid">
-              <input className="wallet-input" value={walletName} onChange={(e) => setWalletName(e.target.value)} placeholder="Wallet name" />
-              <input className="wallet-input" value={walletAddress} onChange={(e) => setWalletAddress(e.target.value)} placeholder="Solana address" />
-              <button className="wallet-btn primary wallet-btn-wide" onClick={handleAddWallet}>Add Wallet</button>
-            </div>
-          )}
-
-          {createTab === 'generate' && (
-            <div className="wallet-form wallet-create-grid">
-              <input className="wallet-input" value={genName} onChange={(e) => setGenName(e.target.value)} placeholder="Wallet name" />
-              <button className="wallet-btn primary wallet-btn-wide" onClick={handleGenerate}>Generate Wallet</button>
-              {genSuccess && (
-                <div className="wallet-success-msg">Generated: {shortAddress(genSuccess)}</div>
-              )}
-            </div>
-          )}
-        </div>
-
-        <div className="wallet-settings-card wallet-settings-card--full">
-          <div className="wallet-settings-card-head">
-            <div>
-              <div className="wallet-label">Manage Wallets</div>
-              <div className="wallet-caption">Choose defaults, link wallets to the active project, and manage signing operations.</div>
-            </div>
-          </div>
-
-          <div className="wallet-list wallet-list-cards">
-          {wallets.map((wallet) => (
-            <div key={wallet.id} className="wallet-row wallet-row-card">
-              <div className="wallet-row-main wallet-row-main-top">
-                <div className="wallet-row-identity">
-                  <div className="wallet-name">
-                    {wallet.name}
-                  </div>
-                  <div className="wallet-row-sub wallet-row-subtle wallet-row-chipline">
-                    {wallet.isDefault && <span className="wallet-badge">default</span>}
-                    <span className={`wallet-pill ${keypairCache[wallet.id] ? 'live' : 'muted'}`}>
-                      {keypairCache[wallet.id] ? 'Signer' : 'Watch-only'}
-                    </span>
-                    <span className="wallet-pill">{shortAddress(wallet.address)}</span>
-                    <span className="wallet-pill">{wallet.tokenCount} assets</span>
-                  </div>
-                </div>
-                <div className="wallet-value wallet-value-strong">${formatUsd(wallet.totalUsd)}</div>
-              </div>
-
-              <div className="wallet-actions-card">
-                <div className="wallet-actions wallet-actions-wrap wallet-actions-card-main">
-                  {!wallet.isDefault && (
-                    <button className="wallet-btn" onClick={() => onSetDefault(wallet.id)}>Set Default</button>
-                  )}
-                  {activeProjectId && (
-                    <button className="wallet-btn primary-soft" onClick={() => onAssignProject(wallet.id)}>Use For Project</button>
-                  )}
-                  {keypairCache[wallet.id] && (
-                    <button className="wallet-btn primary" onClick={() => onOpenSend(wallet.id, 'sol')}>Send Funds</button>
-                  )}
-                </div>
-                <div className="wallet-actions wallet-actions-wrap wallet-actions-card-utility">
-                  {keypairCache[wallet.id] && (
-                    <button className="wallet-btn subtle" onClick={() => onExportKeyStart(wallet.id)}>Export Key</button>
-                  )}
-                  <button className="wallet-btn danger" onClick={() => onDeleteWallet(wallet.id)}>Remove</button>
-                </div>
-              </div>
-              {renderWalletInline(wallet.id)}
-            </div>
-          ))}
-          {wallets.length === 0 && <div className="wallet-empty">No wallets configured</div>}
-          </div>
-        </div>
       </div>
     </section>
   )
-}
-
-function formatUsd(value: number): string {
-  return value.toLocaleString(undefined, { minimumFractionDigits: value >= 1000 ? 0 : 2, maximumFractionDigits: 2 })
-}
-
-function shortAddress(value: string): string {
-  return `${value.slice(0, 4)}...${value.slice(-4)}`
 }

--- a/src/panels/WalletPanel/WalletSwapForm.tsx
+++ b/src/panels/WalletPanel/WalletSwapForm.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import './WalletPanel.css'
 
 const SOL_MINT = 'So11111111111111111111111111111111111111112'
@@ -27,6 +27,8 @@ interface WalletSwapFormProps {
   walletName: string
   holdings: Array<{ mint: string; symbol: string; amount: number; decimals?: number }>
   executionMode: WalletInfrastructureSettings['executionMode']
+  initialInputMint?: string
+  initialOutputMint?: string
   onBack: () => void
   onRefresh: () => Promise<void>
 }
@@ -45,9 +47,9 @@ interface PendingSwap {
   confirmedAt: number
 }
 
-export function WalletSwapForm({ walletId, walletName, holdings, executionMode, onBack, onRefresh }: WalletSwapFormProps) {
-  const [inputMint, setInputMint] = useState(SOL_MINT)
-  const [outputMint, setOutputMint] = useState(USDC_MINT)
+export function WalletSwapForm({ walletId, walletName, holdings, executionMode, initialInputMint, initialOutputMint, onBack, onRefresh }: WalletSwapFormProps) {
+  const [inputMint, setInputMint] = useState(initialInputMint ?? SOL_MINT)
+  const [outputMint, setOutputMint] = useState(initialOutputMint ?? USDC_MINT)
   const [amount, setAmount] = useState('')
   const [slippageBps, setSlippageBps] = useState('50')
 
@@ -71,6 +73,11 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
 
   const inputToken = allTokens.find((t) => t.mint === inputMint)
   const outputToken = allTokens.find((t) => t.mint === outputMint)
+
+  useEffect(() => {
+    if (initialInputMint) setInputMint(initialInputMint)
+    if (initialOutputMint) setOutputMint(initialOutputMint)
+  }, [initialInputMint, initialOutputMint])
 
   const handleGetQuote = async () => {
     setQuoteError(null)

--- a/src/panels/WalletPanel/tabs/WalletTab.tsx
+++ b/src/panels/WalletPanel/tabs/WalletTab.tsx
@@ -1,18 +1,21 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useUIStore } from '../../../store/ui'
 import { useWalletStore } from '../../../store/wallet'
+import { useNotificationsStore } from '../../../store/notifications'
 import { WalletSettings } from '../WalletSettings'
-import { WalletSendForm } from '../WalletSendForm'
 import { WalletExportKey } from '../WalletExportKey'
 import { TransactionHistory } from '../TransactionHistory'
 import { WalletReceiveView } from '../WalletReceiveView'
 import { WalletSwapForm } from '../WalletSwapForm'
 import { VaultSection } from '../VaultSection'
 import { PnlHoldings } from '../PnlHoldings'
+import { WalletSendForm } from '../WalletSendForm'
 
 interface Props {
   onRefresh: () => Promise<void>
 }
+
+type ManageCreateTab = 'import' | 'generate'
 
 export function WalletTab({ onRefresh }: Props) {
   const activeProjectId = useUIStore((s) => s.activeProjectId)
@@ -24,8 +27,10 @@ export function WalletTab({ onRefresh }: Props) {
   const setStoreShowTitlebarWallet = useWalletStore((s) => s.setShowTitlebarWallet)
   const activeView = useWalletStore((s) => s.activeView)
   const setActiveView = useWalletStore((s) => s.setActiveView)
+  const pushSuccess = useNotificationsStore((s) => s.pushSuccess)
+  const pushError = useNotificationsStore((s) => s.pushError)
 
-  const [showSettings, setShowSettings] = useState(false)
+  const [showInfrastructure, setShowInfrastructure] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [genSuccess, setGenSuccess] = useState<string | null>(null)
   const [jupiterConfigured, setJupiterConfigured] = useState(false)
@@ -38,6 +43,11 @@ export function WalletTab({ onRefresh }: Props) {
     executionMode: 'rpc',
     jitoBlockEngineUrl: 'https://mainnet.block-engine.jito.wtf/api/v1/transactions',
   })
+
+  const [createTab, setCreateTab] = useState<ManageCreateTab>('import')
+  const [walletName, setWalletName] = useState('')
+  const [walletAddress, setWalletAddress] = useState('')
+  const [genName, setGenName] = useState('')
 
   const [sendWalletId, setSendWalletId] = useState<string | null>(null)
   const [sendMode, setSendMode] = useState<'sol' | 'token' | null>(null)
@@ -56,20 +66,52 @@ export function WalletTab({ onRefresh }: Props) {
   const [revealedKey, setRevealedKey] = useState<string | null>(null)
   const [exportConfirmId, setExportConfirmId] = useState<string | null>(null)
   const [exportConfirmText, setExportConfirmText] = useState('')
+  const [preferredSwapMint, setPreferredSwapMint] = useState<string | null>(null)
   const sendLockRef = useRef(false)
   const [pendingSend, setPendingSend] = useState<{
     walletId: string; mode: 'sol' | 'token'; dest: string; amount?: number; sendMax?: boolean; mint?: string
   } | null>(null)
 
+  const activeWallet = dashboard.activeWallet
+  const activeWalletMeta = dashboard.wallets.find((w) => w.id === activeWallet?.id)
+  const hasKeypair = activeWalletMeta ? keypairCache[activeWalletMeta.id] === true : false
+  const trackedWallets = dashboard.wallets
+  const holdingsPreview = activeWallet?.holdings.slice(0, 4) ?? []
+  const executionLabel = walletInfrastructure.executionMode === 'jito' ? 'Jito path' : 'Standard RPC'
+
   useEffect(() => {
-    if (activeView === 'send' && dashboard.activeWallet && !sendWalletId) {
-      setSendWalletId(dashboard.activeWallet.id)
-      setSendMode('sol')
-      setSendDest(''); setSendAmount(''); setSendMint('')
-      setSendMax(false); setSelectedRecipientWalletId('')
-      setSendResult(null); setSendError(null)
+    void Promise.all([
+      window.daemon.wallet.hasJupiterKey(),
+      window.daemon.settings.getWalletInfrastructureSettings(),
+    ]).then(([jupiterRes, infraRes]) => {
+      if (jupiterRes.ok) setJupiterConfigured(jupiterRes.data === true)
+      if (infraRes.ok && infraRes.data) setWalletInfrastructure(infraRes.data)
+    }).catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (!dashboard.wallets) return
+    const check = async () => {
+      const cache: Record<string, boolean> = {}
+      for (const w of dashboard.wallets) {
+        try {
+          const res = await window.daemon.wallet.hasKeypair(w.id)
+          cache[w.id] = res.ok && res.data === true
+        } catch {
+          cache[w.id] = false
+        }
+      }
+      setKeypairCache(cache)
     }
-  }, [activeView, dashboard.activeWallet, sendWalletId])
+    void check()
+  }, [dashboard.wallets])
+
+  useEffect(() => {
+    if ((activeView === 'move' || activeView === 'overview') && activeWallet && !sendWalletId) {
+      setSendWalletId(activeWallet.id)
+      setSendMode('sol')
+    }
+  }, [activeView, activeWallet, sendWalletId])
 
   useEffect(() => {
     if (!sendWalletId) return
@@ -84,7 +126,6 @@ export function WalletTab({ onRefresh }: Props) {
 
   useEffect(() => {
     if (!sendWalletId || sendMode !== 'token') return
-
     const existing = walletTokenOptions[sendWalletId]
     if (existing) {
       if (!sendMint) {
@@ -97,7 +138,8 @@ export function WalletTab({ onRefresh }: Props) {
     let cancelled = false
     void window.daemon.wallet.holdings(sendWalletId).then((res) => {
       if (!res.ok || !res.data || cancelled) return
-      const holdings = res.data.filter((holding) => holding.amount > 0 && holding.symbol !== 'SOL')
+      const holdings = res.data
+        .filter((holding) => holding.amount > 0 && holding.symbol !== 'SOL')
         .map((holding) => ({ mint: holding.mint, symbol: holding.symbol, amount: holding.amount }))
       setWalletTokenOptions((prev) => ({ ...prev, [sendWalletId]: holdings }))
       if (!sendMint) {
@@ -110,55 +152,97 @@ export function WalletTab({ onRefresh }: Props) {
   }, [sendWalletId, sendMode, sendMint, walletTokenOptions])
 
   useEffect(() => {
-    if (!dashboard.wallets) return
-    const check = async () => {
-      const cache: Record<string, boolean> = {}
-      for (const w of dashboard.wallets) {
-        try {
-          const res = await window.daemon.wallet.hasKeypair(w.id)
-          cache[w.id] = res.ok && res.data === true
-        } catch { cache[w.id] = false }
-      }
-      setKeypairCache(cache)
-    }
-    void check()
-  }, [dashboard.wallets])
+    if (sendMode !== 'token') return
+    if (sendMint) return
+    const tokenOptions = sendWalletId && walletTokenOptions[sendWalletId]
+      ? walletTokenOptions[sendWalletId]
+      : sendWalletId === dashboard.activeWallet?.id
+        ? dashboard.activeWallet.holdings
+          .filter((holding) => holding.amount > 0 && holding.symbol !== 'SOL')
+          .map((holding) => ({ mint: holding.mint, symbol: holding.symbol, amount: holding.amount }))
+        : []
+    const firstToken = tokenOptions.find((holding) => holding.amount > 0)
+    if (firstToken) setSendMint(firstToken.mint)
+  }, [sendMode, sendMint, sendWalletId, dashboard.activeWallet, walletTokenOptions])
 
-  useEffect(() => {
-    void Promise.all([
-      window.daemon.wallet.hasJupiterKey(),
-      window.daemon.settings.getWalletInfrastructureSettings(),
-    ]).then(([jupiterRes, infraRes]) => {
-      if (jupiterRes.ok) setJupiterConfigured(jupiterRes.data === true)
-      if (infraRes.ok && infraRes.data) setWalletInfrastructure(infraRes.data)
-    }).catch(() => {})
-  }, [])
+  const walletActionCards = useMemo(() => {
+    if (!activeWallet) return []
+    return [
+      { label: 'Active wallet', value: activeWallet.name, meta: truncateAddress(activeWallet.address) },
+      { label: 'Execution', value: executionLabel, meta: dashboard.heliusConfigured ? 'Helius connected' : 'Local mode' },
+      { label: 'Can sign', value: hasKeypair ? 'Ready' : 'Watch-only', meta: hasKeypair ? 'Send, swap, export, receive' : 'Import or generate a signer to act' },
+    ]
+  }, [activeWallet, dashboard.heliusConfigured, executionLabel, hasKeypair])
+
+  const resetSendState = () => {
+    setSendDest('')
+    setSendAmount('')
+    setSendMint('')
+    setSendMax(false)
+    setSelectedRecipientWalletId('')
+  }
+
+  const openSend = (walletId: string, mode: 'sol' | 'token') => {
+    setSendWalletId(walletId)
+    setSendMode(mode)
+    resetSendState()
+    setSendResult(null)
+    setSendError(null)
+    setActiveView('move')
+  }
+
+  const closeSend = () => {
+    setSendWalletId(activeWallet?.id ?? null)
+    setSendMode('sol')
+    resetSendState()
+  }
 
   const handleAddWallet = async (name: string, address: string) => {
     setError(null)
     const res = await window.daemon.wallet.create({ name, address })
-    if (res.ok) { await onRefresh(); return }
+    if (res.ok) {
+      pushSuccess('Wallet added', 'Wallet')
+      setWalletName('')
+      setWalletAddress('')
+      await onRefresh()
+      return
+    }
     setError(res.error ?? 'Failed to add wallet')
   }
 
   const handleGenerate = async (name: string) => {
-    setError(null); setGenSuccess(null)
+    setError(null)
+    setGenSuccess(null)
     const res = await window.daemon.wallet.generate({ name })
-    if (res.ok && res.data) { setGenSuccess(res.data.address); await onRefresh(); return }
+    if (res.ok && res.data) {
+      setGenSuccess(res.data.address)
+      setGenName('')
+      pushSuccess('Signing wallet generated', 'Wallet')
+      await onRefresh()
+      return
+    }
     setError(res.error ?? 'Failed to generate wallet')
   }
 
   const handleSaveHelius = async (key: string) => {
     setError(null)
     const res = await window.daemon.wallet.storeHeliusKey(key)
-    if (res.ok) { await onRefresh(); return }
+    if (res.ok) {
+      await onRefresh()
+      pushSuccess('Helius key saved', 'Wallet')
+      return
+    }
     setError(res.error ?? 'Failed to save Helius key')
   }
 
   const handleDeleteHelius = async () => {
     setError(null)
     const res = await window.daemon.wallet.deleteHeliusKey()
-    if (res.ok) { await onRefresh(); return }
+    if (res.ok) {
+      await onRefresh()
+      pushSuccess('Helius key removed', 'Wallet')
+      return
+    }
     setError(res.error ?? 'Failed to delete Helius key')
   }
 
@@ -167,6 +251,7 @@ export function WalletTab({ onRefresh }: Props) {
     const res = await window.daemon.wallet.storeJupiterKey(key)
     if (res.ok) {
       setJupiterConfigured(true)
+      pushSuccess('Jupiter key saved', 'Wallet')
       return
     }
     setError(res.error ?? 'Failed to save Jupiter key')
@@ -177,6 +262,7 @@ export function WalletTab({ onRefresh }: Props) {
     const res = await window.daemon.wallet.deleteJupiterKey()
     if (res.ok) {
       setJupiterConfigured(false)
+      pushSuccess('Jupiter key removed', 'Wallet')
       return
     }
     setError(res.error ?? 'Failed to delete Jupiter key')
@@ -188,6 +274,7 @@ export function WalletTab({ onRefresh }: Props) {
     if (res.ok) {
       setWalletInfrastructure(settings)
       await onRefresh()
+      pushSuccess('Wallet infrastructure updated', 'Wallet')
       return
     }
     setError(res.error ?? 'Failed to save wallet infrastructure settings')
@@ -196,33 +283,52 @@ export function WalletTab({ onRefresh }: Props) {
   const handleSetDefault = async (walletId: string) => {
     setError(null)
     const res = await window.daemon.wallet.setDefault(walletId)
-    if (res.ok) await onRefresh()
-    else setError(res.error ?? 'Failed to set default wallet')
+    if (res.ok) {
+      pushSuccess('Default wallet updated', 'Wallet')
+      await onRefresh()
+    } else {
+      setError(res.error ?? 'Failed to set default wallet')
+    }
   }
 
   const handleAssignProject = async (walletId: string) => {
     if (!activeProjectId) return
     setError(null)
     const res = await window.daemon.wallet.assignProject(activeProjectId, walletId)
-    if (res.ok) await onRefresh()
-    else setError(res.error ?? 'Failed to assign wallet to project')
+    if (res.ok) {
+      pushSuccess('Project wallet updated', 'Wallet')
+      await onRefresh()
+    } else {
+      setError(res.error ?? 'Failed to assign wallet to project')
+    }
   }
 
   const handleDeleteWallet = async (walletId: string) => {
     setError(null)
     const res = await window.daemon.wallet.delete(walletId)
-    if (res.ok) await onRefresh()
-    else setError(res.error ?? 'Failed to remove wallet')
+    if (res.ok) {
+      pushSuccess('Wallet removed', 'Wallet')
+      await onRefresh()
+    } else {
+      setError(res.error ?? 'Failed to remove wallet')
+    }
   }
 
   const handleConfirmSend = (fromWalletId: string) => {
-    setSendError(null); setSendResult(null)
+    setSendError(null)
+    setSendResult(null)
     const amount = parseFloat(sendAmount)
     if (sendMode === 'sol') {
-      if (!sendDest.trim() || (!sendMax && (isNaN(amount) || amount <= 0))) { setSendError('Invalid destination or amount'); return }
+      if (!sendDest.trim() || (!sendMax && (isNaN(amount) || amount <= 0))) {
+        setSendError('Invalid destination or amount')
+        return
+      }
       setPendingSend({ walletId: fromWalletId, mode: 'sol', dest: sendDest.trim(), amount: sendMax ? undefined : amount, sendMax })
     } else {
-      if (!sendDest.trim() || !sendMint.trim() || (!sendMax && (isNaN(amount) || amount <= 0))) { setSendError('Invalid destination, mint, or amount'); return }
+      if (!sendDest.trim() || !sendMint.trim() || (!sendMax && (isNaN(amount) || amount <= 0))) {
+        setSendError('Invalid destination, mint, or amount')
+        return
+      }
       setPendingSend({ walletId: fromWalletId, mode: 'token', dest: sendDest.trim(), amount: sendMax ? undefined : amount, sendMax, mint: sendMint.trim() })
     }
   }
@@ -230,53 +336,63 @@ export function WalletTab({ onRefresh }: Props) {
   const handleExecuteSend = async () => {
     if (!pendingSend || sendLockRef.current) return
     sendLockRef.current = true
-    setSendLoading(true); setSendError(null)
+    setSendLoading(true)
+    setSendError(null)
     try {
       if (pendingSend.mode === 'sol') {
         const res = await window.daemon.wallet.sendSol({ fromWalletId: pendingSend.walletId, toAddress: pendingSend.dest, amountSol: pendingSend.amount, sendMax: pendingSend.sendMax })
         setPendingSend(null)
-        if (res.ok && res.data) { setSendResult(res.data); setSendDest(''); setSendAmount(''); setSendMax(false); setSelectedRecipientWalletId(''); await onRefresh() }
-        else setSendError(res.error ?? 'Send failed')
+        if (res.ok && res.data) {
+          setSendResult(res.data)
+          resetSendState()
+          await onRefresh()
+        } else {
+          setSendError(res.error ?? 'Send failed')
+        }
       } else {
         const res = await window.daemon.wallet.sendToken({ fromWalletId: pendingSend.walletId, toAddress: pendingSend.dest, mint: pendingSend.mint!, amount: pendingSend.amount, sendMax: pendingSend.sendMax })
         setPendingSend(null)
-        if (res.ok && res.data) { setSendResult(res.data); setSendDest(''); setSendAmount(''); setSendMint(''); setSendMax(false); setSelectedRecipientWalletId(''); await onRefresh() }
-        else setSendError(res.error ?? 'Send failed')
+        if (res.ok && res.data) {
+          setSendResult(res.data)
+          resetSendState()
+          await onRefresh()
+        } else {
+          setSendError(res.error ?? 'Send failed')
+        }
       }
-    } finally { setSendLoading(false); sendLockRef.current = false }
+    } finally {
+      setSendLoading(false)
+      sendLockRef.current = false
+    }
   }
 
   const handleCancelSend = () => setPendingSend(null)
 
   const handleExportKeyStart = (walletId: string) => {
-    setExportConfirmId(walletId); setExportConfirmText('')
-    setRevealKeyId(null); setRevealedKey(null)
+    setExportConfirmId(walletId)
+    setExportConfirmText('')
+    setRevealKeyId(null)
+    setRevealedKey(null)
   }
 
   const handleExportKeyConfirm = async () => {
     if (!exportConfirmId || exportConfirmText !== 'EXPORT') return
     const res = await window.daemon.wallet.exportPrivateKey(exportConfirmId)
     if (res.ok && res.data) {
-      setRevealKeyId(exportConfirmId); setRevealedKey(res.data)
-      setExportConfirmId(null); setExportConfirmText('')
-      setTimeout(() => { setRevealKeyId(null); setRevealedKey(null) }, 5_000)
+      setRevealKeyId(exportConfirmId)
+      setRevealedKey(res.data)
+      setExportConfirmId(null)
+      setExportConfirmText('')
+      pushSuccess('Private key copied to clipboard for 30 seconds', 'Wallet')
+      setTimeout(() => {
+        setRevealKeyId(null)
+        setRevealedKey(null)
+      }, 5_000)
     } else {
       setError(res.error ?? 'Failed to export key')
-      setExportConfirmId(null); setExportConfirmText('')
+      setExportConfirmId(null)
+      setExportConfirmText('')
     }
-  }
-
-  const openSend = (walletId: string, mode: 'sol' | 'token') => {
-    setSendWalletId(walletId); setSendMode(mode)
-    setSendDest(''); setSendAmount(''); setSendMint('')
-    setSendMax(false); setSelectedRecipientWalletId('')
-    setSendResult(null); setSendError(null)
-  }
-
-  const closeSend = () => {
-    setSendWalletId(null); setSendMode(null)
-    setSendMax(false); setSelectedRecipientWalletId('')
-    if (activeView === 'send') setActiveView('overview')
   }
 
   const handleRecipientWalletChange = (walletId: string) => {
@@ -293,64 +409,35 @@ export function WalletTab({ onRefresh }: Props) {
     })
   }
 
+  const handleCopyWalletAddress = async (address: string, name: string) => {
+    const res = await window.daemon.env.copyValue(address)
+    if (res.ok) pushSuccess(`${name} address copied`, 'Wallet')
+    else pushError(res.error ?? 'Failed to copy wallet address', 'Wallet')
+  }
+
+  const handleCopyMint = async (mint: string, symbol: string) => {
+    const res = await window.daemon.env.copyValue(mint)
+    if (res.ok) pushSuccess(`${symbol} mint copied`, 'Wallet')
+    else pushError(res.error ?? 'Failed to copy mint', 'Wallet')
+  }
+
+  const handleSwapHolding = (mint: string) => {
+    setPreferredSwapMint(mint)
+    setActiveView('swap')
+  }
+
   const renderWalletInline = (walletId: string) => (
-    <>
-      <WalletExportKey
-        walletId={walletId}
-        exportConfirmId={exportConfirmId}
-        exportConfirmText={exportConfirmText}
-        revealKeyId={revealKeyId}
-        revealedKey={revealedKey}
-        onConfirmTextChange={setExportConfirmText}
-        onConfirm={handleExportKeyConfirm}
-        onCancel={() => { setExportConfirmId(null); setExportConfirmText('') }}
-      />
-      {sendWalletId === walletId && sendMode && (
-        (() => {
-          const tokenOptions = sendMode === 'token'
-            ? (walletTokenOptions[walletId]
-              ?? (walletId === dashboard.activeWallet?.id
-                ? dashboard.activeWallet.holdings.filter((holding) => holding.amount > 0)
-                  .map((holding) => ({ mint: holding.mint, symbol: holding.symbol, amount: holding.amount }))
-                : []))
-            : []
-          return (
-        <WalletSendForm
-          walletId={walletId} walletName={dashboard.wallets.find((wallet) => wallet.id === walletId)?.name ?? 'Wallet'} sendMode={sendMode} sendDest={sendDest} sendAmount={sendAmount}
-          sendMint={sendMint} sendMax={sendMax} selectedRecipientWalletId={selectedRecipientWalletId}
-          recipientWallets={dashboard.wallets.filter((wallet) => wallet.id !== walletId).map((wallet) => ({ id: wallet.id, name: wallet.name, address: wallet.address }))}
-          tokenOptions={tokenOptions}
-          walletBalanceSol={walletBalances[walletId] ?? null}
-          executionMode={walletInfrastructure.executionMode}
-          sendLoading={sendLoading} sendError={sendError} sendResult={sendResult}
-          pendingSend={pendingSend} onRecipientWalletChange={handleRecipientWalletChange}
-          onDestChange={setSendDest} onAmountChange={setSendAmount}
-          onMintChange={setSendMint} onToggleSendMax={toggleSendMax}
-          onConfirmSend={handleConfirmSend} onExecuteSend={handleExecuteSend}
-          onCancelSend={handleCancelSend} onClose={closeSend}
-        />
-          )
-        })()
-      )}
-    </>
+    <WalletExportKey
+      walletId={walletId}
+      exportConfirmId={exportConfirmId}
+      exportConfirmText={exportConfirmText}
+      revealKeyId={revealKeyId}
+      revealedKey={revealedKey}
+      onConfirmTextChange={setExportConfirmText}
+      onConfirm={handleExportKeyConfirm}
+      onCancel={() => { setExportConfirmId(null); setExportConfirmText('') }}
+    />
   )
-
-  const activeWallet = dashboard.activeWallet
-  const activeWalletMeta = dashboard.wallets.find((w) => w.id === activeWallet?.id)
-  const hasKeypair = activeWalletMeta ? keypairCache[activeWalletMeta.id] === true : false
-
-  useEffect(() => {
-    if (sendMode !== 'token') return
-    if (sendMint) return
-    const tokenOptions = sendWalletId && walletTokenOptions[sendWalletId]
-      ? walletTokenOptions[sendWalletId]
-      : sendWalletId === dashboard.activeWallet?.id
-        ? dashboard.activeWallet.holdings.filter((holding) => holding.amount > 0 && holding.symbol !== 'SOL')
-          .map((holding) => ({ mint: holding.mint, symbol: holding.symbol, amount: holding.amount }))
-        : []
-    const firstToken = tokenOptions.find((holding) => holding.amount > 0)
-    if (firstToken) setSendMint(firstToken.mint)
-  }, [sendMode, sendMint, sendWalletId, dashboard.activeWallet, walletTokenOptions])
 
   if (activeView === 'vault') return <VaultSection onBack={() => setActiveView('overview')} />
 
@@ -359,107 +446,313 @@ export function WalletTab({ onRefresh }: Props) {
   }
 
   if (activeView === 'swap' && activeWallet && hasKeypair) {
-    return <WalletSwapForm walletId={activeWallet.id} walletName={activeWallet.name} holdings={activeWallet.holdings} executionMode={walletInfrastructure.executionMode} onBack={() => setActiveView('overview')} onRefresh={onRefresh} />
+    return (
+      <WalletSwapForm
+        walletId={activeWallet.id}
+        walletName={activeWallet.name}
+        holdings={activeWallet.holdings}
+        executionMode={walletInfrastructure.executionMode}
+        initialInputMint={preferredSwapMint ?? undefined}
+        initialOutputMint={preferredSwapMint ? 'So11111111111111111111111111111111111111112' : undefined}
+        onBack={() => {
+          setPreferredSwapMint(null)
+          setActiveView('overview')
+        }}
+        onRefresh={onRefresh}
+      />
+    )
   }
 
   return (
     <>
-      {/* Portfolio */}
       <section className="wallet-section">
-        <div className="wallet-section-header">
-          <div className="wallet-section-title">Portfolio</div>
-          <button className="wallet-icon-btn" onClick={() => setShowSettings((v) => !v)}>
-            {showSettings ? 'Close' : 'Settings'}
-          </button>
-        </div>
-        <div className="wallet-total">${formatUsd(dashboard.portfolio.totalUsd)}</div>
-        <div className={`wallet-delta ${dashboard.portfolio.delta24hUsd >= 0 ? 'up' : 'down'}`}>
-          {dashboard.portfolio.delta24hUsd >= 0 ? '+' : '-'}${formatUsd(Math.abs(dashboard.portfolio.delta24hUsd))} · {formatPct(dashboard.portfolio.delta24hPct)}
-          <span className="wallet-delta-timeframe">24h</span>
-        </div>
-        <div className="wallet-caption">{dashboard.portfolio.walletCount} wallet{dashboard.portfolio.walletCount !== 1 ? 's' : ''} tracked</div>
-
-        {activeWallet && (
-          <div className="wallet-quick-actions">
-            <button className={`wallet-action-btn${activeView === 'send' ? ' active' : ''}`} onClick={() => { if (hasKeypair) { openSend(activeWallet.id, 'sol'); setActiveView('send') } }} disabled={!hasKeypair} title={hasKeypair ? 'Send SOL or tokens' : 'No keypair — watch-only wallet'}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
-              Send
-            </button>
-            <button className={`wallet-action-btn${activeView === 'swap' ? ' active' : ''}`} onClick={() => { if (hasKeypair) setActiveView('swap') }} disabled={!hasKeypair} title={hasKeypair ? 'Swap tokens via Jupiter' : 'No keypair — watch-only wallet'}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><polyline points="7 23 3 19 7 15"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg>
-              Swap
-            </button>
-            <button className="wallet-action-btn" onClick={() => setActiveView('receive')}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>
-              Receive
-            </button>
-            <button className="wallet-action-btn" onClick={() => setActiveView('vault')}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-              Vault
-            </button>
+        <div className="wallet-portfolio-hero">
+          <div className="wallet-portfolio-primary">
+            <div className="wallet-total">${formatUsd(dashboard.portfolio.totalUsd)}</div>
+            <div className={`wallet-delta ${dashboard.portfolio.delta24hUsd >= 0 ? 'up' : 'down'}`}>
+              {dashboard.portfolio.delta24hUsd >= 0 ? '+' : '-'}${formatUsd(Math.abs(dashboard.portfolio.delta24hUsd))} · {formatPct(dashboard.portfolio.delta24hPct)}
+              <span className="wallet-delta-timeframe">24h</span>
+            </div>
+            <div className="wallet-caption">{dashboard.portfolio.walletCount} wallet{dashboard.portfolio.walletCount !== 1 ? 's' : ''} tracked</div>
           </div>
-        )}
+          <div className="wallet-portfolio-grid">
+            {walletActionCards.map((card) => (
+              <div key={card.label} className="wallet-portfolio-card">
+                <span className="wallet-portfolio-label">{card.label}</span>
+                <strong className="wallet-portfolio-value">{card.value}</strong>
+                <span className="wallet-portfolio-meta">{card.meta}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="wallet-quick-actions">
+          <button className={`wallet-action-btn${activeView === 'overview' ? ' active' : ''}`} onClick={() => setActiveView('overview')}>Overview</button>
+          <button className={`wallet-action-btn${activeView === 'holdings' ? ' active' : ''}`} onClick={() => setActiveView('holdings')}>Holdings</button>
+          <button className={`wallet-action-btn${activeView === 'move' ? ' active' : ''}`} onClick={() => {
+            if (activeWallet && hasKeypair) openSend(activeWallet.id, sendMode ?? 'sol')
+            else setActiveView('move')
+          }}>Move</button>
+          <button className={`wallet-action-btn${activeView === 'manage' ? ' active' : ''}`} onClick={() => setActiveView('manage')}>Manage</button>
+          <button className={`wallet-action-btn${activeView === 'history' ? ' active' : ''}`} onClick={() => setActiveView('history')}>History</button>
+          <button className={`wallet-action-btn${showInfrastructure ? ' active' : ''}`} onClick={() => setShowInfrastructure((v) => !v)}>Infra</button>
+        </div>
       </section>
 
-      {/* Inline send form */}
-      {activeView === 'send' && activeWallet && hasKeypair && (
+      {showInfrastructure && (
+        <WalletSettings
+          showMarketTape={showMarketTape}
+          showTitlebarWallet={showTitlebarWallet}
+          heliusConfigured={dashboard.heliusConfigured}
+          jupiterConfigured={jupiterConfigured}
+          infrastructure={walletInfrastructure}
+          error={error}
+          onToggleTape={async (checked) => { await setStoreShowMarketTape(checked) }}
+          onToggleTitlebarWallet={async (checked) => { await setStoreShowTitlebarWallet(checked) }}
+          onSaveHelius={handleSaveHelius}
+          onDeleteHelius={handleDeleteHelius}
+          onSaveJupiter={handleSaveJupiter}
+          onDeleteJupiter={handleDeleteJupiter}
+          onSaveInfrastructure={handleSaveInfrastructure}
+        />
+      )}
+
+      {activeView === 'overview' && activeWallet && (
+        <>
+          <section className="wallet-section">
+            <div className="wallet-section-header">
+              <div>
+                <div className="wallet-section-title">Active wallet</div>
+                <div className="wallet-caption">{activeWallet.name} · {truncateAddress(activeWallet.address)}</div>
+              </div>
+              <div className="wallet-actions wallet-actions-wrap">
+                <button className="wallet-btn" onClick={() => void handleCopyWalletAddress(activeWallet.address, activeWallet.name)}>Copy address</button>
+                <button className="wallet-btn" onClick={() => setActiveView('receive')}>Receive</button>
+                {hasKeypair && <button className="wallet-btn primary-soft" onClick={() => handleExportKeyStart(activeWallet.id)}>Export key</button>}
+              </div>
+            </div>
+            <div className="wallet-overview-grid">
+              <div className="wallet-overview-card">
+                <span className="wallet-overview-label">Best next action</span>
+                <strong>{hasKeypair ? 'Move funds or sell a holding' : 'Turn this into a signer'}</strong>
+                <p>{hasKeypair ? 'Use Move for transfers and Holdings for quick sell and swap actions.' : 'Import or generate a signing wallet so this workspace can send and trade.'}</p>
+                <div className="wallet-actions wallet-actions-wrap">
+                  {hasKeypair ? (
+                    <>
+                      <button className="wallet-btn primary" onClick={() => openSend(activeWallet.id, 'sol')}>Move funds</button>
+                      <button className="wallet-btn" onClick={() => setActiveView('holdings')}>Open holdings</button>
+                    </>
+                  ) : (
+                    <button className="wallet-btn primary" onClick={() => setActiveView('manage')}>Open manage</button>
+                  )}
+                </div>
+              </div>
+              <div className="wallet-overview-card">
+                <span className="wallet-overview-label">Quick status</span>
+                <strong>{activeWallet.holdings.length} assets tracked</strong>
+                <p>{transactions?.length ? `${transactions.length} recent transaction${transactions.length === 1 ? '' : 's'} loaded.` : 'No recent transactions loaded yet.'}</p>
+                <div className="wallet-actions wallet-actions-wrap">
+                  <button className="wallet-btn" onClick={() => setActiveView('history')}>View history</button>
+                  <button className="wallet-btn" onClick={() => setActiveView('manage')}>Switch wallet</button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {holdingsPreview.length > 0 && (
+            <section className="wallet-section">
+              <div className="wallet-section-header">
+                <div className="wallet-section-title">Holdings preview</div>
+                <button className="wallet-icon-btn" onClick={() => setActiveView('holdings')}>See all</button>
+              </div>
+              <div className="wallet-holdings">
+                {holdingsPreview.map((holding) => (
+                  <div key={holding.mint} className="wallet-holding-row">
+                    <div className="wallet-holding-main">
+                      <div className="wallet-label">{holding.symbol}</div>
+                      <div className="wallet-caption">{holding.amount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</div>
+                    </div>
+                    <div className="wallet-actions wallet-actions-wrap">
+                      {hasKeypair && holding.symbol !== 'SOL' && (
+                        <button className="wallet-inline-link" onClick={() => handleSwapHolding(holding.mint)}>Sell</button>
+                      )}
+                      <button className="wallet-inline-link" onClick={() => void handleCopyMint(holding.mint, holding.symbol)}>Copy mint</button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+        </>
+      )}
+
+      {activeView === 'holdings' && activeWallet && activeWalletMeta && (
+        <PnlHoldings
+          walletAddress={activeWalletMeta.address}
+          holdings={activeWallet.holdings}
+          onSwapHolding={hasKeypair ? handleSwapHolding : undefined}
+          onCopyMint={(mint, symbol) => { void handleCopyMint(mint, symbol) }}
+        />
+      )}
+
+      {activeView === 'move' && activeWallet && (
         <section className="wallet-section">
-          <div className="wallet-section-title" style={{ margin: 0 }}>Send from {activeWallet.name}</div>
-          <div className="wallet-swap-field" style={{ marginBottom: 6 }}>
-            <label className="wallet-caption">Mode</label>
-            <div className="wallet-actions">
-              <button className={`wallet-btn ${sendMode === 'sol' ? 'primary' : ''}`} onClick={() => openSend(activeWallet.id, 'sol')}>SOL</button>
-              <button className={`wallet-btn ${sendMode === 'token' ? 'primary' : ''}`} onClick={() => openSend(activeWallet.id, 'token')}>Token</button>
+          <div className="wallet-section-header">
+            <div>
+              <div className="wallet-section-title">Move funds</div>
+              <div className="wallet-caption">Transfer between your wallets, send out, or jump into swap mode without leaving this workspace.</div>
+            </div>
+            <div className="wallet-actions wallet-actions-wrap">
+              <button className={`wallet-btn ${sendMode === 'sol' ? 'primary' : ''}`} onClick={() => openSend(activeWallet.id, 'sol')}>Send SOL</button>
+              <button className={`wallet-btn ${sendMode === 'token' ? 'primary' : ''}`} onClick={() => openSend(activeWallet.id, 'token')}>Send token</button>
+              <button className="wallet-btn" onClick={() => setActiveView('swap')} disabled={!hasKeypair}>Swap</button>
             </div>
           </div>
-          {sendWalletId === activeWallet.id && sendMode && (
-            <WalletSendForm walletId={activeWallet.id} walletName={activeWallet.name} sendMode={sendMode} sendDest={sendDest} sendAmount={sendAmount} sendMint={sendMint} sendMax={sendMax} selectedRecipientWalletId={selectedRecipientWalletId} recipientWallets={dashboard.wallets.filter((wallet) => wallet.id !== activeWallet.id).map((wallet) => ({ id: wallet.id, name: wallet.name, address: wallet.address }))} tokenOptions={sendMode === 'token' ? ((walletTokenOptions[activeWallet.id] ?? activeWallet.holdings.filter((holding) => holding.amount > 0 && holding.symbol !== 'SOL').map((holding) => ({ mint: holding.mint, symbol: holding.symbol, amount: holding.amount })))) : []} walletBalanceSol={walletBalances[activeWallet.id] ?? null} executionMode={walletInfrastructure.executionMode} sendLoading={sendLoading} sendError={sendError} sendResult={sendResult} pendingSend={pendingSend} onRecipientWalletChange={handleRecipientWalletChange} onDestChange={setSendDest} onAmountChange={setSendAmount} onMintChange={setSendMint} onToggleSendMax={toggleSendMax} onConfirmSend={handleConfirmSend} onExecuteSend={handleExecuteSend} onCancelSend={handleCancelSend} onClose={closeSend} />
+          <div className="wallet-move-grid">
+            <div className="wallet-move-card">
+              <span className="wallet-overview-label">From</span>
+              <strong>{activeWallet.name}</strong>
+              <p>{truncateAddress(activeWallet.address)}</p>
+            </div>
+            <div className="wallet-move-card">
+              <span className="wallet-overview-label">Recommended</span>
+              <strong>{dashboard.wallets.length > 1 ? 'Transfer between tracked wallets first' : 'Paste an external destination'}</strong>
+              <p>{dashboard.wallets.length > 1 ? 'Use the tracked wallet picker to move funds safely inside your own wallet set.' : 'You only have one tracked wallet right now, so this acts like a send form.'}</p>
+            </div>
+          </div>
+          {hasKeypair ? (
+            sendWalletId === activeWallet.id && sendMode && (
+              <WalletSendForm
+                walletId={activeWallet.id}
+                walletName={activeWallet.name}
+                sendMode={sendMode}
+                sendDest={sendDest}
+                sendAmount={sendAmount}
+                sendMint={sendMint}
+                sendMax={sendMax}
+                selectedRecipientWalletId={selectedRecipientWalletId}
+                recipientWallets={dashboard.wallets.filter((wallet) => wallet.id !== activeWallet.id).map((wallet) => ({ id: wallet.id, name: wallet.name, address: wallet.address }))}
+                tokenOptions={sendMode === 'token' ? (walletTokenOptions[activeWallet.id] ?? activeWallet.holdings.filter((holding) => holding.amount > 0 && holding.symbol !== 'SOL').map((holding) => ({ mint: holding.mint, symbol: holding.symbol, amount: holding.amount }))) : []}
+                walletBalanceSol={walletBalances[activeWallet.id] ?? null}
+                executionMode={walletInfrastructure.executionMode}
+                sendLoading={sendLoading}
+                sendError={sendError}
+                sendResult={sendResult}
+                pendingSend={pendingSend}
+                onRecipientWalletChange={handleRecipientWalletChange}
+                onDestChange={setSendDest}
+                onAmountChange={setSendAmount}
+                onMintChange={setSendMint}
+                onToggleSendMax={toggleSendMax}
+                onConfirmSend={handleConfirmSend}
+                onExecuteSend={handleExecuteSend}
+                onCancelSend={handleCancelSend}
+                onClose={closeSend}
+              />
+            )
+          ) : (
+            <div className="wallet-empty">This wallet is watch-only. Open Manage to import or generate a signing wallet before sending or swapping.</div>
           )}
         </section>
       )}
 
-      {showSettings && (
-        <WalletSettings
-          showMarketTape={showMarketTape} showTitlebarWallet={showTitlebarWallet}
-          heliusConfigured={dashboard.heliusConfigured} jupiterConfigured={jupiterConfigured} infrastructure={walletInfrastructure} wallets={dashboard.wallets}
-          keypairCache={keypairCache} activeProjectId={activeProjectId}
-          error={error} genSuccess={genSuccess}
-          onToggleTape={async (c) => { await setStoreShowMarketTape(c) }} onToggleTitlebarWallet={async (c) => { await setStoreShowTitlebarWallet(c) }}
-          onSaveHelius={handleSaveHelius} onDeleteHelius={handleDeleteHelius}
-          onSaveJupiter={handleSaveJupiter} onDeleteJupiter={handleDeleteJupiter} onSaveInfrastructure={handleSaveInfrastructure}
-          onAddWallet={handleAddWallet} onGenerateWallet={handleGenerate}
-          onClearGenSuccess={() => setGenSuccess(null)} onSetDefault={handleSetDefault}
-          onAssignProject={handleAssignProject} onDeleteWallet={handleDeleteWallet}
-          onOpenSend={openSend} onExportKeyStart={handleExportKeyStart}
-          renderWalletInline={renderWalletInline}
-        />
-      )}
+      {activeView === 'manage' && (
+        <>
+          <section className="wallet-section">
+            <div className="wallet-section-header">
+              <div>
+                <div className="wallet-section-title">Create or import</div>
+                <div className="wallet-caption">Bring in tracked wallets, create fresh signers, and choose which wallet should act by default.</div>
+              </div>
+            </div>
+            <div className="wallet-tab-group wallet-create-tabs">
+              <button className={`wallet-tab ${createTab === 'import' ? 'active' : ''}`} onClick={() => { setCreateTab('import'); setGenSuccess(null) }}>Import</button>
+              <button className={`wallet-tab ${createTab === 'generate' ? 'active' : ''}`} onClick={() => { setCreateTab('generate'); setGenSuccess(null) }}>Generate</button>
+            </div>
+            {createTab === 'import' && (
+              <div className="wallet-form wallet-create-grid">
+                <input className="wallet-input" value={walletName} onChange={(e) => setWalletName(e.target.value)} placeholder="Wallet name" />
+                <input className="wallet-input" value={walletAddress} onChange={(e) => setWalletAddress(e.target.value)} placeholder="Solana address" />
+                <button className="wallet-btn primary wallet-btn-wide" onClick={() => void handleAddWallet(walletName.trim(), walletAddress.trim())}>Add Wallet</button>
+              </div>
+            )}
+            {createTab === 'generate' && (
+              <div className="wallet-form wallet-create-grid">
+                <input className="wallet-input" value={genName} onChange={(e) => setGenName(e.target.value)} placeholder="Wallet name" />
+                <button className="wallet-btn primary wallet-btn-wide" onClick={() => void handleGenerate(genName.trim())}>Generate Wallet</button>
+                {genSuccess && <div className="wallet-success-msg">Generated: {truncateAddress(genSuccess)}</div>}
+              </div>
+            )}
+          </section>
 
-      {/* Holdings + Feed + Transactions — responsive grid when expanded */}
-      <div className="wallet-body-grid">
-        <div className="wallet-body-main">
-          {activeWallet && activeWalletMeta && (
-            <PnlHoldings walletAddress={activeWalletMeta.address} holdings={activeWallet.holdings} />
-          )}
-          {transactions && transactions.length > 0 && <TransactionHistory transactions={transactions} />}
-        </div>
-
-        {dashboard.feed.length > 0 && (
-          <div className="wallet-body-side">
-            <section className="wallet-section">
-              <div className="wallet-section-title">Live Feed</div>
-              {dashboard.feed.slice(0, 8).map((entry) => (
-                <div key={entry.walletId} className="wallet-feed-row">
-                  <span className="wallet-feed-name">{entry.walletName}</span>
-                  <span className={`wallet-feed-delta ${entry.deltaUsd >= 0 ? 'up' : 'down'}`}>
-                    {entry.deltaUsd >= 0 ? '+' : '-'}${formatUsd(Math.abs(entry.deltaUsd))}
-                  </span>
+          <section className="wallet-section">
+            <div className="wallet-section-header">
+              <div>
+                <div className="wallet-section-title">Wallets</div>
+                <div className="wallet-caption">Set your main wallet, assign one to the current project, export keys, copy addresses, and move funds between them.</div>
+              </div>
+            </div>
+            <div className="wallet-list wallet-list-cards">
+              {trackedWallets.map((wallet) => (
+                <div key={wallet.id} className="wallet-row wallet-row-card">
+                  <div className="wallet-row-main wallet-row-main-top">
+                    <div className="wallet-row-identity">
+                      <div className="wallet-name">{wallet.name}</div>
+                      <div className="wallet-row-sub wallet-row-subtle wallet-row-chipline">
+                        {wallet.isDefault && <span className="wallet-badge">default</span>}
+                        <span className={`wallet-pill ${keypairCache[wallet.id] ? 'live' : 'muted'}`}>{keypairCache[wallet.id] ? 'Signer' : 'Watch-only'}</span>
+                        <span className="wallet-pill">{truncateAddress(wallet.address)}</span>
+                        <span className="wallet-pill">{wallet.tokenCount} assets</span>
+                      </div>
+                    </div>
+                    <div className="wallet-value wallet-value-strong">${formatUsd(wallet.totalUsd)}</div>
+                  </div>
+                  <div className="wallet-actions-card">
+                    <div className="wallet-actions wallet-actions-wrap wallet-actions-card-main">
+                      {!wallet.isDefault && <button className="wallet-btn" onClick={() => void handleSetDefault(wallet.id)}>Make main wallet</button>}
+                      {activeProjectId && <button className="wallet-btn primary-soft" onClick={() => void handleAssignProject(wallet.id)}>Use for project</button>}
+                      <button className="wallet-btn" onClick={() => void handleCopyWalletAddress(wallet.address, wallet.name)}>Copy address</button>
+                      {keypairCache[wallet.id] && <button className="wallet-btn primary" onClick={() => openSend(wallet.id, 'sol')}>Move funds</button>}
+                    </div>
+                    <div className="wallet-actions wallet-actions-wrap wallet-actions-card-utility">
+                      {keypairCache[wallet.id] && <button className="wallet-btn subtle" onClick={() => handleExportKeyStart(wallet.id)}>Export key</button>}
+                      <button className="wallet-btn danger" onClick={() => void handleDeleteWallet(wallet.id)}>Remove</button>
+                    </div>
+                  </div>
+                  {renderWalletInline(wallet.id)}
                 </div>
               ))}
-            </section>
+              {trackedWallets.length === 0 && <div className="wallet-empty">No wallets configured</div>}
+            </div>
+          </section>
+        </>
+      )}
+
+      {activeView === 'history' && (
+        <section className="wallet-section">
+          <div className="wallet-section-header">
+            <div>
+              <div className="wallet-section-title">History</div>
+              <div className="wallet-caption">Recent confirmed transactions for the active wallet.</div>
+            </div>
           </div>
-        )}
-      </div>
+          {transactions && transactions.length > 0 ? <TransactionHistory transactions={transactions} /> : <div className="wallet-empty">No recent transactions for the active wallet yet.</div>}
+        </section>
+      )}
+
+      {activeView === 'overview' && dashboard.feed.length > 0 && (
+        <section className="wallet-section">
+          <div className="wallet-section-title">Live feed</div>
+          {dashboard.feed.slice(0, 8).map((entry) => (
+            <div key={entry.walletId} className="wallet-feed-row">
+              <span className="wallet-feed-name">{entry.walletName}</span>
+              <span className={`wallet-feed-delta ${entry.deltaUsd >= 0 ? 'up' : 'down'}`}>
+                {entry.deltaUsd >= 0 ? '+' : '-'}${formatUsd(Math.abs(entry.deltaUsd))}
+              </span>
+            </div>
+          ))}
+        </section>
+      )}
     </>
   )
 }
@@ -471,4 +764,9 @@ function formatUsd(value: number): string {
 function formatPct(value: number): string {
   const sign = value >= 0 ? '+' : '-'
   return `${sign}${Math.abs(value).toFixed(2)}%`
+}
+
+function truncateAddress(address: string): string {
+  if (address.length <= 12) return address
+  return `${address.slice(0, 4)}…${address.slice(-4)}`
 }

--- a/src/store/browser.ts
+++ b/src/store/browser.ts
@@ -32,7 +32,7 @@ interface BrowserState {
 }
 
 export const useBrowserStore = create<BrowserState>((set) => ({
-  currentUrl: 'http://localhost:3000',
+  currentUrl: 'https://www.daemonide.tech/',
   isInspectMode: false,
   loadStatus: 'idle',
   agentTerminalId: null,

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -41,6 +41,8 @@ interface UIState {
   centerMode: CenterMode
   browserTabOpen: boolean
   browserTabActive: boolean
+  workspaceToolTabs: string[]
+  activeWorkspaceToolId: string | null
   rightPanelTab: RightPanelTab
   dashboardTabOpen: boolean
   dashboardTabActive: boolean
@@ -67,6 +69,10 @@ interface UIState {
   openBrowserTab: () => void
   closeBrowserTab: () => void
   setBrowserTabActive: (active: boolean) => void
+  openWorkspaceTool: (toolId: string) => void
+  closeWorkspaceTool: (toolId: string) => void
+  setActiveWorkspaceTool: (toolId: string | null) => void
+  toggleWorkspaceTool: (toolId: string) => void
   setRightPanelTab: (tab: RightPanelTab) => void
   toggleDashboardTab: () => void
   openDashboardTab: () => void
@@ -112,6 +118,8 @@ export const useUIStore = create<UIState>((set) => ({
   centerMode: 'canvas' as CenterMode,
   browserTabOpen: false,
   browserTabActive: false,
+  workspaceToolTabs: [],
+  activeWorkspaceToolId: null,
   rightPanelTab: 'claude' as RightPanelTab,
   dashboardTabOpen: false,
   dashboardTabActive: false,
@@ -136,6 +144,7 @@ export const useUIStore = create<UIState>((set) => ({
         centerMode: 'canvas' as CenterMode,
         browserTabActive: false,
         dashboardTabActive: false,
+        activeWorkspaceToolId: null,
         activeFilePathByProject: updateRecord(state.activeFilePathByProject, file.projectId, file.path),
       }
     }
@@ -143,6 +152,7 @@ export const useUIStore = create<UIState>((set) => ({
       centerMode: 'canvas' as CenterMode,
       browserTabActive: false,
       dashboardTabActive: false,
+      activeWorkspaceToolId: null,
       openFiles: [...state.openFiles, { ...file, isDirty: false }],
       activeFilePathByProject: updateRecord(state.activeFilePathByProject, file.projectId, file.path),
     }
@@ -161,6 +171,9 @@ export const useUIStore = create<UIState>((set) => ({
   }),
 
   setActiveFile: (projectId, path) => set((state) => ({
+    browserTabActive: false,
+    dashboardTabActive: false,
+    activeWorkspaceToolId: null,
     activeFilePathByProject: updateRecord(state.activeFilePathByProject, projectId, path),
   })),
 
@@ -228,6 +241,7 @@ export const useUIStore = create<UIState>((set) => ({
       browserTabOpen: true,
       browserTabActive: true,
       dashboardTabActive: false,
+      activeWorkspaceToolId: null,
     })
   },
   closeBrowserTab: () => set({ browserTabOpen: false, browserTabActive: false }),
@@ -237,9 +251,92 @@ export const useUIStore = create<UIState>((set) => ({
       ? {
           browserTabActive: true,
           dashboardTabActive: false,
+          activeWorkspaceToolId: null,
         }
       : { browserTabActive: false })
   },
+  openWorkspaceTool: (toolId) => {
+    if (toolId === 'browser') {
+      useUIStore.getState().openBrowserTab()
+      return
+    }
+    if (toolId === 'dashboard') {
+      useUIStore.getState().openDashboardTab()
+      return
+    }
+    useWorkflowShellStore.getState().closeDrawer()
+    set((state) => ({
+      centerMode: 'canvas' as CenterMode,
+      browserTabActive: false,
+      dashboardTabActive: false,
+      workspaceToolTabs: state.workspaceToolTabs.includes(toolId)
+        ? state.workspaceToolTabs
+        : [...state.workspaceToolTabs, toolId],
+      activeWorkspaceToolId: toolId,
+    }))
+  },
+  closeWorkspaceTool: (toolId) => set((state) => {
+    const nextTabs = state.workspaceToolTabs.filter((id) => id !== toolId)
+    return {
+      workspaceToolTabs: nextTabs,
+      activeWorkspaceToolId: state.activeWorkspaceToolId === toolId
+        ? nextTabs[nextTabs.length - 1] ?? null
+        : state.activeWorkspaceToolId,
+    }
+  }),
+  setActiveWorkspaceTool: (toolId) => {
+    if (toolId === 'browser') {
+      useUIStore.getState().setBrowserTabActive(true)
+      return
+    }
+    if (toolId === 'dashboard') {
+      useUIStore.getState().setDashboardTabActive(true)
+      return
+    }
+    if (toolId) useWorkflowShellStore.getState().closeDrawer()
+    set(toolId
+      ? {
+          browserTabActive: false,
+          dashboardTabActive: false,
+          activeWorkspaceToolId: toolId,
+        }
+      : { activeWorkspaceToolId: null })
+  },
+  toggleWorkspaceTool: (toolId) => set((state) => {
+    if (toolId === 'browser') {
+      if (state.browserTabActive) {
+        useUIStore.getState().closeBrowserTab()
+      } else {
+        useUIStore.getState().openBrowserTab()
+      }
+      return {}
+    }
+    if (toolId === 'dashboard') {
+      if (state.dashboardTabActive) {
+        useUIStore.getState().closeDashboardTab()
+      } else {
+        useUIStore.getState().openDashboardTab()
+      }
+      return {}
+    }
+    if (state.activeWorkspaceToolId === toolId) {
+      const nextTabs = state.workspaceToolTabs.filter((id) => id !== toolId)
+      return {
+        workspaceToolTabs: nextTabs,
+        activeWorkspaceToolId: nextTabs[nextTabs.length - 1] ?? null,
+      }
+    }
+    useWorkflowShellStore.getState().closeDrawer()
+    return {
+      centerMode: 'canvas' as CenterMode,
+      browserTabActive: false,
+      dashboardTabActive: false,
+      workspaceToolTabs: state.workspaceToolTabs.includes(toolId)
+        ? state.workspaceToolTabs
+        : [...state.workspaceToolTabs, toolId],
+      activeWorkspaceToolId: toolId,
+    }
+  }),
   setRightPanelTab: (tab) => {
     set({ rightPanelTab: tab })
     if (typeof window !== 'undefined') {
@@ -262,6 +359,7 @@ export const useUIStore = create<UIState>((set) => ({
       dashboardTabOpen: true,
       dashboardTabActive: true,
       browserTabActive: false,
+      activeWorkspaceToolId: null,
     })
   },
   closeDashboardTab: () => set({ dashboardTabOpen: false, dashboardTabActive: false }),
@@ -271,6 +369,7 @@ export const useUIStore = create<UIState>((set) => ({
       ? {
           dashboardTabActive: true,
           browserTabActive: false,
+          activeWorkspaceToolId: null,
         }
       : { dashboardTabActive: false })
   },

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { daemon } from '../lib/daemonBridge'
 import { updateRecord, deleteFromRecord, filterRecord, mapRecord } from './stateHelpers'
+import { useWorkflowShellStore } from './workflowShell'
 
 interface OpenFile {
   path: string
@@ -43,7 +44,6 @@ interface UIState {
   rightPanelTab: RightPanelTab
   dashboardTabOpen: boolean
   dashboardTabActive: boolean
-  launchWizardOpen: boolean
   activeDashboardMint: string | null
   grindPageCount: number
   activeGrindPage: number
@@ -72,8 +72,6 @@ interface UIState {
   openDashboardTab: () => void
   closeDashboardTab: () => void
   setDashboardTabActive: (active: boolean) => void
-  openLaunchWizard: () => void
-  closeLaunchWizard: () => void
   setActiveDashboardMint: (mint: string | null) => void
   setActiveGrindPage: (page: number) => void
   addGrindPage: () => void
@@ -92,15 +90,8 @@ interface UIState {
   closeAllQuickViews: () => void
 
   // Command drawer
-  drawerTool: string | null
-  drawerOpen: boolean
-  drawerFullscreen: boolean
   pinnedTools: string[]
   drawerToolOrder: string[]
-  setDrawerTool: (tool: string | null) => void
-  closeDrawer: () => void
-  toggleDrawer: () => void
-  toggleDrawerFullscreen: () => void
   setPinnedTools: (tools: string[]) => void
   pinTool: (toolId: string) => void
   unpinTool: (toolId: string) => void
@@ -124,16 +115,12 @@ export const useUIStore = create<UIState>((set) => ({
   rightPanelTab: 'claude' as RightPanelTab,
   dashboardTabOpen: false,
   dashboardTabActive: false,
-  launchWizardOpen: false,
   activeDashboardMint: null,
   grindPageCount: 1,
   activeGrindPage: 0,
   grindPages: {},
   walletQuickViewOpen: false,
   emailQuickViewOpen: false,
-  drawerTool: null,
-  drawerOpen: false,
-  drawerFullscreen: false,
   pinnedTools: ['git', 'browser', 'token-launch', 'solana-toolbox'],
   drawerToolOrder: [],
 
@@ -142,11 +129,10 @@ export const useUIStore = create<UIState>((set) => ({
   setProjects: (projects) => set({ projects }),
 
   openFile: (file) => set((state) => {
+    useWorkflowShellStore.getState().closeDrawer()
     const exists = state.openFiles.find((f) => f.path === file.path && f.projectId === file.projectId)
     if (exists) {
       return {
-        drawerTool: null,
-        drawerOpen: false,
         centerMode: 'canvas' as CenterMode,
         browserTabActive: false,
         dashboardTabActive: false,
@@ -154,8 +140,6 @@ export const useUIStore = create<UIState>((set) => ({
       }
     }
     return {
-      drawerTool: null,
-      drawerOpen: false,
       centerMode: 'canvas' as CenterMode,
       browserTabActive: false,
       dashboardTabActive: false,
@@ -231,33 +215,31 @@ export const useUIStore = create<UIState>((set) => ({
   toggleBrowserTab: () => set((state) => {
     const isOpen = !state.browserTabOpen
     if (!isOpen) return { browserTabOpen: false, browserTabActive: false }
+    useWorkflowShellStore.getState().closeDrawer()
     return {
       browserTabOpen: true,
       browserTabActive: true,
       dashboardTabActive: false,
-      drawerTool: null,
-      drawerOpen: false,
-      drawerFullscreen: false,
     }
   }),
-  openBrowserTab: () => set({
-    browserTabOpen: true,
-    browserTabActive: true,
-    dashboardTabActive: false,
-    drawerTool: null,
-    drawerOpen: false,
-    drawerFullscreen: false,
-  }),
+  openBrowserTab: () => {
+    useWorkflowShellStore.getState().closeDrawer()
+    set({
+      browserTabOpen: true,
+      browserTabActive: true,
+      dashboardTabActive: false,
+    })
+  },
   closeBrowserTab: () => set({ browserTabOpen: false, browserTabActive: false }),
-  setBrowserTabActive: (active) => set(active
-    ? {
-        browserTabActive: true,
-        dashboardTabActive: false,
-        drawerTool: null,
-        drawerOpen: false,
-        drawerFullscreen: false,
-      }
-    : { browserTabActive: false }),
+  setBrowserTabActive: (active) => {
+    if (active) useWorkflowShellStore.getState().closeDrawer()
+    set(active
+      ? {
+          browserTabActive: true,
+          dashboardTabActive: false,
+        }
+      : { browserTabActive: false })
+  },
   setRightPanelTab: (tab) => {
     set({ rightPanelTab: tab })
     if (typeof window !== 'undefined') {
@@ -267,35 +249,31 @@ export const useUIStore = create<UIState>((set) => ({
   toggleDashboardTab: () => set((state) => {
     const isOpen = !state.dashboardTabOpen
     if (!isOpen) return { dashboardTabOpen: false, dashboardTabActive: false }
+    useWorkflowShellStore.getState().closeDrawer()
     return {
       dashboardTabOpen: true,
       dashboardTabActive: true,
       browserTabActive: false,
-      drawerTool: null,
-      drawerOpen: false,
-      drawerFullscreen: false,
     }
   }),
-  openDashboardTab: () => set({
-    dashboardTabOpen: true,
-    dashboardTabActive: true,
-    browserTabActive: false,
-    drawerTool: null,
-    drawerOpen: false,
-    drawerFullscreen: false,
-  }),
+  openDashboardTab: () => {
+    useWorkflowShellStore.getState().closeDrawer()
+    set({
+      dashboardTabOpen: true,
+      dashboardTabActive: true,
+      browserTabActive: false,
+    })
+  },
   closeDashboardTab: () => set({ dashboardTabOpen: false, dashboardTabActive: false }),
-  setDashboardTabActive: (active) => set(active
-    ? {
-        dashboardTabActive: true,
-        browserTabActive: false,
-        drawerTool: null,
-        drawerOpen: false,
-        drawerFullscreen: false,
-      }
-    : { dashboardTabActive: false }),
-  openLaunchWizard: () => set({ launchWizardOpen: true }),
-  closeLaunchWizard: () => set({ launchWizardOpen: false }),
+  setDashboardTabActive: (active) => {
+    if (active) useWorkflowShellStore.getState().closeDrawer()
+    set(active
+      ? {
+          dashboardTabActive: true,
+          browserTabActive: false,
+        }
+      : { dashboardTabActive: false })
+  },
   setActiveDashboardMint: (mint) => set({ activeDashboardMint: mint }),
   setActiveGrindPage: (page) => set({ activeGrindPage: page }),
   addGrindPage: () => set((state) => ({
@@ -382,16 +360,6 @@ export const useUIStore = create<UIState>((set) => ({
   })),
   closeAllQuickViews: () => set({ walletQuickViewOpen: false, emailQuickViewOpen: false }),
 
-  setDrawerTool: (tool) => set((state) => ({
-    drawerTool: tool,
-    drawerOpen: tool !== null,
-    drawerFullscreen: tool !== null ? state.drawerFullscreen : false,
-  })),
-  closeDrawer: () => set({ drawerOpen: false, drawerTool: null, drawerFullscreen: false }),
-  toggleDrawer: () => set((state) => state.drawerOpen
-    ? { drawerOpen: false, drawerTool: null, drawerFullscreen: false }
-    : { drawerOpen: true, drawerTool: null, drawerFullscreen: false }),
-  toggleDrawerFullscreen: () => set((state) => ({ drawerFullscreen: !state.drawerFullscreen })),
   setPinnedTools: (tools) => {
     set({ pinnedTools: tools })
     daemon.settings.setPinnedTools(tools).catch(() => {})

--- a/src/store/wallet.ts
+++ b/src/store/wallet.ts
@@ -51,7 +51,7 @@ interface WalletTransaction {
   created_at: number
 }
 
-type WalletActiveView = 'overview' | 'send' | 'swap' | 'receive' | 'vault'
+type WalletActiveView = 'overview' | 'holdings' | 'move' | 'manage' | 'history' | 'swap' | 'receive' | 'vault'
 type WalletTab = 'wallet' | 'agents'
 
 interface WalletStoreState {

--- a/src/store/workflowShell.ts
+++ b/src/store/workflowShell.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+
+export interface WorkflowShellState {
+  drawerTool: string | null
+  drawerOpen: boolean
+  drawerFullscreen: boolean
+  launchWizardOpen: boolean
+  setDrawerTool: (tool: string | null) => void
+  closeDrawer: () => void
+  toggleDrawer: () => void
+  toggleDrawerFullscreen: () => void
+  openLaunchWizard: () => void
+  closeLaunchWizard: () => void
+}
+
+export const useWorkflowShellStore = create<WorkflowShellState>((set) => ({
+  drawerTool: null,
+  drawerOpen: false,
+  drawerFullscreen: false,
+  launchWizardOpen: false,
+  setDrawerTool: (tool) => set((state) => ({
+    drawerTool: tool,
+    drawerOpen: tool !== null,
+    drawerFullscreen: tool !== null ? state.drawerFullscreen : false,
+  })),
+  closeDrawer: () => set({ drawerOpen: false, drawerTool: null, drawerFullscreen: false }),
+  toggleDrawer: () => set((state) => state.drawerOpen
+    ? { drawerOpen: false, drawerTool: null, drawerFullscreen: false }
+    : { drawerOpen: true, drawerTool: null, drawerFullscreen: false }),
+  toggleDrawerFullscreen: () => set((state) => ({ drawerFullscreen: !state.drawerFullscreen })),
+  openLaunchWizard: () => set({ launchWizardOpen: true }),
+  closeLaunchWizard: () => set({ launchWizardOpen: false }),
+}))

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -393,8 +393,17 @@ declare global {
     ranAt: number
   }
 
+  interface AppMeta {
+    version: string
+    electronVersion: string
+    platform: string
+    updateChannel: string
+    releaseUrl: string
+  }
+
   interface DaemonSettings {
     getUi: () => Promise<IpcResponse<UiSettings>>
+    getAppMeta: () => Promise<IpcResponse<AppMeta>>
     setShowMarketTape: (enabled: boolean) => Promise<IpcResponse>
     setShowTitlebarWallet: (enabled: boolean) => Promise<IpcResponse>
     isOnboardingComplete: () => Promise<IpcResponse<boolean>>

--- a/test/ui-store-extended.test.ts
+++ b/test/ui-store-extended.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { useUIStore } from '../src/store/ui'
+import { useWorkflowShellStore } from '../src/store/workflowShell'
 
 function resetStore() {
   useUIStore.setState({
@@ -13,11 +14,22 @@ function resetStore() {
     mcpDirty: false,
     mcpVersion: 0,
     centerMode: 'canvas',
+    browserTabOpen: false,
+    browserTabActive: false,
+    workspaceToolTabs: [],
+    activeWorkspaceToolId: null,
+    dashboardTabOpen: false,
+    dashboardTabActive: false,
     grindPageCount: 1,
     activeGrindPage: 0,
     grindPages: {},
+  })
+
+  useWorkflowShellStore.setState({
     drawerTool: null,
     drawerOpen: false,
+    drawerFullscreen: false,
+    launchWizardOpen: false,
   })
 }
 
@@ -33,7 +45,7 @@ describe('useUIStore — initial state', () => {
     expect(state.terminals).toEqual([])
     expect(state.mcpDirty).toBe(false)
     expect(state.centerMode).toBe('canvas')
-    expect(state.drawerTool).toBeNull()
+    expect(useWorkflowShellStore.getState().drawerTool).toBeNull()
   })
 })
 
@@ -116,12 +128,13 @@ describe('useUIStore — openFile / closeFile / setActiveFile', () => {
 
   it('openFile resets centerMode to canvas and closes drawer', () => {
     useUIStore.getState().setCenterMode('grind')
-    useUIStore.getState().setDrawerTool('git')
+    useWorkflowShellStore.getState().setDrawerTool('git')
     useUIStore.getState().openFile({ projectId: 'p1', path: '/a.ts', name: 'a.ts', content: 'a' })
     const state = useUIStore.getState()
+    const shellState = useWorkflowShellStore.getState()
     expect(state.centerMode).toBe('canvas')
-    expect(state.drawerTool).toBeNull()
-    expect(state.drawerOpen).toBe(false)
+    expect(shellState.drawerTool).toBeNull()
+    expect(shellState.drawerOpen).toBe(false)
   })
 })
 
@@ -165,20 +178,20 @@ describe('useUIStore — addTerminal / removeTerminal', () => {
   })
 })
 
-describe('useUIStore — setDrawerTool / setCenterMode', () => {
+describe('useUIStore / useWorkflowShellStore — drawer and center mode', () => {
   beforeEach(resetStore)
 
   it('changes drawer tool and opens drawer', () => {
-    useUIStore.getState().setDrawerTool('git')
-    const state = useUIStore.getState()
+    useWorkflowShellStore.getState().setDrawerTool('git')
+    const state = useWorkflowShellStore.getState()
     expect(state.drawerTool).toBe('git')
     expect(state.drawerOpen).toBe(true)
   })
 
   it('clears drawer tool when set to null', () => {
-    useUIStore.getState().setDrawerTool('git')
-    useUIStore.getState().setDrawerTool(null)
-    const state = useUIStore.getState()
+    useWorkflowShellStore.getState().setDrawerTool('git')
+    useWorkflowShellStore.getState().setDrawerTool(null)
+    const state = useWorkflowShellStore.getState()
     expect(state.drawerTool).toBeNull()
     expect(state.drawerOpen).toBe(false)
   })
@@ -191,43 +204,35 @@ describe('useUIStore — setDrawerTool / setCenterMode', () => {
   })
 
   it('activating browser closes the drawer and deactivates dashboard', () => {
-    useUIStore.setState({
-      drawerTool: 'hackathon',
-      drawerOpen: true,
-      drawerFullscreen: true,
-      dashboardTabOpen: true,
-      dashboardTabActive: true,
-    })
+    useWorkflowShellStore.setState({ drawerTool: 'hackathon', drawerOpen: true, drawerFullscreen: true })
+    useUIStore.setState({ dashboardTabOpen: true, dashboardTabActive: true })
 
     useUIStore.getState().openBrowserTab()
 
     const state = useUIStore.getState()
+    const shellState = useWorkflowShellStore.getState()
     expect(state.browserTabOpen).toBe(true)
     expect(state.browserTabActive).toBe(true)
     expect(state.dashboardTabActive).toBe(false)
-    expect(state.drawerTool).toBeNull()
-    expect(state.drawerOpen).toBe(false)
-    expect(state.drawerFullscreen).toBe(false)
+    expect(shellState.drawerTool).toBeNull()
+    expect(shellState.drawerOpen).toBe(false)
+    expect(shellState.drawerFullscreen).toBe(false)
   })
 
   it('activating dashboard closes the drawer and deactivates browser', () => {
-    useUIStore.setState({
-      drawerTool: 'hackathon',
-      drawerOpen: true,
-      drawerFullscreen: true,
-      browserTabOpen: true,
-      browserTabActive: true,
-    })
+    useWorkflowShellStore.setState({ drawerTool: 'hackathon', drawerOpen: true, drawerFullscreen: true })
+    useUIStore.setState({ browserTabOpen: true, browserTabActive: true })
 
     useUIStore.getState().openDashboardTab()
 
     const state = useUIStore.getState()
+    const shellState = useWorkflowShellStore.getState()
     expect(state.dashboardTabOpen).toBe(true)
     expect(state.dashboardTabActive).toBe(true)
     expect(state.browserTabActive).toBe(false)
-    expect(state.drawerTool).toBeNull()
-    expect(state.drawerOpen).toBe(false)
-    expect(state.drawerFullscreen).toBe(false)
+    expect(shellState.drawerTool).toBeNull()
+    expect(shellState.drawerOpen).toBe(false)
+    expect(shellState.drawerFullscreen).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

This PR moves DAEMON away from the old drawer-as-workspace model and makes the main canvas the default place where tools live and workflows happen.

The shell now behaves more like a real IDE workspace:
- tools open as canvas tabs instead of half/fullscreen popouts
- the drawer behaves as a launcher surface
- major tools were rewritten around task flows instead of utility-panel layouts

## What Changed

### Shell and workspace model
- split workflow shell state out of the oversized UI store
- normalized tool routing so canvas tabs are the primary workspace surface
- updated sidebar, command palette, status bar, onboarding, and jump actions to use the canvas tool path

### Browser
- simplified Browser into a compact workspace
- default target is `https://www.daemonide.tech/`
- tracked apps are prioritized over noisy local discovery
- inspect mode auto-copies selectors and toasts success
- fixed Browser tab activation/focus behavior

### Wallet
- rewrote wallet IA around real user jobs:
  - `Overview`
  - `Holdings`
  - `Move`
  - `Manage`
  - `History`
- made copy/export/default/assignment flows easier to reach
- added direct holdings actions like sell/swap and copy mint
- kept infra/settings separate from wallet management

### Solana and Token Launch
- reworked Solana into task-oriented workflow surfaces
- flattened Token Launch into a more guided sequential flow
- tightened layout behavior for drawer/fullscreen widths
- improved protocol-pack presentation

### Env / Email / Git / supporting panels
- brought these tools closer to the same canvas-native workflow model
- removed oversized or unnecessary workspace chrome where it hurt clarity

### Utility surfaces
- redesigned `Ports`, `Processes`, `Sessions`, `Hackathon`, and `Settings` as summary-first canvas panels
- added real release/app metadata into Settings
- made Settings land on `Setup` by default
- improved Hackathon action hierarchy

## Safety / trust fixes
- filtered dangerous ghost-process actions in Ports
- deduped tracked port endpoints
- fixed misleading `Sessions` active counts so stale terminal-closed sessions do not overstate live activity

## Validation
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run test:journeys`

## Notes
This is intended as the new UX baseline for DAEMON’s shell/workspace model, not a final visual polish pass on every panel.
