### PR TITLE
Restore Daemon Pro workspace

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3'
-import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24 } from './schema'
+import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25 } from './schema'
 
 export function runMigrations(db: Database.Database) {
   db.exec(`
@@ -263,6 +263,19 @@ export function runMigrations(db: Database.Database) {
         }
       }
       db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(24)
+    })()
+  }
+
+  if (currentVersion < 25) {
+    db.transaction(() => {
+      const stmts = SCHEMA_V25.split(';').map((s) => s.trim()).filter(Boolean)
+      for (const stmt of stmts) {
+        try { db.exec(stmt) } catch (err) {
+          const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
+          if (!msg.includes('already exists')) throw err
+        }
+      }
+      db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(25)
     })()
   }
 

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -540,3 +540,15 @@ CREATE TABLE IF NOT EXISTS launched_tokens (
 CREATE INDEX IF NOT EXISTS idx_launched_tokens_wallet ON launched_tokens(wallet_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_launched_tokens_mint ON launched_tokens(mint);
 `
+
+export const SCHEMA_V25 = `
+CREATE TABLE IF NOT EXISTS pro_state (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  wallet_id TEXT,
+  wallet_address TEXT,
+  expires_at INTEGER,
+  features TEXT,
+  tier TEXT,
+  updated_at INTEGER NOT NULL
+);
+`

--- a/electron/ipc/pro.ts
+++ b/electron/ipc/pro.ts
@@ -1,0 +1,74 @@
+import { ipcMain } from 'electron'
+import * as ProService from '../services/ProService'
+import { ipcHandler } from '../services/IpcHandlerFactory'
+import type { ArenaSubmissionInput } from '../shared/types'
+
+export function registerProHandlers() {
+  ipcMain.handle('pro:status', ipcHandler(async () => {
+    return ProService.getLocalSubscriptionState()
+  }))
+
+  ipcMain.handle('pro:refresh-status', ipcHandler(async (_event, walletAddress: string) => {
+    if (!walletAddress || typeof walletAddress !== 'string') throw new Error('walletAddress required')
+    return ProService.refreshStatusFromServer(walletAddress)
+  }))
+
+  ipcMain.handle('pro:fetch-price', ipcHandler(async () => {
+    return ProService.fetchPrice()
+  }))
+
+  ipcMain.handle('pro:subscribe', ipcHandler(async (_event, walletId: string) => {
+    if (!walletId || typeof walletId !== 'string') throw new Error('walletId required')
+    return ProService.subscribe(walletId)
+  }))
+
+  ipcMain.handle('pro:claim-holder-access', ipcHandler(async (_event, walletId: string) => {
+    if (!walletId || typeof walletId !== 'string') throw new Error('walletId required')
+    return ProService.claimHolderAccess(walletId)
+  }))
+
+  ipcMain.handle('pro:sign-out', ipcHandler(async () => {
+    ProService.signOut()
+  }))
+
+  ipcMain.handle('pro:arena-list', ipcHandler(async () => {
+    return ProService.listArenaSubmissions()
+  }))
+
+  ipcMain.handle('pro:arena-submit', ipcHandler(async (_event, input: ArenaSubmissionInput) => {
+    if (!input || typeof input !== 'object') throw new Error('Invalid submission input')
+    return ProService.submitToArena(input)
+  }))
+
+  ipcMain.handle('pro:arena-vote', ipcHandler(async (_event, submissionId: string) => {
+    if (!submissionId || typeof submissionId !== 'string') throw new Error('submissionId required')
+    await ProService.voteArenaSubmission(submissionId)
+  }))
+
+  ipcMain.handle('pro:skills-manifest', ipcHandler(async () => {
+    return ProService.fetchProSkillsManifest()
+  }))
+
+  ipcMain.handle('pro:skills-sync', ipcHandler(async () => {
+    return ProService.syncAllProSkills()
+  }))
+
+  ipcMain.handle('pro:skills-download', ipcHandler(async (_event, skillId: string) => {
+    if (!skillId || typeof skillId !== 'string') throw new Error('skillId required')
+    return ProService.downloadProSkill(skillId)
+  }))
+
+  ipcMain.handle('pro:quota', ipcHandler(async () => {
+    return ProService.getPriorityApiQuota()
+  }))
+
+  ipcMain.handle('pro:mcp-push', ipcHandler(async () => {
+    const count = await ProService.pushLocalClaudeConfig()
+    return { count }
+  }))
+
+  ipcMain.handle('pro:mcp-pull', ipcHandler(async () => {
+    const count = await ProService.pullMcpConfigToLocal()
+    return { count }
+  }))
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -19,6 +19,7 @@ import { registerProcessHandlers } from '../ipc/processes'
 import { registerEnvHandlers } from '../ipc/env'
 import { registerPortHandlers } from '../ipc/ports'
 import { registerWalletHandlers } from '../ipc/wallet'
+import { registerProHandlers } from '../ipc/pro'
 import { registerSettingsHandlers } from '../ipc/settings'
 import { registerPluginHandlers } from '../ipc/plugins'
 import { registerTweetHandlers } from '../ipc/tweets'
@@ -134,6 +135,7 @@ function registerAllIpc() {
   registerEnvHandlers()
   registerPortHandlers()
   registerWalletHandlers()
+  registerProHandlers()
   registerSettingsHandlers()
   registerPluginHandlers()
   registerTweetHandlers()

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -228,6 +228,24 @@ contextBridge.exposeInMainWorld('daemon', {
     exportPrivateKey: (walletId: string) => ipcRenderer.invoke('wallet:export-private-key', walletId),
   },
 
+  pro: {
+    status: () => ipcRenderer.invoke('pro:status'),
+    refreshStatus: (walletAddress: string) => ipcRenderer.invoke('pro:refresh-status', walletAddress),
+    fetchPrice: () => ipcRenderer.invoke('pro:fetch-price'),
+    subscribe: (walletId: string) => ipcRenderer.invoke('pro:subscribe', walletId),
+    claimHolderAccess: (walletId: string) => ipcRenderer.invoke('pro:claim-holder-access', walletId),
+    signOut: () => ipcRenderer.invoke('pro:sign-out'),
+    arenaList: () => ipcRenderer.invoke('pro:arena-list'),
+    arenaSubmit: (input: unknown) => ipcRenderer.invoke('pro:arena-submit', input),
+    arenaVote: (submissionId: string) => ipcRenderer.invoke('pro:arena-vote', submissionId),
+    skillsManifest: () => ipcRenderer.invoke('pro:skills-manifest'),
+    skillsSync: () => ipcRenderer.invoke('pro:skills-sync'),
+    skillsDownload: (skillId: string) => ipcRenderer.invoke('pro:skills-download', skillId),
+    quota: () => ipcRenderer.invoke('pro:quota'),
+    mcpPush: () => ipcRenderer.invoke('pro:mcp-push'),
+    mcpPull: () => ipcRenderer.invoke('pro:mcp-pull'),
+  },
+
   pnl: {
     syncHistory: (walletAddress?: string) => ipcRenderer.invoke('pnl:sync-history', walletAddress),
     getPortfolio: (walletAddress: string, holdings: Array<{ mint: string; symbol: string; name: string; amount: number; logoUri: string | null }>) => ipcRenderer.invoke('pnl:get-portfolio', walletAddress, holdings),

--- a/electron/services/ProService.ts
+++ b/electron/services/ProService.ts
@@ -1,0 +1,586 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { app } from 'electron'
+import bs58 from 'bs58'
+import nacl from 'tweetnacl'
+import { getDb } from '../db/db'
+import type {
+  ArenaSubmission,
+  ArenaSubmissionInput,
+  ProFeature,
+  ProPriceInfo,
+  ProSkillManifest,
+  ProSubscriptionState,
+} from '../shared/types'
+import * as SecureKey from './SecureKeyService'
+import { withKeypair } from './SolanaService'
+
+const DEFAULT_PRO_API_BASE =
+  process.env.NODE_ENV === 'production'
+    ? 'https://daemon-pro-api-production.up.railway.app'
+    : 'http://127.0.0.1:4021'
+
+const DAEMON_PRO_API_BASE = process.env.DAEMON_PRO_API_BASE ?? DEFAULT_PRO_API_BASE
+const DEV_BYPASS_ENABLED =
+  process.env.NODE_ENV !== 'production' && process.env.DAEMON_PRO_DEV_BYPASS === '1'
+const DEV_BYPASS_FEATURES: ProFeature[] = ['arena', 'pro-skills', 'mcp-sync', 'priority-api']
+const DEV_BYPASS_PRICE: ProPriceInfo = {
+  priceUsdc: 5,
+  durationDays: 30,
+  network: 'solana:mainnet',
+  payTo: 'GNVxk3sn4iJ2iUaqEUskWQ1KNy9Mmcee3WF3AMtRjN7W',
+  holderMint: '4vpf4qNtNVkvz2dm5qL2mT6jBXH9gDY8qH2QsHN5pump',
+  holderMinAmount: 1_000_000,
+}
+const JWT_KEY = 'daemon_pro_jwt'
+
+const EMPTY_HOLDER_STATUS: ProSubscriptionState['holderStatus'] = {
+  enabled: false,
+  eligible: false,
+  mint: null,
+  minAmount: null,
+  currentAmount: null,
+  symbol: 'DAEMON',
+}
+
+function devBypassState(overrides: Partial<ProSubscriptionState> = {}): ProSubscriptionState {
+  const expiresAt = Date.now() + DEV_BYPASS_PRICE.durationDays * 24 * 60 * 60 * 1000
+  return {
+    active: true,
+    walletId: null,
+    walletAddress: null,
+    expiresAt,
+    features: DEV_BYPASS_FEATURES,
+    tier: 'pro',
+    accessSource: 'holder',
+    holderStatus: {
+      enabled: true,
+      eligible: true,
+      mint: DEV_BYPASS_PRICE.holderMint ?? null,
+      minAmount: DEV_BYPASS_PRICE.holderMinAmount ?? null,
+      currentAmount: DEV_BYPASS_PRICE.holderMinAmount ?? null,
+      symbol: 'DAEMON',
+    },
+    priceUsdc: DEV_BYPASS_PRICE.priceUsdc,
+    durationDays: DEV_BYPASS_PRICE.durationDays,
+    ...overrides,
+  }
+}
+
+function getLocalRow() {
+  const row = getDb()
+    .prepare('SELECT wallet_id, wallet_address, expires_at, features, tier FROM pro_state WHERE id = 1')
+    .get() as
+    | {
+        wallet_id: string | null
+        wallet_address: string | null
+        expires_at: number | null
+        features: string | null
+        tier: string | null
+      }
+    | undefined
+  return row ?? null
+}
+
+function writeLocalProState(params: {
+  walletId: string | null
+  walletAddress: string | null
+  expiresAt: number | null
+  features: ProFeature[]
+  tier: 'pro' | null
+}) {
+  getDb()
+    .prepare(`
+      INSERT INTO pro_state (id, wallet_id, wallet_address, expires_at, features, tier, updated_at)
+      VALUES (1, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        wallet_id = excluded.wallet_id,
+        wallet_address = excluded.wallet_address,
+        expires_at = excluded.expires_at,
+        features = excluded.features,
+        tier = excluded.tier,
+        updated_at = excluded.updated_at
+    `)
+    .run(
+      params.walletId,
+      params.walletAddress,
+      params.expiresAt,
+      JSON.stringify(params.features),
+      params.tier,
+      Date.now(),
+    )
+}
+
+function clearLocalProState() {
+  getDb().prepare('DELETE FROM pro_state WHERE id = 1').run()
+  try {
+    SecureKey.deleteKey(JWT_KEY)
+  } catch {
+    // no-op
+  }
+}
+
+export function getLocalSubscriptionState(): ProSubscriptionState {
+  if (DEV_BYPASS_ENABLED) {
+    const row = getLocalRow()
+    if (!row) return devBypassState()
+    return devBypassState({
+      walletId: row.wallet_id,
+      walletAddress: row.wallet_address,
+      expiresAt: row.expires_at,
+      features: row.features ? (JSON.parse(row.features) as ProFeature[]) : DEV_BYPASS_FEATURES,
+      tier: (row.tier as 'pro' | null) ?? 'pro',
+    })
+  }
+
+  const row = getLocalRow()
+  if (!row) {
+    return {
+      active: false,
+      walletId: null,
+      walletAddress: null,
+      expiresAt: null,
+      features: [],
+      tier: null,
+      accessSource: null,
+      holderStatus: EMPTY_HOLDER_STATUS,
+      priceUsdc: null,
+      durationDays: null,
+    }
+  }
+
+  const active = row.expires_at !== null && row.expires_at > Date.now()
+  return {
+    active,
+    walletId: row.wallet_id,
+    walletAddress: row.wallet_address,
+    expiresAt: row.expires_at,
+    features: active && row.features ? (JSON.parse(row.features) as ProFeature[]) : [],
+    tier: active ? (row.tier as 'pro' | null) : null,
+    accessSource: active ? 'payment' : null,
+    holderStatus: EMPTY_HOLDER_STATUS,
+    priceUsdc: null,
+    durationDays: null,
+  }
+}
+
+class ProApiError extends Error {
+  status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+  }
+}
+
+function authHeaders(): Record<string, string> {
+  const jwt = SecureKey.getKey(JWT_KEY)
+  if (!jwt) throw new ProApiError(401, 'Not subscribed to Daemon Pro')
+  return { Authorization: `Bearer ${jwt}` }
+}
+
+async function proFetch<T>(pathSuffix: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${DAEMON_PRO_API_BASE}${pathSuffix}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  })
+
+  type ApiBody = { ok?: boolean; data?: T; error?: string }
+  let body: ApiBody | null = null
+  try {
+    body = (await response.json()) as ApiBody
+  } catch {
+    body = null
+  }
+
+  if (!response.ok) {
+    throw new ProApiError(response.status, body?.error ?? `HTTP ${response.status}`)
+  }
+  if (body && body.ok === false) {
+    throw new ProApiError(response.status, body.error ?? 'API error')
+  }
+
+  return (body?.data ?? body) as T
+}
+
+export async function fetchPrice(): Promise<ProPriceInfo> {
+  if (DEV_BYPASS_ENABLED) return DEV_BYPASS_PRICE
+  return proFetch<ProPriceInfo>('/v1/subscribe/price')
+}
+
+export async function refreshStatusFromServer(walletAddress: string): Promise<ProSubscriptionState> {
+  if (DEV_BYPASS_ENABLED) {
+    const row = getLocalRow()
+    writeLocalProState({
+      walletId: row?.wallet_id ?? null,
+      walletAddress,
+      expiresAt: row?.expires_at ?? Date.now() + DEV_BYPASS_PRICE.durationDays * 24 * 60 * 60 * 1000,
+      features: row?.features ? (JSON.parse(row.features) as ProFeature[]) : DEV_BYPASS_FEATURES,
+      tier: 'pro',
+    })
+    return getLocalSubscriptionState()
+  }
+
+  const data = await proFetch<{
+    active: boolean
+    expiresAt: number | null
+    features: ProFeature[]
+    tier: 'pro' | null
+    accessSource: 'payment' | 'holder' | null
+    holderStatus: ProSubscriptionState['holderStatus']
+  }>(`/v1/subscribe/status?wallet=${encodeURIComponent(walletAddress)}`)
+
+  const row = getLocalRow()
+  writeLocalProState({
+    walletId: row?.wallet_id ?? null,
+    walletAddress,
+    expiresAt: data.expiresAt,
+    features: data.features,
+    tier: data.tier,
+  })
+
+  return {
+    ...getLocalSubscriptionState(),
+    accessSource: data.accessSource,
+    holderStatus: data.holderStatus,
+  }
+}
+
+export async function subscribe(walletId: string): Promise<{ state: ProSubscriptionState; price: ProPriceInfo }> {
+  if (DEV_BYPASS_ENABLED) {
+    const price = await fetchPrice()
+    const walletAddress = await withKeypair(walletId, async (keypair) => keypair.publicKey.toBase58())
+    writeLocalProState({
+      walletId,
+      walletAddress,
+      expiresAt: Date.now() + price.durationDays * 24 * 60 * 60 * 1000,
+      features: DEV_BYPASS_FEATURES,
+      tier: 'pro',
+    })
+    return { state: getLocalSubscriptionState(), price }
+  }
+
+  const price = await fetchPrice()
+  const challengeRes = await fetch(`${DAEMON_PRO_API_BASE}/v1/subscribe`, { method: 'POST' })
+  if (challengeRes.status !== 402) {
+    throw new ProApiError(challengeRes.status, `Expected 402 Payment Required, got ${challengeRes.status}`)
+  }
+
+  const { walletAddress, paymentHeader } = await withKeypair(walletId, async (keypair) => {
+    const walletAddress = keypair.publicKey.toBase58()
+    const nonce = crypto.randomUUID()
+    const amount = String(Math.round(price.priceUsdc * 1_000_000))
+    const digest = Buffer.from(`${walletAddress}|${nonce}|${amount}|${price.network}|${price.payTo}`, 'utf8')
+    const signature = crypto.createHash('sha256').update(digest).update(keypair.secretKey).digest()
+    return {
+      walletAddress,
+      paymentHeader: Buffer.from(
+        JSON.stringify({
+          wallet: walletAddress,
+          signature: bs58.encode(signature),
+          nonce,
+          amount,
+          network: price.network,
+        }),
+        'utf8',
+      ).toString('base64url'),
+    }
+  })
+
+  const paidRes = await fetch(`${DAEMON_PRO_API_BASE}/v1/subscribe`, {
+    method: 'POST',
+    headers: { 'X-Payment': paymentHeader },
+  })
+  if (!paidRes.ok) {
+    const errBody = await paidRes.json().catch(() => ({ error: `HTTP ${paidRes.status}` })) as { error?: string }
+    throw new ProApiError(paidRes.status, errBody.error ?? 'Subscribe failed')
+  }
+
+  const body = await paidRes.json() as {
+    ok: boolean
+    jwt: string
+    expiresAt: number
+    features: ProFeature[]
+    tier: 'pro'
+  }
+  if (!body.ok || !body.jwt) throw new ProApiError(500, 'Server returned malformed subscribe response')
+
+  SecureKey.storeKey(JWT_KEY, body.jwt)
+  writeLocalProState({
+    walletId,
+    walletAddress,
+    expiresAt: body.expiresAt,
+    features: body.features,
+    tier: body.tier,
+  })
+
+  return { state: getLocalSubscriptionState(), price }
+}
+
+export async function claimHolderAccess(walletId: string): Promise<{ state: ProSubscriptionState }> {
+  if (DEV_BYPASS_ENABLED) {
+    const walletAddress = await withKeypair(walletId, async (keypair) => keypair.publicKey.toBase58())
+    writeLocalProState({
+      walletId,
+      walletAddress,
+      expiresAt: Date.now() + 12 * 60 * 60 * 1000,
+      features: DEV_BYPASS_FEATURES,
+      tier: 'pro',
+    })
+    return { state: devBypassState({ walletId, walletAddress }) }
+  }
+
+  const { walletAddress, challenge, signature } = await withKeypair(walletId, async (keypair) => {
+    const walletAddress = keypair.publicKey.toBase58()
+    const challenge = await proFetch<{
+      nonce: string
+      message: string
+      holderStatus: ProSubscriptionState['holderStatus']
+    }>('/v1/subscribe/holder/challenge', {
+      method: 'POST',
+      body: JSON.stringify({ wallet: walletAddress }),
+    })
+    const messageBytes = Buffer.from(challenge.message, 'utf8')
+    return {
+      walletAddress,
+      challenge,
+      signature: bs58.encode(nacl.sign.detached(messageBytes, keypair.secretKey)),
+    }
+  })
+
+  const body = await proFetch<{
+    jwt: string
+    expiresAt: number
+    features: ProFeature[]
+    tier: 'pro'
+  }>('/v1/subscribe/holder/claim', {
+    method: 'POST',
+    body: JSON.stringify({
+      wallet: walletAddress,
+      nonce: challenge.nonce,
+      signature,
+    }),
+  })
+
+  SecureKey.storeKey(JWT_KEY, body.jwt)
+  writeLocalProState({
+    walletId,
+    walletAddress,
+    expiresAt: body.expiresAt,
+    features: body.features,
+    tier: body.tier,
+  })
+
+  return {
+    state: {
+      ...getLocalSubscriptionState(),
+      accessSource: 'holder',
+      holderStatus: challenge.holderStatus,
+    },
+  }
+}
+
+export function signOut(): void {
+  clearLocalProState()
+}
+
+function devArenaFilePath(): string {
+  return path.join(app?.getPath?.('userData') ?? os.homedir(), 'daemon-pro-dev-arena.json')
+}
+
+function readDevArenaSubmissions(): ArenaSubmission[] {
+  const filePath = devArenaFilePath()
+  if (!fs.existsSync(filePath)) {
+    const seed: ArenaSubmission[] = [
+      {
+        id: 'arena-seed-1',
+        title: 'Discord research copilot',
+        pitch: 'Turns winning research threads into concrete DAEMON tasks.',
+        author: { handle: 'daemon', wallet: 'dev-wallet' },
+        description: 'Cross-posts high-signal research into Discord and turns winning threads into actionable DAEMON tasks.',
+        category: 'agent',
+        themeWeek: 'spring-build',
+        submittedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+        status: 'featured',
+        votes: 9,
+        githubUrl: 'https://github.com/daemon/example-discord-copilot',
+        demoUrl: 'https://example.com/discord-copilot-demo',
+        xHandle: 'daemon',
+        discordHandle: 'daemonteam',
+        contestSlug: 'build-week-01',
+      },
+    ]
+    fs.writeFileSync(filePath, JSON.stringify(seed, null, 2), 'utf8')
+    return seed
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as ArenaSubmission[]
+  } catch {
+    return []
+  }
+}
+
+function writeDevArenaSubmissions(submissions: ArenaSubmission[]) {
+  fs.writeFileSync(devArenaFilePath(), JSON.stringify(submissions, null, 2), 'utf8')
+}
+
+export async function listArenaSubmissions(): Promise<ArenaSubmission[]> {
+  if (DEV_BYPASS_ENABLED) return readDevArenaSubmissions()
+  return proFetch<ArenaSubmission[]>('/v1/arena/submissions', { headers: authHeaders() })
+}
+
+export async function submitToArena(input: ArenaSubmissionInput): Promise<{ id: string }> {
+  if (DEV_BYPASS_ENABLED) {
+    const next: ArenaSubmission = {
+      id: crypto.randomUUID(),
+      title: input.title.trim(),
+      pitch: input.pitch.trim(),
+      author: { handle: 'you', wallet: getLocalRow()?.wallet_address ?? 'dev-wallet' },
+      description: input.description.trim(),
+      category: input.category,
+      themeWeek: 'spring-build',
+      submittedAt: Date.now(),
+      status: 'submitted',
+      votes: 0,
+      githubUrl: input.githubUrl.trim(),
+      demoUrl: input.demoUrl?.trim() || undefined,
+      xHandle: input.xHandle?.trim().replace(/^@/, '') || undefined,
+      discordHandle: input.discordHandle?.trim() || undefined,
+      contestSlug: 'build-week-01',
+    }
+    writeDevArenaSubmissions([next, ...readDevArenaSubmissions()])
+    return { id: next.id }
+  }
+
+  return proFetch<{ id: string }>('/v1/arena/submit', {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(input),
+  })
+}
+
+export async function voteArenaSubmission(submissionId: string): Promise<void> {
+  if (DEV_BYPASS_ENABLED) {
+    const submissions = readDevArenaSubmissions()
+    const index = submissions.findIndex((submission) => submission.id === submissionId)
+    if (index >= 0) {
+      submissions[index] = { ...submissions[index], votes: submissions[index].votes + 1 }
+      writeDevArenaSubmissions(submissions)
+    }
+    return
+  }
+
+  await proFetch<{ voted: true }>(`/v1/arena/vote/${encodeURIComponent(submissionId)}`, {
+    method: 'POST',
+    headers: authHeaders(),
+  })
+}
+
+function proSkillsLocalDir(): string {
+  return path.join(app?.getPath?.('userData') ?? os.homedir(), 'daemon-pro-skills')
+}
+
+export async function fetchProSkillsManifest(): Promise<ProSkillManifest> {
+  if (DEV_BYPASS_ENABLED) return { version: 1, skills: [] }
+  return proFetch<ProSkillManifest>('/v1/pro-skills/manifest', { headers: authHeaders() })
+}
+
+export async function downloadProSkill(skillId: string): Promise<{ fileCount: number; path: string }> {
+  if (!/^[a-zA-Z0-9_-]+$/.test(skillId)) throw new Error('Invalid skill id')
+  if (DEV_BYPASS_ENABLED) {
+    const targetDir = path.join(proSkillsLocalDir(), skillId)
+    fs.mkdirSync(targetDir, { recursive: true })
+    return { fileCount: 0, path: targetDir }
+  }
+
+  const data = await proFetch<{
+    skillId: string
+    files: Array<{ path: string; sha256: string; content: string }>
+  }>(`/v1/pro-skills/${skillId}/files`, { headers: authHeaders() })
+
+  const targetDir = path.join(proSkillsLocalDir(), skillId)
+  fs.mkdirSync(targetDir, { recursive: true })
+  for (const file of data.files) {
+    const absolutePath = path.resolve(targetDir, file.path)
+    if (!absolutePath.startsWith(targetDir + path.sep) && absolutePath !== targetDir) {
+      throw new Error(`Rejected unsafe file path: ${file.path}`)
+    }
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+    fs.writeFileSync(absolutePath, Buffer.from(file.content, 'base64'))
+  }
+
+  return { fileCount: data.files.length, path: targetDir }
+}
+
+export async function syncAllProSkills(): Promise<{ installed: string[]; skipped: string[] }> {
+  const manifest = await fetchProSkillsManifest()
+  const installed: string[] = []
+  const skipped: string[] = []
+
+  for (const skill of manifest.skills) {
+    const shaFile = path.join(proSkillsLocalDir(), skill.id, '.sha')
+    const currentSha = fs.existsSync(shaFile) ? fs.readFileSync(shaFile, 'utf8').trim() : null
+    if (currentSha === skill.sha256) {
+      skipped.push(skill.id)
+      continue
+    }
+    await downloadProSkill(skill.id)
+    fs.mkdirSync(path.join(proSkillsLocalDir(), skill.id), { recursive: true })
+    fs.writeFileSync(shaFile, skill.sha256)
+    installed.push(skill.id)
+  }
+
+  return { installed, skipped }
+}
+
+export async function getPriorityApiQuota(): Promise<{ quota: number; used: number; remaining: number }> {
+  if (DEV_BYPASS_ENABLED) return { quota: 500, used: 0, remaining: 500 }
+  return proFetch<{ quota: number; used: number; remaining: number }>('/v1/priority/quota', {
+    headers: authHeaders(),
+  })
+}
+
+export async function pushLocalClaudeConfig(): Promise<number> {
+  if (DEV_BYPASS_ENABLED) return 0
+  const claudeJsonPath = path.join(os.homedir(), '.claude.json')
+  if (!fs.existsSync(claudeJsonPath)) return 0
+  const json = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')) as {
+    mcpServers?: Record<string, { command: string; args: string[]; env?: Record<string, string> }>
+  }
+  const mcpServers = json.mcpServers ?? {}
+  await proFetch<{ updatedAt: number }>('/v1/sync/mcp', {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ version: 1, updatedAt: Date.now(), mcpServers }),
+  })
+  return Object.keys(mcpServers).length
+}
+
+export async function pullMcpConfigToLocal(): Promise<number> {
+  if (DEV_BYPASS_ENABLED) return 0
+  const remote = await proFetch<{
+    version: 1
+    updatedAt: number
+    mcpServers: Record<string, { command: string; args: string[]; env?: Record<string, string> }>
+  } | null>('/v1/sync/mcp', { headers: authHeaders() })
+  if (!remote) return 0
+
+  const claudeJsonPath = path.join(os.homedir(), '.claude.json')
+  let current: Record<string, unknown> = {}
+  if (fs.existsSync(claudeJsonPath)) {
+    try {
+      current = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'))
+    } catch {
+      current = {}
+    }
+  }
+  current.mcpServers = remote.mcpServers
+  fs.writeFileSync(claudeJsonPath, JSON.stringify(current, null, 2), 'utf8')
+  return Object.keys(remote.mcpServers).length
+}

--- a/electron/services/SettingsService.ts
+++ b/electron/services/SettingsService.ts
@@ -92,7 +92,8 @@ export function setOnboardingProgress(progress: OnboardingProgress): void {
   setJsonSetting('onboarding_progress', progress)
 }
 
-const DEFAULT_PINNED_TOOLS = ['git', 'browser', 'token-launch', 'solana-toolbox']
+const DEFAULT_PINNED_TOOLS = ['git', 'browser', 'token-launch', 'solana-toolbox', 'pro']
+const PRO_PIN_MIGRATION_KEY = 'pinned_tools_pro_default_added'
 const UI_RECOVERY_KEYS = [
   'layout_center_mode',
   'layout_right_panel_tab',
@@ -146,7 +147,13 @@ export function setWorkspaceProfile(profile: WorkspaceProfile): void {
 }
 
 export function getPinnedTools(): string[] {
-  return sanitizePinnedTools(getJsonSetting<unknown>('pinned_tools', DEFAULT_PINNED_TOOLS))
+  const pinnedTools = sanitizePinnedTools(getJsonSetting<unknown>('pinned_tools', DEFAULT_PINNED_TOOLS))
+  if (getBooleanSetting(PRO_PIN_MIGRATION_KEY, false)) return pinnedTools
+
+  const migratedTools = pinnedTools.includes('pro') ? pinnedTools : [...pinnedTools, 'pro']
+  setJsonSetting('pinned_tools', migratedTools)
+  setBooleanSetting(PRO_PIN_MIGRATION_KEY, true)
+  return migratedTools
 }
 
 export function setPinnedTools(tools: string[]): void {

--- a/electron/shared/types.ts
+++ b/electron/shared/types.ts
@@ -201,6 +201,88 @@ export interface GhostPort {
   processName: string | null
 }
 
+// --- Daemon Pro ---
+
+export type ProFeature = 'arena' | 'pro-skills' | 'mcp-sync' | 'priority-api'
+export type ProAccessSource = 'payment' | 'holder'
+
+export interface ProHolderStatus {
+  enabled: boolean
+  eligible: boolean
+  mint: string | null
+  minAmount: number | null
+  currentAmount: number | null
+  symbol: string
+}
+
+export interface ProSubscriptionState {
+  active: boolean
+  walletId: string | null
+  walletAddress: string | null
+  expiresAt: number | null
+  features: ProFeature[]
+  tier: 'pro' | null
+  accessSource: ProAccessSource | null
+  holderStatus: ProHolderStatus
+  priceUsdc: number | null
+  durationDays: number | null
+}
+
+export interface ProPriceInfo {
+  priceUsdc: number
+  durationDays: number
+  network: string
+  payTo: string
+  holderMint?: string
+  holderMinAmount?: number
+}
+
+export interface ArenaSubmission {
+  id: string
+  title: string
+  pitch: string
+  author: {
+    handle: string
+    wallet: string
+  }
+  description: string
+  category: 'tool' | 'agent' | 'skill' | 'mcp' | 'grind-recipe'
+  themeWeek: string | null
+  submittedAt: number
+  status: 'submitted' | 'featured' | 'winner' | 'shipped'
+  votes: number
+  githubUrl?: string
+  demoUrl?: string
+  xHandle?: string
+  discordHandle?: string
+  contestSlug?: string
+}
+
+export interface ArenaSubmissionInput {
+  title: string
+  pitch: string
+  description: string
+  category: ArenaSubmission['category']
+  githubUrl: string
+  demoUrl?: string
+  xHandle?: string
+  discordHandle?: string
+}
+
+export interface ProSkillManifestEntry {
+  id: string
+  name: string
+  version: string
+  description: string
+  downloadUrl: string
+  sha256: string
+}
+
+export interface ProSkillManifest {
+  version: 1
+  skills: ProSkillManifestEntry[]
+}
+
 // --- MCP ---
 
 export interface McpEntry {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "pidusage": "^4.0.1",
     "ps-list": "^8.1.1",
     "simple-git": "^3.27.0",
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.6.1",
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@electron/notarize": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
     devDependencies:
       '@electron/notarize':
         specifier: ^2.2.1

--- a/src/components/CommandDrawer/CommandDrawer.tsx
+++ b/src/components/CommandDrawer/CommandDrawer.tsx
@@ -158,6 +158,13 @@ function TokenLaunchIcon({ size = 18 }: { size?: number }) {
     </svg>
   )
 }
+function ProIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3l2.9 5.88 6.49.95-4.7 4.58 1.11 6.47L12 17.77l-5.8 3.06 1.11-6.47-4.7-4.58 6.49-.95L12 3z" />
+    </svg>
+  )
+}
 
 // Icon lookup for pinned sidebar tools
 export const TOOL_ICONS: Record<string, ComponentType<{ size?: number }>> = {
@@ -166,7 +173,7 @@ export const TOOL_ICONS: Record<string, ComponentType<{ size?: number }>> = {
   ports: PortsIcon, processes: ProcessIcon, settings: SettingsIcon,
   'image-editor': PaintIcon, 'solana-toolbox': SolanaIcon, 'block-scanner': ScannerIcon, docs: DocsIcon, starter: StarterIcon,
   'token-launch': TokenLaunchIcon,
-  dashboard: DashboardIcon, sessions: SessionsIcon, hackathon: HackathonIcon, plugins: PluginsIcon, recovery: RecoveryIcon,
+  dashboard: DashboardIcon, sessions: SessionsIcon, hackathon: HackathonIcon, plugins: PluginsIcon, recovery: RecoveryIcon, pro: ProIcon,
 }
 
 // Tool name lookup
@@ -176,7 +183,7 @@ export const TOOL_NAMES: Record<string, string> = {
   ports: 'Ports', processes: 'Processes', settings: 'Settings',
   'image-editor': 'Image Editor', 'solana-toolbox': 'Solana', 'block-scanner': 'Block Scanner', docs: 'Docs', starter: 'New Project',
   'token-launch': 'Token Launch',
-  dashboard: 'Dashboard', sessions: 'Sessions', hackathon: 'Hackathon', plugins: 'Plugins', recovery: 'Recovery',
+  dashboard: 'Dashboard', sessions: 'Sessions', hackathon: 'Hackathon', plugins: 'Plugins', recovery: 'Recovery', pro: 'Daemon Pro',
 }
 
 // Lazy-load all tool components
@@ -199,6 +206,7 @@ const loadSessionHistory = () => import('../../panels/SessionRegistry/SessionHis
 const loadHackathonPanel = () => import('../../panels/Colosseum/HackathonPanel')
 const loadPluginManager = () => import('../../panels/PluginManager/PluginManager')
 const loadRecoveryPanel = () => import('../../panels/RecoveryPanel/RecoveryPanel')
+const loadProPanel = () => import('../../panels/ProPanel/ProPanel')
 
 const GitPanel = lazyNamedWithReload('git-panel', loadGitPanel, (m) => m.GitPanel)
 const EnvManager = lazyNamedWithReload('env-manager', loadEnvManager, (m) => m.EnvManager)
@@ -219,6 +227,7 @@ const SessionHistory = lazyNamedWithReload('session-history', loadSessionHistory
 const HackathonPanel = lazyNamedWithReload('hackathon-panel', loadHackathonPanel, (m) => m.HackathonPanel)
 const PluginManager = lazyNamedWithReload('plugin-manager', loadPluginManager, (m) => m.PluginManager)
 const RecoveryPanel = lazyNamedWithReload('recovery-panel', loadRecoveryPanel, (m) => m.RecoveryPanel)
+const ProPanel = lazyNamedWithReload('pro-panel', loadProPanel, (m) => m.ProPanel)
 
 // Per-tool accent colors for the drawer grid and sidebar
 export const TOOL_COLORS: Record<string, string> = {
@@ -236,6 +245,7 @@ export const TOOL_COLORS: Record<string, string> = {
   'token-launch': '#38d39f',
   'block-scanner': '#38bdf8',
   docs: '#94a3b8',
+  pro: '#ffd700',
 }
 
 // Built-in tools registry — exported so other modules can enumerate all tool IDs
@@ -258,6 +268,7 @@ export const BUILTIN_TOOLS: DrawerTool[] = [
   { id: 'dashboard', name: 'Dashboard', description: 'Market data and watchlist', icon: DashboardIcon, component: DashboardCanvas, preload: () => { void loadDashboardCanvas() }, category: 'crypto' },
   { id: 'sessions', name: 'Sessions', description: 'Agent session history', icon: SessionsIcon, component: SessionHistory, preload: () => { void loadSessionHistory() }, category: 'dev' },
   { id: 'hackathon', name: 'Hackathon', description: 'Colosseum tracker', icon: HackathonIcon, component: HackathonPanel, preload: () => { void loadHackathonPanel() }, category: 'crypto' },
+  { id: 'pro', name: 'Daemon Pro', description: 'Arena, Pro skills, MCP sync, and priority API', icon: ProIcon, component: ProPanel, preload: () => { void loadProPanel() }, category: 'crypto' },
   { id: 'plugins', name: 'Plugins', description: 'Manage plugins', icon: PluginsIcon, component: PluginManager, preload: () => { void loadPluginManager() }, category: 'system' },
   { id: 'recovery', name: 'Recovery', description: 'Crash recovery and snapshots', icon: RecoveryIcon, component: RecoveryPanel, preload: () => { void loadRecoveryPanel() }, category: 'system' },
 ]

--- a/src/constants/toolIds.ts
+++ b/src/constants/toolIds.ts
@@ -5,5 +5,5 @@ export const BUILTIN_TOOL_IDS: string[] = [
   'starter', 'git', 'deploy', 'env', 'wallet', 'email',
   'ports', 'processes', 'settings', 'image-editor',
   'token-launch', 'solana-toolbox', 'block-scanner', 'docs', 'dashboard',
-  'sessions', 'hackathon', 'plugins', 'recovery',
+  'sessions', 'hackathon', 'pro', 'plugins', 'recovery',
 ]

--- a/src/constants/workspaceProfiles.ts
+++ b/src/constants/workspaceProfiles.ts
@@ -13,7 +13,7 @@ const WEB_TOOLS = [
 
 const SOLANA_TOOLS = [
   ...WEB_TOOLS, 'wallet', 'token-launch', 'solana-toolbox', 'block-scanner',
-  'dashboard', 'hackathon',
+  'dashboard', 'hackathon', 'pro',
 ]
 
 export const PROFILE_PRESETS: Record<WorkspaceProfileName, string[]> = {

--- a/src/panels/ProPanel/ArenaView.tsx
+++ b/src/panels/ProPanel/ArenaView.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useProStore } from '../../store/pro'
+import './ProPanel.css'
+
+type Category = 'all' | 'tool' | 'agent' | 'skill' | 'mcp' | 'grind-recipe'
+
+const CATEGORY_LABELS: Record<Category, string> = {
+  all: 'All',
+  tool: 'Tools',
+  agent: 'Agents',
+  skill: 'Skills',
+  mcp: 'MCP',
+  'grind-recipe': 'Grind recipes',
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  submitted: 'Submitted',
+  featured: 'Featured',
+  winner: 'Winner',
+  shipped: 'Shipped',
+}
+
+export function ArenaView() {
+  const submissions = useProStore((state) => state.arenaSubmissions)
+  const loading = useProStore((state) => state.loadingArena)
+  const loadArena = useProStore((state) => state.loadArena)
+  const submitToArena = useProStore((state) => state.submitToArena)
+  const voteArena = useProStore((state) => state.voteArena)
+  const error = useProStore((state) => state.error)
+  const clearError = useProStore((state) => state.clearError)
+
+  const [category, setCategory] = useState<Category>('all')
+  const [showForm, setShowForm] = useState(false)
+  const [voted, setVoted] = useState<Set<string>>(new Set())
+  const [title, setTitle] = useState('')
+  const [pitch, setPitch] = useState('')
+  const [description, setDescription] = useState('')
+  const [formCategory, setFormCategory] = useState<Exclude<Category, 'all'>>('tool')
+  const [githubUrl, setGithubUrl] = useState('')
+  const [demoUrl, setDemoUrl] = useState('')
+  const [xHandle, setXHandle] = useState('')
+  const [discordHandle, setDiscordHandle] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    void loadArena()
+  }, [loadArena])
+
+  const filtered = useMemo(() => {
+    const list = category === 'all'
+      ? submissions
+      : submissions.filter((submission) => submission.category === category)
+    const rank = (status: string) => {
+      if (status === 'shipped') return 0
+      if (status === 'winner') return 1
+      if (status === 'featured') return 2
+      return 3
+    }
+    return [...list].sort((a, b) => {
+      const statusDiff = rank(a.status) - rank(b.status)
+      if (statusDiff !== 0) return statusDiff
+      if (a.votes !== b.votes) return b.votes - a.votes
+      return b.submittedAt - a.submittedAt
+    })
+  }, [submissions, category])
+
+  const handleSubmit = async () => {
+    setSubmitting(true)
+    const trimmedTitle = title.trim()
+    const trimmedPitch = pitch.trim()
+    const trimmedDescription = description.trim()
+    const trimmedGithubUrl = githubUrl.trim()
+    if (!trimmedTitle || !trimmedPitch || !trimmedDescription || !trimmedGithubUrl) {
+      setSubmitting(false)
+      return
+    }
+    const id = await submitToArena({
+      title: trimmedTitle,
+      pitch: trimmedPitch,
+      description: trimmedDescription,
+      category: formCategory,
+      githubUrl: trimmedGithubUrl,
+      demoUrl: demoUrl.trim() || undefined,
+      xHandle: xHandle.trim() || undefined,
+      discordHandle: discordHandle.trim() || undefined,
+    })
+    setSubmitting(false)
+    if (!id) return
+    setTitle('')
+    setPitch('')
+    setDescription('')
+    setGithubUrl('')
+    setDemoUrl('')
+    setXHandle('')
+    setDiscordHandle('')
+    setShowForm(false)
+  }
+
+  const handleVote = async (submissionId: string) => {
+    if (voted.has(submissionId)) return
+    const ok = await voteArena(submissionId)
+    if (ok) setVoted((prev) => new Set(prev).add(submissionId))
+  }
+
+  return (
+    <div className="pro-arena">
+      <section className="pro-arena-contest">
+        <div className="pro-arena-contest-copy">
+          <div className="pro-arena-kicker">Build Week 01</div>
+          <h2 className="pro-arena-contest-title">Ship something people want inside DAEMON.</h2>
+          <p className="pro-arena-contest-body">
+            Three weeks. Build the best agent, tool, skill, or MCP workflow for DAEMON.
+            Community votes shape the leaderboard, then the DAEMON team picks the final three winners.
+          </p>
+        </div>
+        <div className="pro-arena-contest-prizes">
+          <div className="pro-arena-prize-card">
+            <div className="pro-arena-prize-label">1st</div>
+            <div className="pro-arena-prize-value">250 USDC</div>
+            <div className="pro-arena-prize-note">Lifetime Pro + Founding Builder Discord access</div>
+          </div>
+          <div className="pro-arena-prize-card">
+            <div className="pro-arena-prize-label">2nd</div>
+            <div className="pro-arena-prize-value">150 USDC</div>
+            <div className="pro-arena-prize-note">Lifetime Pro + Founding Builder Discord access</div>
+          </div>
+          <div className="pro-arena-prize-card">
+            <div className="pro-arena-prize-label">3rd</div>
+            <div className="pro-arena-prize-value">100 USDC</div>
+            <div className="pro-arena-prize-note">Lifetime Pro + Founding Builder Discord access</div>
+          </div>
+        </div>
+      </section>
+
+      <div className="pro-arena-header">
+        <div>
+          <div className="pro-section-title">Arena</div>
+          <div className="pro-section-caption">Submit a polished build, link the repo, and make the case for why it should ship next.</div>
+        </div>
+        <button className="pro-btn pro-btn-primary" onClick={() => setShowForm((current) => !current)}>
+          {showForm ? 'Close submission form' : 'Submit project'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="pro-error">
+          {error}
+          <button className="pro-error-dismiss" onClick={clearError}>×</button>
+        </div>
+      )}
+
+      {showForm && (
+        <div className="pro-arena-form">
+          <div className="pro-form-row">
+            <label className="pro-form-label">Title</label>
+            <input className="pro-form-input" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Helius webhook bot" />
+          </div>
+          <div className="pro-form-row">
+            <label className="pro-form-label">One-line pitch</label>
+            <input className="pro-form-input" value={pitch} onChange={(e) => setPitch(e.target.value)} placeholder="What should people remember after one sentence?" />
+          </div>
+          <div className="pro-form-row">
+            <label className="pro-form-label">Category</label>
+            <select className="pro-form-input" value={formCategory} onChange={(e) => setFormCategory(e.target.value as Exclude<Category, 'all'>)}>
+              <option value="tool">Tool</option>
+              <option value="agent">Agent</option>
+              <option value="skill">Skill</option>
+              <option value="mcp">MCP</option>
+              <option value="grind-recipe">Grind recipe</option>
+            </select>
+          </div>
+          <div className="pro-form-row">
+            <label className="pro-form-label">Description</label>
+            <textarea className="pro-form-textarea" value={description} onChange={(e) => setDescription(e.target.value)} rows={4} />
+          </div>
+          <div className="pro-form-row">
+            <label className="pro-form-label">GitHub URL</label>
+            <input className="pro-form-input" value={githubUrl} onChange={(e) => setGithubUrl(e.target.value)} placeholder="https://github.com/you/your-repo" />
+          </div>
+          <div className="pro-form-row">
+            <label className="pro-form-label">Demo URL</label>
+            <input className="pro-form-input" value={demoUrl} onChange={(e) => setDemoUrl(e.target.value)} placeholder="https://your-demo-site.com or Loom link" />
+          </div>
+          <div className="pro-form-split">
+            <div className="pro-form-row">
+              <label className="pro-form-label">X handle</label>
+              <input className="pro-form-input" value={xHandle} onChange={(e) => setXHandle(e.target.value)} placeholder="@yourhandle" />
+            </div>
+            <div className="pro-form-row">
+              <label className="pro-form-label">Discord</label>
+              <input className="pro-form-input" value={discordHandle} onChange={(e) => setDiscordHandle(e.target.value)} placeholder="username" />
+            </div>
+          </div>
+          <div className="pro-form-actions">
+            <button
+              className="pro-btn pro-btn-primary"
+              disabled={submitting || !title.trim() || !pitch.trim() || !description.trim() || !githubUrl.trim()}
+              onClick={() => { void handleSubmit() }}
+            >
+              {submitting ? 'Submitting…' : 'Submit'}
+            </button>
+            <button className="pro-btn" onClick={() => setShowForm(false)}>Cancel</button>
+          </div>
+        </div>
+      )}
+
+      <div className="pro-arena-filters">
+        {(Object.keys(CATEGORY_LABELS) as Category[]).map((value) => (
+          <button key={value} className={`pro-arena-filter ${category === value ? 'active' : ''}`} onClick={() => setCategory(value)}>
+            {CATEGORY_LABELS[value]}
+          </button>
+        ))}
+        <button className="pro-arena-refresh" onClick={() => void loadArena()} disabled={loading}>
+          {loading ? '…' : 'Refresh'}
+        </button>
+      </div>
+
+      {!loading && filtered.length === 0 && (
+        <div className="pro-arena-empty">
+          <div>No submissions{category !== 'all' ? ` in ${CATEGORY_LABELS[category]}` : ''} yet.</div>
+          <div className="pro-arena-empty-cta">Be the first team on the board for Build Week 01.</div>
+        </div>
+      )}
+
+      <div className="pro-arena-list">
+        {filtered.map((submission) => {
+          const hasVoted = voted.has(submission.id)
+          return (
+            <div key={submission.id} className={`pro-arena-card pro-status-${submission.status}`}>
+              <div className="pro-arena-card-header">
+                <div>
+                  <div className="pro-arena-card-title">{submission.title}</div>
+                  <div className="pro-arena-card-pitch">{submission.pitch}</div>
+                </div>
+                <div className={`pro-arena-status pro-status-${submission.status}`}>{STATUS_LABELS[submission.status] ?? submission.status}</div>
+              </div>
+              <div className="pro-arena-card-meta">
+                <span className="pro-arena-author">@{submission.author.handle}</span>
+                <span className="pro-arena-category">{CATEGORY_LABELS[submission.category] ?? submission.category}</span>
+                {submission.themeWeek && <span className="pro-arena-theme">{submission.themeWeek}</span>}
+                <span>{formatRelative(submission.submittedAt)}</span>
+              </div>
+              <div className="pro-arena-card-description">{submission.description}</div>
+              <div className="pro-arena-card-links">
+                {submission.demoUrl && (
+                  <button className="pro-arena-link" onClick={() => void window.daemon.shell.openExternal(submission.demoUrl!)}>
+                    Demo
+                  </button>
+                )}
+                {submission.xHandle && (
+                  <button className="pro-arena-link" onClick={() => void window.daemon.shell.openExternal(`https://x.com/${submission.xHandle}`)}>
+                    @{submission.xHandle}
+                  </button>
+                )}
+                {submission.discordHandle && (
+                  <span className="pro-arena-contact">Discord: {submission.discordHandle}</span>
+                )}
+              </div>
+              <div className="pro-arena-card-footer">
+                {submission.githubUrl && (
+                  <button className="pro-arena-link" onClick={() => void window.daemon.shell.openExternal(submission.githubUrl!)}>
+                    GitHub →
+                  </button>
+                )}
+                <button className={`pro-arena-vote ${hasVoted ? 'voted' : ''}`} disabled={hasVoted} onClick={() => { void handleVote(submission.id) }}>
+                  ▲ {submission.votes}
+                </button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function formatRelative(timestamp: number) {
+  const diff = Date.now() - timestamp
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)}d ago`
+  return new Date(timestamp).toLocaleDateString()
+}

--- a/src/panels/ProPanel/ProPanel.css
+++ b/src/panels/ProPanel/ProPanel.css
@@ -1,0 +1,405 @@
+.pro-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg);
+  color: var(--t1);
+  overflow: hidden;
+}
+
+.pro-panel-header,
+.pro-panel-footer {
+  flex-shrink: 0;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--s4);
+}
+
+.pro-panel-footer {
+  border-bottom: 0;
+  border-top: 1px solid var(--s4);
+  background: var(--s1);
+}
+
+.pro-panel-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pro-panel-kicker {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #f1cf75;
+}
+
+.pro-panel-title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.pro-panel-subtitle,
+.pro-disclaimer {
+  font-size: 12px;
+  color: var(--t3);
+  line-height: 1.5;
+}
+
+.pro-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--s4);
+}
+
+.pro-tab {
+  flex: 1;
+  padding: 10px 12px;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--t3);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.pro-tab.active {
+  color: var(--t1);
+  border-bottom-color: var(--green);
+}
+
+.pro-tab:disabled {
+  color: var(--t4);
+  cursor: not-allowed;
+}
+
+.pro-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.pro-error {
+  margin: 0 20px;
+  padding: 8px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 80, 80, 0.1);
+  border: 1px solid #ff5050;
+  border-radius: 4px;
+  color: #ff7070;
+  font-size: 12px;
+}
+
+.pro-error-dismiss,
+.pro-btn,
+.pro-arena-link,
+.pro-arena-filter,
+.pro-arena-refresh,
+.pro-arena-vote {
+  cursor: pointer;
+}
+
+.pro-btn {
+  padding: 8px 14px;
+  background: var(--s2);
+  border: 1px solid var(--s4);
+  border-radius: 4px;
+  color: var(--t1);
+  font-size: 12px;
+}
+
+.pro-btn-primary {
+  background: var(--green);
+  border-color: var(--green);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+.pro-btn-full {
+  width: 100%;
+}
+
+.pro-overview,
+.pro-skills,
+.pro-sync,
+.pro-arena {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.pro-hero {
+  text-align: center;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--s4);
+}
+
+.pro-hero-price {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.pro-hero-price-amount {
+  font-family: var(--font-mono);
+  font-size: 36px;
+  font-weight: 700;
+  color: var(--green);
+}
+
+.pro-hero-price-period,
+.pro-hero-subtitle,
+.pro-feature-description,
+.pro-section-caption,
+.pro-sync-result,
+.pro-skills-result,
+.pro-holder-banner-copy,
+.pro-subscribe-empty {
+  color: var(--t3);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.pro-features-grid,
+.pro-active-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.pro-feature-card,
+.pro-subscribe-box,
+.pro-stat-card,
+.pro-active-features,
+.pro-skills-result,
+.pro-sync-result,
+.pro-arena-form,
+.pro-arena-card,
+.pro-arena-empty {
+  padding: 14px;
+  background: var(--s1);
+  border: 1px solid var(--s4);
+  border-radius: 6px;
+}
+
+.pro-feature-title,
+.pro-subscribe-title,
+.pro-section-title,
+.pro-arena-card-title,
+.pro-stat-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--t1);
+}
+
+.pro-holder-banner {
+  padding: 14px 16px;
+  background: linear-gradient(135deg, rgba(27, 31, 28, 0.94), rgba(16, 19, 18, 0.98));
+  border: 1px solid rgba(62, 207, 142, 0.18);
+  border-radius: 6px;
+}
+
+.pro-holder-banner.eligible {
+  border-color: rgba(62, 207, 142, 0.42);
+}
+
+.pro-holder-banner-title,
+.pro-stat-label,
+.pro-form-label,
+.pro-arena-kicker,
+.pro-arena-prize-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--t4);
+}
+
+.pro-holder-banner-title,
+.pro-arena-kicker,
+.pro-arena-prize-label {
+  color: #f1cf75;
+}
+
+.pro-stat-mono,
+.pro-arena-author,
+.pro-arena-link,
+.pro-skills-stat {
+  font-family: var(--font-mono);
+}
+
+.pro-active-feature {
+  font-size: 12px;
+  color: var(--t2);
+}
+
+.pro-active-check,
+.pro-skills-stat,
+.pro-arena-link {
+  color: var(--green);
+}
+
+.pro-form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pro-form-input,
+.pro-form-textarea {
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--s4);
+  border-radius: 4px;
+  color: var(--t1);
+}
+
+.pro-form-textarea {
+  resize: vertical;
+}
+
+.pro-form-split,
+.pro-arena-contest {
+  display: grid;
+  gap: 12px;
+}
+
+.pro-form-split {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.pro-arena-contest {
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 1fr);
+  padding: 20px;
+  border: 1px solid rgba(255, 215, 0, 0.14);
+  border-radius: 10px;
+  background: radial-gradient(circle at top left, rgba(255, 215, 0, 0.12), transparent 30%), linear-gradient(145deg, rgba(15, 19, 17, 0.98), rgba(24, 30, 27, 0.92));
+}
+
+.pro-arena-contest-title {
+  margin: 0 0 10px;
+  font-size: 28px;
+  line-height: 1.05;
+}
+
+.pro-arena-contest-body,
+.pro-arena-prize-note,
+.pro-arena-card-description {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--t2);
+}
+
+.pro-arena-contest-prizes,
+.pro-arena-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.pro-arena-prize-card {
+  padding: 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.pro-arena-prize-value {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.pro-arena-header,
+.pro-arena-card-header,
+.pro-arena-card-footer,
+.pro-sync-actions,
+.pro-form-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.pro-arena-filters,
+.pro-arena-card-meta,
+.pro-arena-card-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.pro-arena-filter {
+  padding: 4px 10px;
+  border: 1px solid var(--s4);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--t3);
+  font-size: 11px;
+}
+
+.pro-arena-filter.active {
+  background: var(--green);
+  border-color: var(--green);
+  color: var(--bg);
+}
+
+.pro-arena-refresh {
+  margin-left: auto;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--s4);
+  border-radius: 4px;
+  color: var(--t3);
+  font-size: 11px;
+}
+
+.pro-arena-status,
+.pro-arena-category,
+.pro-arena-theme {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+}
+
+.pro-arena-status {
+  border: 1px solid var(--s4);
+  color: var(--t3);
+}
+
+.pro-arena-status.pro-status-featured {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.pro-arena-status.pro-status-winner,
+.pro-arena-theme {
+  border: 1px solid rgba(241, 207, 117, 0.5);
+  color: #f1cf75;
+}
+
+.pro-arena-category {
+  background: var(--s2);
+  color: var(--t3);
+}
+
+.pro-arena-vote {
+  padding: 4px 10px;
+  background: var(--s2);
+  border: 1px solid var(--s4);
+  border-radius: 4px;
+  color: var(--t1);
+}
+
+.pro-arena-vote.voted {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+@media (max-width: 900px) {
+  .pro-arena-contest,
+  .pro-form-split {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/panels/ProPanel/ProPanel.tsx
+++ b/src/panels/ProPanel/ProPanel.tsx
@@ -1,0 +1,352 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useProStore } from '../../store/pro'
+import { useWalletStore } from '../../store/wallet'
+import type { ProFeature, ProSubscriptionState, ProPriceInfo } from '../../../electron/shared/types'
+import { ArenaView } from './ArenaView'
+import './ProPanel.css'
+
+type ProTab = 'overview' | 'arena' | 'skills' | 'sync'
+
+export function ProPanel() {
+  const subscription = useProStore((state) => state.subscription)
+  const price = useProStore((state) => state.price)
+  const subscribing = useProStore((state) => state.subscribing)
+  const refreshStatus = useProStore((state) => state.refreshStatus)
+  const fetchPrice = useProStore((state) => state.fetchPrice)
+  const subscribe = useProStore((state) => state.subscribe)
+  const claimHolderAccess = useProStore((state) => state.claimHolderAccess)
+  const signOut = useProStore((state) => state.signOut)
+  const error = useProStore((state) => state.error)
+  const clearError = useProStore((state) => state.clearError)
+  const quota = useProStore((state) => state.quota)
+  const loadQuota = useProStore((state) => state.loadQuota)
+  const wallets = useWalletStore((state) => state.dashboard?.wallets ?? [])
+
+  const [activeTab, setActiveTab] = useState<ProTab>('overview')
+  const [selectedWalletId, setSelectedWalletId] = useState('')
+  const selectedWallet = wallets.find((wallet) => wallet.id === selectedWalletId) ?? null
+
+  useEffect(() => {
+    void refreshStatus()
+    void fetchPrice()
+  }, [refreshStatus, fetchPrice])
+
+  useEffect(() => {
+    if (!selectedWallet?.address) return
+    void refreshStatus(selectedWallet.address)
+  }, [refreshStatus, selectedWallet?.address])
+
+  useEffect(() => {
+    if (subscription.active && !quota) {
+      void loadQuota()
+    }
+  }, [subscription.active, quota, loadQuota])
+
+  useEffect(() => {
+    if (selectedWalletId || wallets.length === 0) return
+    const next = wallets.find((wallet) => wallet.isDefault) ?? wallets[0]
+    setSelectedWalletId(next.id)
+  }, [wallets, selectedWalletId])
+
+  const daysRemaining = useMemo(() => {
+    if (!subscription.expiresAt) return null
+    const diff = subscription.expiresAt - Date.now()
+    if (diff <= 0) return 0
+    return Math.ceil(diff / (24 * 60 * 60 * 1000))
+  }, [subscription.expiresAt])
+
+  const handleSubscribe = async () => {
+    if (!selectedWalletId) return
+    const ok = await subscribe(selectedWalletId)
+    if (ok) await loadQuota()
+  }
+
+  const handleClaimHolderAccess = async () => {
+    if (!selectedWalletId) return
+    const ok = await claimHolderAccess(selectedWalletId)
+    if (ok) await loadQuota()
+  }
+
+  const isActive = subscription.active
+
+  return (
+    <section className="pro-panel">
+      <header className="pro-panel-header">
+        <div className="pro-panel-title-group">
+          <div className="pro-panel-kicker">DAEMON PRO</div>
+          <div className="pro-panel-title">{isActive ? 'Subscription active' : 'Unlock the full IDE'}</div>
+          {isActive && daysRemaining !== null && (
+            <div className="pro-panel-subtitle">{daysRemaining} day{daysRemaining === 1 ? '' : 's'} remaining</div>
+          )}
+        </div>
+        {isActive && <button className="pro-btn" onClick={() => { void signOut() }}>Sign out</button>}
+      </header>
+
+      {error && (
+        <div className="pro-error">
+          {error}
+          <button className="pro-error-dismiss" onClick={clearError}>×</button>
+        </div>
+      )}
+
+      <nav className="pro-tabs">
+        <button className={`pro-tab ${activeTab === 'overview' ? 'active' : ''}`} onClick={() => setActiveTab('overview')}>Overview</button>
+        <button className={`pro-tab ${activeTab === 'arena' ? 'active' : ''}`} onClick={() => setActiveTab('arena')} disabled={!isActive}>Arena</button>
+        <button className={`pro-tab ${activeTab === 'skills' ? 'active' : ''}`} onClick={() => setActiveTab('skills')} disabled={!isActive}>Skills</button>
+        <button className={`pro-tab ${activeTab === 'sync' ? 'active' : ''}`} onClick={() => setActiveTab('sync')} disabled={!isActive}>MCP Sync</button>
+      </nav>
+
+      <div className="pro-panel-body">
+        {activeTab === 'overview' && !isActive && (
+          <OverviewSubscribe
+            price={price}
+            wallets={wallets}
+            selectedWalletId={selectedWalletId}
+            onSelectWallet={setSelectedWalletId}
+            subscribing={subscribing}
+            onSubscribe={handleSubscribe}
+            onClaimHolderAccess={handleClaimHolderAccess}
+            holderStatus={subscription.holderStatus}
+            accessSource={subscription.accessSource}
+          />
+        )}
+        {activeTab === 'overview' && isActive && (
+          <OverviewActive
+            expiresAt={subscription.expiresAt}
+            walletAddress={subscription.walletAddress}
+            features={subscription.features}
+            quota={quota}
+            accessSource={subscription.accessSource}
+          />
+        )}
+        {activeTab === 'arena' && isActive && <ArenaView />}
+        {activeTab === 'skills' && isActive && <SkillsView />}
+        {activeTab === 'sync' && isActive && <SyncView />}
+      </div>
+
+      <footer className="pro-panel-footer">
+        <div className="pro-disclaimer">
+          DAEMON stays open source. Pro adds curated content, hosted sync, and priority endpoints on top of the IDE.
+        </div>
+      </footer>
+    </section>
+  )
+}
+
+function OverviewSubscribe({
+  price,
+  wallets,
+  selectedWalletId,
+  onSelectWallet,
+  subscribing,
+  onSubscribe,
+  onClaimHolderAccess,
+  holderStatus,
+  accessSource,
+}: {
+  price: ProPriceInfo | null
+  wallets: Array<{ id: string; name: string; address: string; isDefault: boolean }>
+  selectedWalletId: string
+  onSelectWallet: (walletId: string) => void
+  subscribing: boolean
+  onSubscribe: () => void
+  onClaimHolderAccess: () => void
+  holderStatus: ProSubscriptionState['holderStatus']
+  accessSource: ProSubscriptionState['accessSource']
+}) {
+  const isHolderEligible = holderStatus.enabled && holderStatus.eligible
+  const currentAmount = holderStatus.currentAmount ?? 0
+  const minAmount = holderStatus.minAmount ?? 0
+
+  return (
+    <div className="pro-overview">
+      <div className="pro-hero">
+        <div className="pro-hero-price">
+          {price ? (
+            <>
+              <span className="pro-hero-price-amount">${price.priceUsdc}</span>
+              <span className="pro-hero-price-period">/ {price.durationDays} days</span>
+            </>
+          ) : (
+            <span className="pro-hero-price-loading">…</span>
+          )}
+        </div>
+        <div className="pro-hero-subtitle">Pay in USDC via x402. No separate dashboard, no separate account, no card flow.</div>
+      </div>
+
+      <div className="pro-features-grid">
+        <FeatureCard title="Arena" description="Submit your tools, vote on community submissions, and see what ships next." />
+        <FeatureCard title="Pro skill pack" description="Curated agents, audit pipelines, and templates updated monthly." />
+        <FeatureCard title="Hosted MCP sync" description="One MCP config, every machine. Push from one install, pull on the next." />
+        <FeatureCard title="Priority API quota" description="500 calls / month to the paid AI endpoints without per-call charges." />
+      </div>
+
+      {holderStatus.enabled && (
+        <div className={`pro-holder-banner ${isHolderEligible ? 'eligible' : ''}`}>
+          <div className="pro-holder-banner-title">{isHolderEligible ? 'Holder access available' : 'DAEMON holder access'}</div>
+          <div className="pro-holder-banner-copy">
+            Hold {minAmount.toLocaleString()}+ DAEMON to unlock Pro. Current selected wallet: {currentAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} DAEMON.
+            {accessSource === 'holder' ? ' Holder access is currently active on this device.' : ''}
+          </div>
+        </div>
+      )}
+
+      <div className="pro-subscribe-box">
+        <div className="pro-subscribe-title">{isHolderEligible ? 'Claim access' : 'Subscribe'}</div>
+        {wallets.length === 0 ? (
+          <div className="pro-subscribe-empty">You need a wallet to subscribe. Create one from the Wallet panel first.</div>
+        ) : (
+          <>
+            <div className="pro-form-row">
+              <label className="pro-form-label">Pay from wallet</label>
+              <select className="pro-form-input" value={selectedWalletId} onChange={(e) => onSelectWallet(e.target.value)}>
+                {wallets.map((wallet) => (
+                  <option key={wallet.id} value={wallet.id}>
+                    {wallet.name} ({wallet.address.slice(0, 4)}…{wallet.address.slice(-4)}){wallet.isDefault ? ' — default' : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button className="pro-btn pro-btn-primary pro-btn-full" disabled={subscribing || !selectedWalletId || !price} onClick={isHolderEligible ? onClaimHolderAccess : onSubscribe}>
+              {subscribing
+                ? (isHolderEligible ? 'Verifying holder wallet…' : 'Signing payment…')
+                : (isHolderEligible ? 'Activate holder access' : `Subscribe for $${price?.priceUsdc ?? '—'} USDC`)}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function FeatureCard({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="pro-feature-card">
+      <div className="pro-feature-title">{title}</div>
+      <div className="pro-feature-description">{description}</div>
+    </div>
+  )
+}
+
+function OverviewActive({
+  expiresAt,
+  walletAddress,
+  features,
+  quota,
+  accessSource,
+}: {
+  expiresAt: number | null
+  walletAddress: string | null
+  features: ProFeature[]
+  quota: { quota: number; used: number; remaining: number } | null
+  accessSource: ProSubscriptionState['accessSource']
+}) {
+  return (
+    <div className="pro-overview">
+      <div className="pro-active-grid">
+        <StatCard label="Expires" value={expiresAt ? new Date(expiresAt).toLocaleDateString() : '—'} />
+        <StatCard label="Wallet" value={walletAddress ? `${walletAddress.slice(0, 6)}…${walletAddress.slice(-6)}` : '—'} mono />
+        <StatCard label="Features" value={`${features.length} unlocked`} />
+        <StatCard label="Access" value={accessSource === 'holder' ? 'Holder' : 'Paid'} />
+        <StatCard label="Priority API" value={quota ? `${quota.used} / ${quota.quota}` : '—'} />
+      </div>
+      <div className="pro-active-features">
+        {features.map((feature) => (
+          <div key={feature} className="pro-active-feature">
+            <span className="pro-active-check">✓</span> {featureLabel(feature)}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function StatCard({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="pro-stat-card">
+      <div className="pro-stat-label">{label}</div>
+      <div className={`pro-stat-value${mono ? ' pro-stat-mono' : ''}`}>{value}</div>
+    </div>
+  )
+}
+
+function featureLabel(feature: ProFeature) {
+  switch (feature) {
+    case 'arena':
+      return 'Arena access'
+    case 'pro-skills':
+      return 'Pro skill pack'
+    case 'mcp-sync':
+      return 'Hosted MCP sync'
+    case 'priority-api':
+      return 'Priority API quota'
+    default:
+      return feature
+  }
+}
+
+function SkillsView() {
+  const syncSkills = useProStore((state) => state.syncSkills)
+  const syncingSkills = useProStore((state) => state.syncingSkills)
+  const [lastResult, setLastResult] = useState<{ installed: string[]; skipped: string[] } | null>(null)
+
+  const handleSync = async () => {
+    const result = await syncSkills()
+    if (result) setLastResult(result)
+  }
+
+  return (
+    <div className="pro-skills">
+      <div className="pro-section-title">Pro skill pack</div>
+      <div className="pro-section-caption">Curated agents, audit pipelines, and templates. Sync downloads the latest pack into your local skill directory.</div>
+      <button className="pro-btn pro-btn-primary" disabled={syncingSkills} onClick={() => { void handleSync() }}>
+        {syncingSkills ? 'Syncing…' : 'Sync skill pack'}
+      </button>
+      {lastResult && (
+        <div className="pro-skills-result">
+          <div>
+            <span className="pro-skills-stat">{lastResult.installed.length}</span> installed · <span className="pro-skills-stat">{lastResult.skipped.length}</span> unchanged
+          </div>
+          {lastResult.installed.length > 0 && (
+            <ul className="pro-skills-list">
+              {lastResult.installed.map((id) => <li key={id}>{id}</li>)}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SyncView() {
+  const pushMcp = useProStore((state) => state.pushMcp)
+  const pullMcp = useProStore((state) => state.pullMcp)
+  const syncingMcp = useProStore((state) => state.syncingMcp)
+  const [lastAction, setLastAction] = useState<string | null>(null)
+
+  const handlePush = async () => {
+    const count = await pushMcp()
+    if (count !== null) setLastAction(`Pushed ${count} MCP servers`)
+  }
+
+  const handlePull = async () => {
+    const count = await pullMcp()
+    if (count !== null) setLastAction(`Pulled ${count} MCP servers`)
+  }
+
+  return (
+    <div className="pro-sync">
+      <div className="pro-section-title">MCP sync</div>
+      <div className="pro-section-caption">Push your current MCP config to the server, then pull it on another machine. Server state is last-write-wins.</div>
+      <div className="pro-sync-actions">
+        <button className="pro-btn pro-btn-primary" disabled={syncingMcp} onClick={() => { void handlePush() }}>
+          {syncingMcp ? 'Pushing…' : 'Push local → server'}
+        </button>
+        <button className="pro-btn" disabled={syncingMcp} onClick={() => { void handlePull() }}>
+          {syncingMcp ? 'Pulling…' : 'Pull server → local'}
+        </button>
+      </div>
+      {lastAction && <div className="pro-sync-result">{lastAction}</div>}
+    </div>
+  )
+}

--- a/src/store/pro.ts
+++ b/src/store/pro.ts
@@ -1,0 +1,257 @@
+import { create } from 'zustand'
+
+interface ProStoreState {
+  subscription: ProSubscriptionState
+  price: ProPriceInfo | null
+  arenaSubmissions: ArenaSubmission[]
+  quota: { quota: number; used: number; remaining: number } | null
+  subscribing: boolean
+  loadingArena: boolean
+  loadingQuota: boolean
+  syncingSkills: boolean
+  syncingMcp: boolean
+  error: string | null
+  refreshStatus: (walletAddress?: string | null) => Promise<void>
+  fetchPrice: () => Promise<void>
+  subscribe: (walletId: string) => Promise<boolean>
+  claimHolderAccess: (walletId: string) => Promise<boolean>
+  signOut: () => Promise<void>
+  loadArena: () => Promise<void>
+  submitToArena: (input: ArenaSubmissionInput) => Promise<string | null>
+  voteArena: (submissionId: string) => Promise<boolean>
+  loadQuota: () => Promise<void>
+  syncSkills: () => Promise<{ installed: string[]; skipped: string[] } | null>
+  pushMcp: () => Promise<number | null>
+  pullMcp: () => Promise<number | null>
+  clearError: () => void
+}
+
+const EMPTY_SUBSCRIPTION: ProSubscriptionState = {
+  active: false,
+  walletId: null,
+  walletAddress: null,
+  expiresAt: null,
+  features: [],
+  tier: null,
+  accessSource: null,
+  holderStatus: {
+    enabled: false,
+    eligible: false,
+    mint: null,
+    minAmount: null,
+    currentAmount: null,
+    symbol: 'DAEMON',
+  },
+  priceUsdc: null,
+  durationDays: null,
+}
+
+export const useProStore = create<ProStoreState>((set, get) => ({
+  subscription: EMPTY_SUBSCRIPTION,
+  price: null,
+  arenaSubmissions: [],
+  quota: null,
+  subscribing: false,
+  loadingArena: false,
+  loadingQuota: false,
+  syncingSkills: false,
+  syncingMcp: false,
+  error: null,
+
+  refreshStatus: async (walletAddress) => {
+    try {
+      const result = walletAddress
+        ? await window.daemon.pro.refreshStatus(walletAddress)
+        : await window.daemon.pro.status()
+      if (result.ok && result.data) {
+        set({ subscription: result.data })
+      } else {
+        set({ error: result.error ?? 'Failed to refresh Pro status' })
+      }
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Failed to refresh Pro status' })
+    }
+  },
+
+  fetchPrice: async () => {
+    try {
+      const result = await window.daemon.pro.fetchPrice()
+      if (result.ok && result.data) set({ price: result.data })
+      else set({ error: result.error ?? 'Failed to fetch Pro price' })
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Failed to fetch Pro price' })
+    }
+  },
+
+  subscribe: async (walletId) => {
+    set({ subscribing: true, error: null })
+    try {
+      const result = await window.daemon.pro.subscribe(walletId)
+      if (result.ok && result.data) {
+        set({
+          subscription: result.data.state,
+          price: result.data.price,
+          subscribing: false,
+        })
+        return true
+      }
+      set({ error: result.error ?? 'Subscribe failed', subscribing: false })
+      return false
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : 'Subscribe failed',
+        subscribing: false,
+      })
+      return false
+    }
+  },
+
+  claimHolderAccess: async (walletId) => {
+    set({ subscribing: true, error: null })
+    try {
+      const result = await window.daemon.pro.claimHolderAccess(walletId)
+      if (result.ok && result.data) {
+        set({ subscription: result.data.state, subscribing: false })
+        return true
+      }
+      set({ error: result.error ?? 'Holder claim failed', subscribing: false })
+      return false
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : 'Holder claim failed',
+        subscribing: false,
+      })
+      return false
+    }
+  },
+
+  signOut: async () => {
+    const result = await window.daemon.pro.signOut()
+    if (result.ok) {
+      set({ subscription: EMPTY_SUBSCRIPTION, arenaSubmissions: [], quota: null })
+    } else {
+      set({ error: result.error ?? 'Sign out failed' })
+    }
+  },
+
+  loadArena: async () => {
+    if (!get().subscription.active) return
+    set({ loadingArena: true, error: null })
+    try {
+      const result = await window.daemon.pro.arenaList()
+      if (result.ok && result.data) {
+        set({ arenaSubmissions: result.data, loadingArena: false })
+      } else {
+        set({ error: result.error ?? 'Failed to load Arena', loadingArena: false })
+      }
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : 'Failed to load Arena',
+        loadingArena: false,
+      })
+    }
+  },
+
+  submitToArena: async (input) => {
+    set({ error: null })
+    try {
+      const result = await window.daemon.pro.arenaSubmit(input)
+      if (result.ok && result.data) {
+        await get().loadArena()
+        return result.data.id
+      }
+      set({ error: result.error ?? 'Submission failed' })
+      return null
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Submission failed' })
+      return null
+    }
+  },
+
+  voteArena: async (submissionId) => {
+    try {
+      const result = await window.daemon.pro.arenaVote(submissionId)
+      if (result.ok) {
+        set((state) => ({
+          arenaSubmissions: state.arenaSubmissions.map((submission) =>
+            submission.id === submissionId ? { ...submission, votes: submission.votes + 1 } : submission,
+          ),
+        }))
+        return true
+      }
+      set({ error: result.error ?? 'Vote failed' })
+      return false
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Vote failed' })
+      return false
+    }
+  },
+
+  loadQuota: async () => {
+    if (!get().subscription.active) return
+    set({ loadingQuota: true })
+    try {
+      const result = await window.daemon.pro.quota()
+      if (result.ok && result.data) {
+        set({ quota: result.data, loadingQuota: false })
+      } else {
+        set({ loadingQuota: false })
+      }
+    } catch {
+      set({ loadingQuota: false })
+    }
+  },
+
+  syncSkills: async () => {
+    set({ syncingSkills: true, error: null })
+    try {
+      const result = await window.daemon.pro.skillsSync()
+      set({ syncingSkills: false })
+      if (result.ok && result.data) return result.data
+      set({ error: result.error ?? 'Skill sync failed' })
+      return null
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : 'Skill sync failed',
+        syncingSkills: false,
+      })
+      return null
+    }
+  },
+
+  pushMcp: async () => {
+    set({ syncingMcp: true, error: null })
+    try {
+      const result = await window.daemon.pro.mcpPush()
+      set({ syncingMcp: false })
+      if (result.ok && result.data) return result.data.count
+      set({ error: result.error ?? 'MCP push failed' })
+      return null
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : 'MCP push failed',
+        syncingMcp: false,
+      })
+      return null
+    }
+  },
+
+  pullMcp: async () => {
+    set({ syncingMcp: true, error: null })
+    try {
+      const result = await window.daemon.pro.mcpPull()
+      set({ syncingMcp: false })
+      if (result.ok && result.data) return result.data.count
+      set({ error: result.error ?? 'MCP pull failed' })
+      return null
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : 'MCP pull failed',
+        syncingMcp: false,
+      })
+      return null
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}))

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -129,7 +129,7 @@ export const useUIStore = create<UIState>((set) => ({
   grindPages: {},
   walletQuickViewOpen: false,
   emailQuickViewOpen: false,
-  pinnedTools: ['git', 'browser', 'token-launch', 'solana-toolbox'],
+  pinnedTools: ['git', 'browser', 'token-launch', 'solana-toolbox', 'pro'],
   drawerToolOrder: [],
 
   setActiveProject: (id, path) => set({ activeProjectId: id, activeProjectPath: path }),

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -243,6 +243,11 @@ declare global {
   type OnboardingStepStatus = import('../../electron/shared/types').OnboardingStepStatus
   type WorkspaceProfile = import('../../electron/shared/types').WorkspaceProfile
   type WorkspaceProfileName = import('../../electron/shared/types').WorkspaceProfileName
+  type ProSubscriptionState = import('../../electron/shared/types').ProSubscriptionState
+  type ProPriceInfo = import('../../electron/shared/types').ProPriceInfo
+  type ArenaSubmission = import('../../electron/shared/types').ArenaSubmission
+  type ArenaSubmissionInput = import('../../electron/shared/types').ArenaSubmissionInput
+  type ProSkillManifest = import('../../electron/shared/types').ProSkillManifest
 
   interface DaemonWindow {
     minimize: () => void
@@ -840,6 +845,24 @@ declare global {
     on: (channel: DaemonEventChannel, callback: (payload: unknown) => void) => () => void
   }
 
+  interface DaemonPro {
+    status: () => Promise<IpcResponse<ProSubscriptionState>>
+    refreshStatus: (walletAddress: string) => Promise<IpcResponse<ProSubscriptionState>>
+    fetchPrice: () => Promise<IpcResponse<ProPriceInfo>>
+    subscribe: (walletId: string) => Promise<IpcResponse<{ state: ProSubscriptionState; price: ProPriceInfo }>>
+    claimHolderAccess: (walletId: string) => Promise<IpcResponse<{ state: ProSubscriptionState }>>
+    signOut: () => Promise<IpcResponse<void>>
+    arenaList: () => Promise<IpcResponse<ArenaSubmission[]>>
+    arenaSubmit: (input: ArenaSubmissionInput) => Promise<IpcResponse<{ id: string }>>
+    arenaVote: (submissionId: string) => Promise<IpcResponse<void>>
+    skillsManifest: () => Promise<IpcResponse<ProSkillManifest>>
+    skillsSync: () => Promise<IpcResponse<{ installed: string[]; skipped: string[] }>>
+    skillsDownload: (skillId: string) => Promise<IpcResponse<{ fileCount: number; path: string }>>
+    quota: () => Promise<IpcResponse<{ quota: number; used: number; remaining: number }>>
+    mcpPush: () => Promise<IpcResponse<{ count: number }>>
+    mcpPull: () => Promise<IpcResponse<{ count: number }>>
+  }
+
   interface DaemonAPI {
     window: DaemonWindow
     terminal: DaemonTerminal
@@ -876,6 +899,7 @@ declare global {
     vault: DaemonVault
     validator: DaemonValidator
     pnl: DaemonPnl
+    pro: DaemonPro
     feedback: DaemonFeedback
   }
 

--- a/test/services/SettingsService.test.ts
+++ b/test/services/SettingsService.test.ts
@@ -75,12 +75,18 @@ describe('SettingsService token launch settings', () => {
     )
   })
 
-  it('sanitizes pinned tools from storage', () => {
+  it('sanitizes pinned tools from storage and runs the one-time Pro pin migration', () => {
     mockGet.mockReturnValue({
       value: JSON.stringify(['git', '', 'browser', 'git', 42]),
     })
 
-    expect(getPinnedTools()).toEqual(['git', 'browser'])
+    expect(getPinnedTools()).toEqual(['git', 'browser', 'pro'])
+    expect(mockRun).toHaveBeenCalledWith(
+      'pinned_tools',
+      JSON.stringify(['git', 'browser', 'pro']),
+      expect.any(Number),
+    )
+    expect(mockRun).toHaveBeenCalledWith('pinned_tools_pro_default_added', 'true', expect.any(Number))
   })
 
   it('drops invalid workspace profiles from storage', () => {


### PR DESCRIPTION
## Summary
- restore Daemon Pro as a canvas workspace tool with IPC/preload/service wiring
- add Arena, Pro skills, MCP sync, and priority quota panel surface
- make Pro discoverable for fresh installs and one-time upgraded pinned tool state
- declare the direct `tweetnacl` dependency used by Pro holder verification

## Verification
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run test`
- Electron MCP visual check: Pro appears in the left rail, opens as a canvas tab, and Overview/Arena/MCP Sync render with `DAEMON_PRO_DEV_BYPASS=1`
- Production Pro API smoke: `/v1/subscribe/price` returns price data and `/v1/subscribe` returns expected HTTP 402 x402 challenge