### PR TITLE
Add SendAI Agent Kit setup workflow

### DIFF
--- a/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.css
+++ b/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.css
@@ -341,6 +341,118 @@
   font-size: 11px;
 }
 
+.icc-setup-workflow {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 13px;
+  border: 1px solid rgba(20, 241, 149, 0.18);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, rgba(20, 241, 149, 0.055), transparent 120px),
+    rgba(255, 255, 255, 0.02);
+}
+
+.icc-setup-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.icc-setup-head h3 {
+  margin: 5px 0 0;
+  color: var(--t1);
+  font-size: 15px;
+  line-height: 1.25;
+}
+
+.icc-setup-head p {
+  margin: 5px 0 0;
+  color: var(--t3);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.icc-plan-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.icc-plan-card {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.055);
+  border-radius: var(--radius-md);
+  background: rgba(0, 0, 0, 0.14);
+}
+
+.icc-plan-card span,
+.icc-mini-title {
+  color: var(--t4);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+}
+
+.icc-plan-card code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--t2);
+  font-size: 11px;
+}
+
+.icc-plan-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.icc-check-list,
+.icc-safety-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.icc-check-list span,
+.icc-safety-notes span {
+  color: var(--t3);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.icc-check-list span::before {
+  content: '+';
+  margin-right: 6px;
+  color: #14f195;
+}
+
+.icc-safety-notes {
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.055);
+}
+
+.icc-safety-notes span::before {
+  content: 'safe';
+  display: inline-block;
+  margin-right: 7px;
+  color: #98fbd0;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.icc-apply-setup {
+  align-self: flex-end;
+}
+
 .icc-action {
   display: flex;
   align-items: center;
@@ -493,10 +605,16 @@
 
   .icc-card-top,
   .icc-detail-head,
+  .icc-setup-head,
   .icc-footer-actions,
   .icc-action {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .icc-plan-grid,
+  .icc-plan-columns {
+    grid-template-columns: 1fr;
   }
 
   .icc-footer-actions {

--- a/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
+++ b/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
@@ -1,32 +1,24 @@
 import { useEffect, useMemo, useState } from 'react'
 import { daemon } from '../../lib/daemonBridge'
+import { useAppActions } from '../../store/appActions'
 import { useUIStore } from '../../store/ui'
 import { useSolanaToolboxStore } from '../../store/solanaToolbox'
 import type { EnvFile, WalletListEntry } from '../../types/daemon'
 import { INTEGRATION_CATEGORIES, INTEGRATION_REGISTRY, type IntegrationCategory, type IntegrationDefinition } from './registry'
 import { runIntegrationAction, type IntegrationActionResult } from './actionRunner'
 import { resolveIntegrationStatus, summarizeRegistry, type IntegrationContext, type IntegrationStatusSummary } from './status'
+import {
+  createSendAiSetupPlan,
+  mergeEnvExample,
+  parsePackageInfo,
+  type PackageInfo,
+  type PackageManager,
+  type SendAiSetupPlan,
+} from './sendaiSetup'
 import './IntegrationCommandCenter.css'
 
 function joinProjectPath(projectPath: string, child: string): string {
   return `${projectPath.replace(/[\\/]+$/, '')}/${child}`
-}
-
-function collectPackages(packageJson: string): Set<string> {
-  try {
-    const parsed = JSON.parse(packageJson) as {
-      dependencies?: Record<string, string>
-      devDependencies?: Record<string, string>
-      optionalDependencies?: Record<string, string>
-    }
-    return new Set([
-      ...Object.keys(parsed.dependencies ?? {}),
-      ...Object.keys(parsed.devDependencies ?? {}),
-      ...Object.keys(parsed.optionalDependencies ?? {}),
-    ])
-  } catch {
-    return new Set()
-  }
 }
 
 function statusLabel(summary: IntegrationStatusSummary): string {
@@ -34,6 +26,8 @@ function statusLabel(summary: IntegrationStatusSummary): string {
   if (summary.status === 'partial') return 'Partial'
   return 'Setup needed'
 }
+
+const EMPTY_PACKAGE_INFO: PackageInfo = { packages: new Set(), packageManagerHint: null }
 
 function RiskPill({ risk }: { risk: string }) {
   return <span className={`icc-risk icc-risk--${risk}`}>{risk.replace('-', ' ')}</span>
@@ -54,6 +48,65 @@ function RequirementList({ summary }: { summary: IntegrationStatusSummary }) {
           </div>
         </div>
       ))}
+    </div>
+  )
+}
+
+function SendAiSetupWorkflow({
+  plan,
+  applying,
+  onApply,
+}: {
+  plan: SendAiSetupPlan
+  applying: boolean
+  onApply: () => void
+}) {
+  return (
+    <div className="icc-setup-workflow">
+      <div className="icc-setup-head">
+        <div>
+          <span className="icc-section-title">Guided setup</span>
+          <h3>Add Solana Agent Kit to this project</h3>
+          <p>Preview what DAEMON will do, then apply only the package install and env template changes.</p>
+        </div>
+        <span className="icc-status-badge partial">{plan.packageManager}</span>
+      </div>
+
+      <div className="icc-plan-grid">
+        <div className="icc-plan-card">
+          <span>Install command</span>
+          <code>{plan.installCommand ?? 'All SendAI packages are already installed'}</code>
+        </div>
+        <div className="icc-plan-card">
+          <span>Env template</span>
+          <code>{plan.envFileName} adds {plan.missingEnvKeys.length} missing key{plan.missingEnvKeys.length === 1 ? '' : 's'}</code>
+        </div>
+      </div>
+
+      <div className="icc-plan-columns">
+        <div>
+          <span className="icc-mini-title">Packages</span>
+          <div className="icc-check-list">
+            {plan.missingPackages.map((name) => <span key={name}>Install {name}</span>)}
+            {plan.missingPackages.length === 0 ? <span>All recommended packages are present</span> : null}
+          </div>
+        </div>
+        <div>
+          <span className="icc-mini-title">Env keys</span>
+          <div className="icc-check-list">
+            {plan.missingEnvKeys.map((key) => <span key={key}>Template {key}</span>)}
+            {plan.missingEnvKeys.length === 0 ? <span>Env template keys already detected</span> : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="icc-safety-notes">
+        {plan.safetyNotes.map((note) => <span key={note}>{note}</span>)}
+      </div>
+
+      <button type="button" className="icc-primary icc-apply-setup" onClick={onApply} disabled={applying}>
+        {applying ? 'Applying setup...' : 'Apply Setup'}
+      </button>
     </div>
   )
 }
@@ -92,6 +145,8 @@ export function IntegrationCommandCenter() {
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
   const openWorkspaceTool = useUIStore((s) => s.openWorkspaceTool)
+  const addTerminal = useUIStore((s) => s.addTerminal)
+  const focusTerminal = useAppActions((s) => s.focusTerminal)
   const mcps = useSolanaToolboxStore((s) => s.mcps)
   const toolchain = useSolanaToolboxStore((s) => s.toolchain)
   const loadMcps = useSolanaToolboxStore((s) => s.loadMcps)
@@ -101,10 +156,12 @@ export function IntegrationCommandCenter() {
   const [search, setSearch] = useState('')
   const [selectedId, setSelectedId] = useState(INTEGRATION_REGISTRY[0]?.id ?? '')
   const [envFiles, setEnvFiles] = useState<EnvFile[]>([])
-  const [packages, setPackages] = useState<Set<string>>(new Set())
+  const [packageInfo, setPackageInfo] = useState<PackageInfo>(EMPTY_PACKAGE_INFO)
+  const [lockfiles, setLockfiles] = useState<Partial<Record<PackageManager, boolean>>>({})
   const [wallets, setWallets] = useState<WalletListEntry[]>([])
   const [secureKeys, setSecureKeys] = useState<Record<string, boolean>>({})
   const [loading, setLoading] = useState(false)
+  const [applyingSetup, setApplyingSetup] = useState(false)
   const [actionResult, setActionResult] = useState<IntegrationActionResult | null>(null)
   const [runningActionId, setRunningActionId] = useState<string | null>(null)
 
@@ -136,18 +193,29 @@ export function IntegrationCommandCenter() {
             loadToolchain(activeProjectPath),
           ])
 
-          const [envRes, packageRes] = await Promise.all([
+          const [envRes, packageRes, pnpmLockRes, npmLockRes, yarnLockRes, bunLockRes] = await Promise.all([
             daemon.env.projectVars(activeProjectPath),
             daemon.fs.readFile(joinProjectPath(activeProjectPath, 'package.json')),
+            daemon.fs.readFile(joinProjectPath(activeProjectPath, 'pnpm-lock.yaml')),
+            daemon.fs.readFile(joinProjectPath(activeProjectPath, 'package-lock.json')),
+            daemon.fs.readFile(joinProjectPath(activeProjectPath, 'yarn.lock')),
+            daemon.fs.readFile(joinProjectPath(activeProjectPath, 'bun.lockb')),
           ])
 
           if (cancelled) return
 
           setEnvFiles(envRes.ok && envRes.data ? envRes.data : [])
-          setPackages(packageRes.ok && packageRes.data ? collectPackages(packageRes.data.content) : new Set())
+          setPackageInfo(packageRes.ok && packageRes.data ? parsePackageInfo(packageRes.data.content) : EMPTY_PACKAGE_INFO)
+          setLockfiles({
+            pnpm: Boolean(pnpmLockRes.ok),
+            npm: Boolean(npmLockRes.ok),
+            yarn: Boolean(yarnLockRes.ok),
+            bun: Boolean(bunLockRes.ok),
+          })
         } else {
           setEnvFiles([])
-          setPackages(new Set())
+          setPackageInfo(EMPTY_PACKAGE_INFO)
+          setLockfiles({})
           await loadToolchain(undefined)
         }
       } finally {
@@ -169,14 +237,21 @@ export function IntegrationCommandCenter() {
   const context: IntegrationContext = useMemo(() => ({
     envFiles,
     mcps,
-    packages,
+    packages: packageInfo.packages,
     walletReady: Boolean(defaultWallet),
     defaultWallet,
     secureKeys,
     toolchain,
-  }), [envFiles, mcps, packages, defaultWallet, secureKeys, toolchain])
+  }), [envFiles, mcps, packageInfo, defaultWallet, secureKeys, toolchain])
 
   const registrySummary = useMemo(() => summarizeRegistry(INTEGRATION_REGISTRY, context), [context])
+  const envKeys = useMemo(() => new Set(
+    envFiles.flatMap((file) => file.vars.filter((envVar) => !envVar.isComment).map((envVar) => envVar.key)),
+  ), [envFiles])
+  const sendAiSetupPlan = useMemo(
+    () => createSendAiSetupPlan({ packageInfo, lockfiles, envKeys }),
+    [packageInfo, lockfiles, envKeys],
+  )
 
   const visibleIntegrations = useMemo(() => {
     const query = search.trim().toLowerCase()
@@ -215,6 +290,67 @@ export function IntegrationCommandCenter() {
       setActionResult(result)
     } finally {
       setRunningActionId(null)
+    }
+  }
+
+  async function handleApplySendAiSetup(plan: SendAiSetupPlan) {
+    if (!activeProjectPath || !activeProjectId) {
+      setActionResult({
+        title: 'Open a project first',
+        status: 'warning',
+        detail: 'DAEMON needs an active project before it can install packages or write .env.example.',
+      })
+      return
+    }
+
+    setApplyingSetup(true)
+    setActionResult(null)
+
+    try {
+      const envExamplePath = joinProjectPath(activeProjectPath, plan.envFileName)
+      const currentEnvRes = await daemon.fs.readFile(envExamplePath)
+      const currentEnv = currentEnvRes.ok && currentEnvRes.data ? currentEnvRes.data.content : ''
+      const nextEnv = mergeEnvExample(currentEnv)
+      const changedFiles: string[] = []
+
+      if (nextEnv !== currentEnv) {
+        const writeRes = await daemon.fs.writeFile(envExamplePath, nextEnv)
+        if (!writeRes.ok) {
+          throw new Error(writeRes.error ?? `Could not write ${plan.envFileName}`)
+        }
+        changedFiles.push(plan.envFileName)
+      }
+
+      if (plan.installCommand) {
+        const terminalRes = await daemon.terminal.create({
+          cwd: activeProjectPath,
+          startupCommand: plan.installCommand,
+          userInitiated: true,
+        })
+        if (!terminalRes.ok || !terminalRes.data) {
+          throw new Error(terminalRes.error ?? 'Could not start package install terminal')
+        }
+        addTerminal(activeProjectId, terminalRes.data.id, 'Install SendAI', terminalRes.data.agentId)
+        focusTerminal()
+        changedFiles.push(`terminal: ${plan.installCommand}`)
+      }
+
+      setActionResult({
+        title: 'SendAI setup started',
+        status: 'success',
+        detail: plan.installCommand
+          ? 'DAEMON updated the env template and opened a visible terminal for package installation.'
+          : 'DAEMON updated the env template. Required SendAI packages were already present.',
+        items: changedFiles.length > 0 ? changedFiles : ['No changes needed'],
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'SendAI setup failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not apply the setup plan.',
+      })
+    } finally {
+      setApplyingSetup(false)
     }
   }
 
@@ -306,6 +442,14 @@ export function IntegrationCommandCenter() {
               <span>Install</span>
               <code>{selectedIntegration.installCommand}</code>
             </div>
+          )}
+
+          {selectedIntegration.id === 'sendai-agent-kit' && (
+            <SendAiSetupWorkflow
+              plan={sendAiSetupPlan}
+              applying={applyingSetup}
+              onApply={() => void handleApplySendAiSetup(sendAiSetupPlan)}
+            />
           )}
 
           <div className="icc-detail-section">

--- a/src/panels/IntegrationCommandCenter/sendaiSetup.ts
+++ b/src/panels/IntegrationCommandCenter/sendaiSetup.ts
@@ -1,0 +1,161 @@
+export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
+
+export interface PackageInfo {
+  packages: Set<string>
+  packageManagerHint: PackageManager | null
+}
+
+export interface SendAiSetupPlan {
+  packageManager: PackageManager
+  missingPackages: string[]
+  installedPackages: string[]
+  installCommand: string | null
+  envFileName: string
+  missingEnvKeys: string[]
+  presentEnvKeys: string[]
+  enabledActions: string[]
+  safetyNotes: string[]
+}
+
+export interface EnvTemplateEntry {
+  key: string
+  value: string
+  comment: string
+}
+
+export const SENDAI_AGENT_KIT_PACKAGES = [
+  'solana-agent-kit',
+  '@solana-agent-kit/plugin-token',
+  '@solana-agent-kit/plugin-defi',
+  '@solana-agent-kit/plugin-nft',
+  '@solana-agent-kit/plugin-misc',
+  '@solana-agent-kit/plugin-blinks',
+]
+
+export const SENDAI_ENV_TEMPLATE: EnvTemplateEntry[] = [
+  {
+    key: 'RPC_URL',
+    value: 'https://api.devnet.solana.com',
+    comment: 'Solana RPC endpoint. Start on devnet until the workflow is tested.',
+  },
+  {
+    key: 'OPENAI_API_KEY',
+    value: 'replace_with_model_provider_key',
+    comment: 'Model provider key used by the agent runtime.',
+  },
+  {
+    key: 'SOLANA_PRIVATE_KEY',
+    value: 'replace_with_devnet_wallet_private_key_or_use_daemon_wallet',
+    comment: 'Server-side agent wallet secret. Do not commit real private keys.',
+  },
+  {
+    key: 'HELIUS_API_KEY',
+    value: 'optional_helius_key_for_rpc_das_and_priority_fees',
+    comment: 'Optional but recommended for production RPC, DAS, and priority fees.',
+  },
+]
+
+export function parsePackageInfo(packageJson: string): PackageInfo {
+  try {
+    const parsed = JSON.parse(packageJson) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+      optionalDependencies?: Record<string, string>
+      packageManager?: string
+    }
+    return {
+      packages: new Set([
+        ...Object.keys(parsed.dependencies ?? {}),
+        ...Object.keys(parsed.devDependencies ?? {}),
+        ...Object.keys(parsed.optionalDependencies ?? {}),
+      ]),
+      packageManagerHint: parsePackageManagerHint(parsed.packageManager),
+    }
+  } catch {
+    return { packages: new Set(), packageManagerHint: null }
+  }
+}
+
+export function detectPackageManager(
+  packageInfo: PackageInfo,
+  lockfiles: Partial<Record<PackageManager, boolean>>,
+): PackageManager {
+  if (packageInfo.packageManagerHint) return packageInfo.packageManagerHint
+  if (lockfiles.pnpm) return 'pnpm'
+  if (lockfiles.bun) return 'bun'
+  if (lockfiles.yarn) return 'yarn'
+  return 'npm'
+}
+
+export function buildInstallCommand(packageManager: PackageManager, packages: string[]): string | null {
+  if (packages.length === 0) return null
+  const prefix = packageManager === 'yarn' ? 'yarn add' : `${packageManager} add`
+  return `${prefix} ${packages.join(' ')}`
+}
+
+export function createSendAiSetupPlan(input: {
+  packageInfo: PackageInfo
+  lockfiles: Partial<Record<PackageManager, boolean>>
+  envKeys: Set<string>
+}): SendAiSetupPlan {
+  const packageManager = detectPackageManager(input.packageInfo, input.lockfiles)
+  const missingPackages = SENDAI_AGENT_KIT_PACKAGES.filter((name) => !input.packageInfo.packages.has(name))
+  const installedPackages = SENDAI_AGENT_KIT_PACKAGES.filter((name) => input.packageInfo.packages.has(name))
+  const missingEnvKeys = SENDAI_ENV_TEMPLATE.map((entry) => entry.key).filter((key) => !input.envKeys.has(key))
+  const presentEnvKeys = SENDAI_ENV_TEMPLATE.map((entry) => entry.key).filter((key) => input.envKeys.has(key))
+
+  return {
+    packageManager,
+    missingPackages,
+    installedPackages,
+    installCommand: buildInstallCommand(packageManager, missingPackages),
+    envFileName: '.env.example',
+    missingEnvKeys,
+    presentEnvKeys,
+    enabledActions: [
+      'Create token and NFT action tools',
+      'Preview DeFi routes before signing',
+      'Expose agent-readable Solana actions through MCP later',
+    ],
+    safetyNotes: [
+      'Apply Setup writes placeholders to .env.example, not real secrets.',
+      'Package install runs in a visible terminal so the user can stop it.',
+      'No transaction, mint, swap, or transfer is executed by this setup.',
+    ],
+  }
+}
+
+export function mergeEnvExample(currentContent: string, entries: EnvTemplateEntry[] = SENDAI_ENV_TEMPLATE): string {
+  const normalized = currentContent.replace(/\r\n/g, '\n')
+  const existingKeys = new Set<string>()
+
+  for (const line of normalized.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const withoutExport = trimmed.startsWith('export ') ? trimmed.slice(7) : trimmed
+    const eqIndex = withoutExport.indexOf('=')
+    if (eqIndex > 0) existingKeys.add(withoutExport.slice(0, eqIndex).trim())
+  }
+
+  const missing = entries.filter((entry) => !existingKeys.has(entry.key))
+  if (missing.length === 0) return normalized
+
+  const lines = normalized.length > 0 ? normalized.replace(/\n*$/, '\n').split('\n') : []
+  if (lines.length > 0 && lines[lines.length - 1] !== '') lines.push('')
+  lines.push('# SendAI Solana Agent Kit')
+  for (const entry of missing) {
+    lines.push(`# ${entry.comment}`)
+    lines.push(`${entry.key}=${entry.value}`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+function parsePackageManagerHint(value: string | undefined): PackageManager | null {
+  if (!value) return null
+  if (value.startsWith('pnpm@')) return 'pnpm'
+  if (value.startsWith('npm@')) return 'npm'
+  if (value.startsWith('yarn@')) return 'yarn'
+  if (value.startsWith('bun@')) return 'bun'
+  return null
+}

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -21,6 +21,31 @@ vi.mock('../../src/utils/lazyWithReload', () => ({
 const { CommandDrawer } = await import('../../src/components/CommandDrawer/CommandDrawer')
 
 function installDaemonBridge() {
+  const readFile = vi.fn().mockImplementation(async (filePath: string) => {
+    if (filePath.endsWith('package.json')) {
+      return {
+        ok: true,
+        data: {
+          path: filePath,
+          content: JSON.stringify({
+            packageManager: 'pnpm@9.15.3',
+            dependencies: {
+              'solana-agent-kit': '^2.0.0',
+              '@metaplex-foundation/umi': '^1.0.0',
+            },
+          }),
+        },
+      }
+    }
+
+    if (filePath.endsWith('pnpm-lock.yaml')) {
+      return { ok: true, data: { path: filePath, content: 'lockfileVersion: 9.0' } }
+    }
+
+    return { ok: false, error: 'File not found' }
+  })
+  const writeFile = vi.fn().mockResolvedValue({ ok: true })
+  const createTerminal = vi.fn().mockResolvedValue({ ok: true, data: { id: 'terminal-sendai', pid: 123, agentId: null } })
   const transactionPreview = vi.fn().mockResolvedValue({
     ok: true,
     data: {
@@ -64,18 +89,11 @@ function installDaemonBridge() {
         }),
       },
       fs: {
-        readFile: vi.fn().mockResolvedValue({
-          ok: true,
-          data: {
-            path: 'C:/work/daemon-app/package.json',
-            content: JSON.stringify({
-              dependencies: {
-                'solana-agent-kit': '^2.0.0',
-                '@metaplex-foundation/umi': '^1.0.0',
-              },
-            }),
-          },
-        }),
+        readFile,
+        writeFile,
+      },
+      terminal: {
+        create: createTerminal,
       },
       launch: {
         listLaunchpads: vi.fn().mockResolvedValue({
@@ -150,7 +168,7 @@ function installDaemonBridge() {
     },
   })
 
-  return { transactionPreview }
+  return { createTerminal, readFile, transactionPreview, writeFile }
 }
 
 function resetStores() {
@@ -214,6 +232,21 @@ describe('App surface DOM coverage', () => {
     expect(screen.getAllByText('SendAI Agent Kit').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Helius').length).toBeGreaterThan(0)
     expect(screen.getByText('safe checks')).toBeInTheDocument()
+    expect(screen.getByText('Add Solana Agent Kit to this project')).toBeInTheDocument()
+    expect(await screen.findByText(/pnpm add @solana-agent-kit\/plugin-token/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Apply Setup' }))
+
+    expect(await screen.findByText('SendAI setup started')).toBeInTheDocument()
+    expect(window.daemon.fs.writeFile).toHaveBeenCalledWith(
+      'C:/work/daemon-app/.env.example',
+      expect.stringContaining('SOLANA_PRIVATE_KEY=replace_with_devnet_wallet_private_key_or_use_daemon_wallet'),
+    )
+    expect(window.daemon.terminal.create).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: 'C:/work/daemon-app',
+      startupCommand: expect.stringContaining('pnpm add @solana-agent-kit/plugin-token'),
+    }))
+    expect(useUIStore.getState().terminals.some((terminal) => terminal.id === 'terminal-sendai')).toBe(true)
 
     await userEvent.click(screen.getByRole('button', { name: 'DeFi' }))
     expect(screen.getByRole('heading', { name: 'Jupiter' })).toBeInTheDocument()

--- a/test/panels/IntegrationCommandCenter.sendaiSetup.test.ts
+++ b/test/panels/IntegrationCommandCenter.sendaiSetup.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createSendAiSetupPlan,
+  mergeEnvExample,
+  parsePackageInfo,
+} from '../../src/panels/IntegrationCommandCenter/sendaiSetup'
+
+describe('SendAI Agent Kit setup planner', () => {
+  it('detects package manager and only installs missing packages', () => {
+    const packageInfo = parsePackageInfo(JSON.stringify({
+      packageManager: 'pnpm@9.15.3',
+      dependencies: {
+        'solana-agent-kit': '^2.0.0',
+        '@solana-agent-kit/plugin-token': '^2.0.0',
+      },
+    }))
+
+    const plan = createSendAiSetupPlan({
+      packageInfo,
+      lockfiles: {},
+      envKeys: new Set(['RPC_URL']),
+    })
+
+    expect(plan.packageManager).toBe('pnpm')
+    expect(plan.installCommand).toContain('pnpm add @solana-agent-kit/plugin-defi')
+    expect(plan.installCommand).not.toContain('pnpm add solana-agent-kit')
+    expect(plan.presentEnvKeys).toEqual(['RPC_URL'])
+    expect(plan.missingEnvKeys).toContain('SOLANA_PRIVATE_KEY')
+  })
+
+  it('merges env example placeholders without duplicating existing keys', () => {
+    const merged = mergeEnvExample('RPC_URL=https://rpc.example\n')
+
+    expect(merged).toContain('# SendAI Solana Agent Kit')
+    expect(merged).toContain('OPENAI_API_KEY=replace_with_model_provider_key')
+    expect(merged).toContain('SOLANA_PRIVATE_KEY=replace_with_devnet_wallet_private_key_or_use_daemon_wallet')
+    expect(merged.match(/^RPC_URL=/gm)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Add a guided SendAI Agent Kit setup workflow inside the Integration Command Center.
- Detect package manager/package readiness and preview install/env template changes.
- Apply setup by writing safe .env.example placeholders and opening a visible terminal for package installation only.

## Validation
- pnpm run typecheck
- pnpm test -- test/panels/IntegrationCommandCenter.sendaiSetup.test.ts test/panels/IntegrationCommandCenter.registry.test.ts test/panels/AppSurfaces.dom.test.tsx
- pnpm run test:layout
- pnpm run test:responsive
- git diff --check

## Note
- pnpm run test:visual builds successfully, but current visual snapshot comparison reports unrelated baseline drift in right-panel/ARIA/terminal surfaces that this branch does not modify.