### PR TITLE
Add first SendAI agent scaffold workflow

### DIFF
--- a/scripts/smoke/app-responsive.mjs
+++ b/scripts/smoke/app-responsive.mjs
@@ -233,7 +233,7 @@ async function assertNoHorizontalOverflow(page, viewportName, contextName) {
 }
 
 async function verifySolanaTabs(page) {
-  const tabs = ['Overview', 'Connect', 'Build', 'Integrate', 'Diagnose']
+  const tabs = ['Start', 'Connect', 'Transact', 'Launch', 'Debug']
   for (const tab of tabs) {
     await page.locator('.solana-view-tab').evaluateAll((nodes, expected) => {
       for (const node of nodes) {

--- a/src/lib/solanaReadiness.ts
+++ b/src/lib/solanaReadiness.ts
@@ -1,0 +1,164 @@
+export interface SolanaRouteReadinessItem {
+  key: string
+  label: string
+  ready: boolean
+  detail: string
+}
+
+export interface SolanaRouteNextAction {
+  id: 'open-project' | 'open-wallet' | 'set-main-wallet' | 'assign-project' | 'set-preferred-wallet' | 'open-infrastructure' | 'preview-transaction' | 'transact'
+  label: string
+  detail: string
+}
+
+export interface SolanaRouteReadinessModel {
+  headline: string
+  description: string
+  items: SolanaRouteReadinessItem[]
+  nextAction: SolanaRouteNextAction
+  readyCount: number
+  totalCount: number
+  walletLabel: string
+  signingPathLabel: string
+}
+
+interface BuildSolanaRouteReadinessInput {
+  walletPresent: boolean
+  walletName?: string | null
+  walletAddress?: string | null
+  isMainWallet: boolean
+  signerReady: boolean
+  hasActiveProject: boolean
+  projectAssigned: boolean
+  preferredWallet: WalletInfrastructureSettings['preferredWallet']
+  executionMode: WalletInfrastructureSettings['executionMode']
+  rpcLabel: string
+  rpcReady: boolean
+  requirePreferredWallet?: boolean
+}
+
+export function buildSolanaRouteReadiness(input: BuildSolanaRouteReadinessInput): SolanaRouteReadinessModel {
+  const preferredWalletReady = input.requirePreferredWallet ? input.preferredWallet === 'phantom' : true
+  const preferredWalletDetail = input.preferredWallet === 'phantom'
+    ? 'Phantom-first wallet UX is active for transaction review and signing.'
+    : 'Wallet Standard is active. Phantom-specific flows are still available, but not preferred.'
+
+  const items: SolanaRouteReadinessItem[] = [
+    {
+      key: 'main-wallet',
+      label: 'Main wallet route',
+      ready: input.walletPresent && input.isMainWallet,
+      detail: input.walletPresent
+        ? input.isMainWallet
+          ? `${input.walletName ?? 'Wallet'} is the default route for wallet-backed Solana actions.`
+          : `${input.walletName ?? 'Wallet'} is available, but another wallet is still marked as main.`
+        : 'No wallet is configured yet.',
+    },
+    {
+      key: 'signer',
+      label: 'Signer ready',
+      ready: input.walletPresent && input.signerReady,
+      detail: input.walletPresent
+        ? input.signerReady
+          ? 'This wallet can sign sends, swaps, previews, and launch flows.'
+          : 'This wallet is watch-only until a signer is imported or generated.'
+        : 'A wallet must exist before signer readiness matters.',
+    },
+    {
+      key: 'project',
+      label: 'Project assignment',
+      ready: input.hasActiveProject ? input.projectAssigned : true,
+      detail: input.hasActiveProject
+        ? input.projectAssigned
+          ? 'The active project already routes through this wallet.'
+          : 'The active project is not assigned to this wallet yet.'
+        : 'No active project selected, so assignment is optional.',
+    },
+    {
+      key: 'provider',
+      label: 'Execution path',
+      ready: input.rpcReady && preferredWalletReady,
+      detail: `${input.rpcLabel} • ${input.executionMode === 'jito' ? 'Jito relay' : 'Standard RPC'} • ${preferredWalletDetail}`,
+    },
+  ]
+
+  const nextAction: SolanaRouteNextAction = !input.walletPresent
+    ? {
+      id: 'open-wallet',
+      label: 'Open wallet manager',
+      detail: 'Create or import a wallet first so DAEMON has one Solana route to work from.',
+    }
+    : !input.isMainWallet
+      ? {
+        id: 'set-main-wallet',
+        label: 'Make this the main wallet',
+        detail: 'Use one default wallet route so sends, swaps, and previews do not guess which wallet to use.',
+      }
+      : !input.signerReady
+        ? {
+          id: 'open-wallet',
+          label: 'Open wallet manager',
+          detail: 'Import or generate a signer before expecting wallet-backed actions to work.',
+        }
+        : input.hasActiveProject && !input.projectAssigned
+          ? {
+            id: 'assign-project',
+            label: 'Use wallet for current project',
+            detail: 'Bind the wallet to the active project so Solana workflows use the right signer path by default.',
+          }
+          : !input.rpcReady
+            ? {
+              id: 'open-infrastructure',
+              label: 'Open infrastructure',
+              detail: 'Finish the RPC path before using wallet-backed Solana execution.',
+            }
+            : input.requirePreferredWallet && input.preferredWallet !== 'phantom'
+              ? {
+                id: 'set-preferred-wallet',
+                label: 'Set Phantom as preferred wallet',
+                detail: 'Switch DAEMON to a Phantom-first wallet path so signing UX stays consistent.',
+              }
+              : {
+                id: input.requirePreferredWallet ? 'preview-transaction' : 'transact',
+                label: input.requirePreferredWallet ? 'Preview first transaction' : 'Move funds',
+                detail: input.requirePreferredWallet
+                  ? 'Preview one safe Solana transaction so the signing flow is visible before anything is sent.'
+                  : 'The wallet route is ready. Move into sends, swaps, or holdings next.',
+              }
+
+  const headline = nextAction.id === 'open-wallet'
+    ? input.walletPresent
+      ? 'Add a signer before this wallet can act'
+      : 'Create a wallet route first'
+    : nextAction.id === 'set-main-wallet'
+      ? 'Promote this wallet to the main route'
+      : nextAction.id === 'assign-project'
+        ? 'Route this wallet into the current project'
+        : nextAction.id === 'open-infrastructure'
+          ? 'Finish the execution path before sending'
+          : nextAction.id === 'set-preferred-wallet'
+            ? 'Switch to a Phantom-first signing path'
+            : nextAction.id === 'preview-transaction'
+              ? 'Wallet route is ready for a safe first preview'
+              : 'Wallet route is ready for Solana actions'
+
+  const description = nextAction.detail
+  const readyCount = items.filter((item) => item.ready).length
+  const walletLabel = input.walletPresent
+    ? `${input.walletName ?? 'Wallet'} • ${input.walletAddress ?? 'address pending'}`
+    : 'No wallet configured'
+  const signingPathLabel = input.preferredWallet === 'phantom'
+    ? 'Phantom-first wallet UX'
+    : 'Wallet-standard wallet UX'
+
+  return {
+    headline,
+    description,
+    items,
+    nextAction,
+    readyCount,
+    totalCount: items.length,
+    walletLabel,
+    signingPathLabel,
+  }
+}

--- a/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.css
+++ b/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.css
@@ -3,7 +3,9 @@
   flex-direction: column;
   min-height: 0;
   height: 100%;
+  width: 100%;
   overflow: hidden;
+  container-type: inline-size;
   background:
     radial-gradient(circle at 16% 0%, rgba(20, 241, 149, 0.06), transparent 28%),
     var(--bg);
@@ -12,11 +14,44 @@
 
 .icc-header {
   flex-shrink: 0;
+  display: grid;
+  gap: 6px;
+  padding: 4px var(--drawer-space-inline) var(--drawer-space-block);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.045);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent 100%),
+    rgba(255, 255, 255, 0.008);
+}
+
+.icc-header-kicker {
+  color: #98fbd0;
+  font-size: 10px;
+  font-weight: 780;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.icc-header-title {
+  max-width: 700px;
+  margin: 0;
+  color: var(--t1);
+  font-size: clamp(19px, 2.4cqi, 28px);
+  font-weight: 780;
+  line-height: 1.08;
+  text-wrap: balance;
+}
+
+.icc-header-subtitle {
+  max-width: 780px;
+  margin: 0;
+  color: var(--t3);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .icc-metrics {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(168px, 100%), 1fr));
   gap: 10px;
   padding: 0 var(--drawer-space-inline) var(--drawer-space-block);
   flex-shrink: 0;
@@ -48,7 +83,7 @@
 
 .icc-toolbar {
   display: grid;
-  grid-template-columns: minmax(220px, 0.8fr) minmax(0, 1.2fr);
+  grid-template-columns: minmax(220px, 0.85fr) minmax(0, 1.15fr);
   gap: 12px;
   padding: 0 var(--drawer-space-inline) var(--drawer-space-block);
   flex-shrink: 0;
@@ -100,7 +135,7 @@
 
 .icc-layout {
   display: grid;
-  grid-template-columns: minmax(260px, 0.95fr) minmax(340px, 1.05fr);
+  grid-template-columns: minmax(250px, 0.92fr) minmax(0, 1.08fr);
   gap: 12px;
   min-height: 0;
   padding: 0 var(--drawer-space-inline) var(--drawer-space-inline);
@@ -253,6 +288,10 @@
   gap: 10px;
 }
 
+.icc-detail-section--compact {
+  gap: 8px;
+}
+
 .icc-requirements,
 .icc-actions,
 .icc-result-items {
@@ -381,6 +420,99 @@
   line-height: 1.45;
 }
 
+.icc-guided-next {
+  display: grid;
+  gap: 6px;
+  padding: 11px 12px;
+  border: 1px solid rgba(20, 241, 149, 0.16);
+  border-radius: var(--radius-md);
+  background: rgba(20, 241, 149, 0.055);
+}
+
+.icc-guided-next strong {
+  color: var(--t1);
+  font-size: 14px;
+  font-weight: 780;
+  line-height: 1.2;
+}
+
+.icc-guided-next p {
+  margin: 0;
+  color: var(--t3);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.icc-step-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.icc-step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.icc-step.active {
+  border-color: rgba(20, 241, 149, 0.2);
+  background: rgba(20, 241, 149, 0.045);
+}
+
+.icc-step.ready {
+  border-color: rgba(20, 241, 149, 0.14);
+}
+
+.icc-step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--t2);
+  font-size: 11px;
+  font-weight: 780;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.icc-step.active .icc-step-index,
+.icc-step.ready .icc-step-index {
+  border-color: rgba(20, 241, 149, 0.22);
+  color: #98fbd0;
+}
+
+.icc-step-main {
+  min-width: 0;
+}
+
+.icc-step-main strong {
+  display: block;
+  color: var(--t1);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.icc-step-main p {
+  margin: 4px 0 0;
+  color: var(--t4);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.icc-step-main code {
+  color: var(--t2);
+  font-size: 11px;
+}
+
 .icc-plan-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -475,6 +607,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .icc-action {
@@ -573,7 +706,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: auto;
+  margin-top: 2px;
 }
 
 .icc-primary,
@@ -606,7 +739,7 @@
   text-align: center;
 }
 
-@media (max-width: 1100px) {
+@container (max-width: 1080px) {
   .icc-toolbar,
   .icc-layout {
     grid-template-columns: 1fr;
@@ -622,7 +755,7 @@
   }
 }
 
-@media (max-width: 720px) {
+@container (max-width: 760px) {
   .icc-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -631,7 +764,8 @@
   .icc-detail-head,
   .icc-setup-head,
   .icc-footer-actions,
-  .icc-action {
+  .icc-action,
+  .icc-step {
     align-items: stretch;
     flex-direction: column;
   }
@@ -644,5 +778,38 @@
   .icc-setup-actions,
   .icc-footer-actions {
     justify-content: stretch;
+  }
+
+  .icc-step {
+    display: flex;
+  }
+
+  .icc-primary,
+  .icc-secondary {
+    width: 100%;
+  }
+}
+
+@container (max-width: 560px) {
+  .icc-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .icc-header {
+    gap: 5px;
+    padding-top: 2px;
+  }
+
+  .icc-toolbar {
+    gap: 10px;
+  }
+
+  .icc-header-title {
+    font-size: 18px;
+    line-height: 1.12;
+  }
+
+  .icc-header-subtitle {
+    font-size: 11px;
   }
 }

--- a/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.css
+++ b/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.css
@@ -353,6 +353,13 @@
     rgba(255, 255, 255, 0.02);
 }
 
+.icc-setup-workflow--secondary {
+  border-color: rgba(102, 172, 255, 0.18);
+  background:
+    linear-gradient(180deg, rgba(102, 172, 255, 0.06), transparent 120px),
+    rgba(255, 255, 255, 0.02);
+}
+
 .icc-setup-head {
   display: flex;
   align-items: flex-start;
@@ -438,6 +445,16 @@
   border-top: 1px solid rgba(255, 255, 255, 0.055);
 }
 
+.icc-inline-note {
+  padding: 10px;
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  border-radius: var(--radius-md);
+  background: rgba(245, 158, 11, 0.06);
+  color: var(--t3);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
 .icc-safety-notes span::before {
   content: 'safe';
   display: inline-block;
@@ -451,6 +468,13 @@
 
 .icc-apply-setup {
   align-self: flex-end;
+}
+
+.icc-setup-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 .icc-action {
@@ -617,6 +641,7 @@
     grid-template-columns: 1fr;
   }
 
+  .icc-setup-actions,
   .icc-footer-actions {
     justify-content: stretch;
   }

--- a/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
+++ b/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
@@ -4,6 +4,7 @@ import { useAppActions } from '../../store/appActions'
 import { useUIStore } from '../../store/ui'
 import { useSolanaToolboxStore } from '../../store/solanaToolbox'
 import type { EnvFile, WalletListEntry } from '../../types/daemon'
+import { buildSolanaRouteReadiness } from '../../lib/solanaReadiness'
 import { INTEGRATION_CATEGORIES, INTEGRATION_REGISTRY, type IntegrationCategory, type IntegrationDefinition } from './registry'
 import { runIntegrationAction, type IntegrationActionResult } from './actionRunner'
 import { resolveIntegrationStatus, summarizeRegistry, type IntegrationContext, type IntegrationStatusSummary } from './status'
@@ -34,6 +35,114 @@ function statusLabel(summary: IntegrationStatusSummary): string {
 }
 
 const EMPTY_PACKAGE_INFO: PackageInfo = { packages: new Set(), scripts: new Set(), packageManagerHint: null }
+const SOL_MINT = 'So11111111111111111111111111111111111111112'
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+const METAPLEX_DRAFT_DIR = 'assets/metaplex'
+const METAPLEX_DRAFT_FILE = `${METAPLEX_DRAFT_DIR}/metadata.example.json`
+const METAPLEX_DRAFT_SCRIPT = 'metaplex:draft-check'
+const LIGHT_STARTER_DIR = 'src/light'
+const LIGHT_STARTER_FILE = `${LIGHT_STARTER_DIR}/compression-check.mjs`
+const LIGHT_STARTER_SCRIPT = 'light:check'
+const GUIDED_WORKFLOW_INTEGRATIONS = new Set([
+  'sendai-agent-kit',
+  'sendai-solana-mcp',
+  'helius',
+  'phantom',
+  'jupiter',
+  'metaplex',
+  'light-protocol',
+  'protocol-skills',
+])
+const DEFAULT_WALLET_INFRASTRUCTURE: WalletInfrastructureSettings = {
+  rpcProvider: 'helius',
+  quicknodeRpcUrl: '',
+  customRpcUrl: '',
+  swapProvider: 'jupiter',
+  preferredWallet: 'phantom',
+  executionMode: 'rpc',
+  jitoBlockEngineUrl: 'https://mainnet.block-engine.jito.wtf/api/v1/transactions',
+}
+
+interface DetailShortcut {
+  label: string
+  onClick: () => void
+}
+
+function getWalletRpcLabel(settings: WalletInfrastructureSettings): string {
+  if (settings.rpcProvider === 'helius') return 'Helius RPC'
+  if (settings.rpcProvider === 'quicknode') return 'QuickNode RPC'
+  if (settings.rpcProvider === 'custom') return 'Custom RPC'
+  return 'Public RPC'
+}
+
+function isWalletRpcReady(settings: WalletInfrastructureSettings, heliusConfigured: boolean): boolean {
+  if (settings.rpcProvider === 'helius') return heliusConfigured
+  if (settings.rpcProvider === 'quicknode') return settings.quicknodeRpcUrl.trim().length > 0
+  if (settings.rpcProvider === 'custom') return settings.customRpcUrl.trim().length > 0
+  return true
+}
+
+function buildSendAiSkillSuggestions(context: IntegrationContext): string[] {
+  const suggestions: string[] = []
+
+  if (context.packages.has('solana-agent-kit')) suggestions.push('solana-agent-kit')
+  if (context.secureKeys.HELIUS_API_KEY || context.mcps.some((entry) => entry.name === 'helius' && entry.enabled)) suggestions.push('helius')
+  if (context.secureKeys.JUPITER_API_KEY) suggestions.push('integrating-jupiter')
+  if (context.packages.has('@metaplex-foundation/umi')) suggestions.push('metaplex')
+  if (context.packages.has('@lightprotocol/stateless.js')) suggestions.push('light-protocol')
+  if (context.packages.has('@raydium-io/raydium-sdk-v2')) suggestions.push('raydium')
+
+  return suggestions.length > 0 ? suggestions : ['solana-agent-kit', 'helius', 'integrating-jupiter']
+}
+
+function buildMetaplexDraftFile(): string {
+  return `${JSON.stringify({
+    name: 'DAEMON Collection Example',
+    symbol: 'DMON',
+    description: 'Example Metaplex metadata draft scaffolded by DAEMON.',
+    seller_fee_basis_points: 500,
+    image: 'image.png',
+    external_url: 'https://example.com',
+    attributes: [
+      { trait_type: 'Collection', value: 'Example' },
+      { trait_type: 'Tier', value: 'Starter' },
+    ],
+    properties: {
+      category: 'image',
+      files: [
+        { type: 'image/png', uri: 'image.png' },
+      ],
+      creators: [
+        { address: 'replace_with_creator_wallet', share: 100 },
+      ],
+    },
+  }, null, 2)}\n`
+}
+
+function buildLightCompressionStarter(): string {
+  return `async function main() {
+  const rpcUrl = process.env.RPC_URL?.trim()
+  if (!rpcUrl) {
+    throw new Error('Missing RPC_URL. Copy .env.example into .env and set a compression-capable RPC first.')
+  }
+
+  const light = await import('@lightprotocol/stateless.js')
+  const exportedKeys = Object.keys(light).sort()
+
+  console.log('Light Protocol starter is ready.')
+  console.log(\`RPC: \${rpcUrl}\`)
+  console.log(\`Exports detected: \${exportedKeys.length}\`)
+  console.log(\`Sample exports: \${exportedKeys.slice(0, 12).join(', ')}\`)
+  console.log('Next step: replace this import check with the compressed-state flow you want DAEMON to guide.')
+}
+
+main().catch((error) => {
+  console.error('Light starter failed.')
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})
+`
+}
 
 function RiskPill({ risk }: { risk: string }) {
   return <span className={`icc-risk icc-risk--${risk}`}>{risk.replace('-', ' ')}</span>
@@ -58,135 +167,415 @@ function RequirementList({ summary }: { summary: IntegrationStatusSummary }) {
   )
 }
 
-function SendAiSetupWorkflow({
-  plan,
+function SendAiAgentLaunchpad({
+  projectReady,
+  setupPlan,
+  agentPlan,
+  setupApplied,
   applying,
-  onApply,
+  scaffolding,
+  running,
+  onOpenProjectStarter,
+  onApplySetup,
+  onScaffold,
+  onRun,
 }: {
-  plan: SendAiSetupPlan
+  projectReady: boolean
+  setupPlan: SendAiSetupPlan
+  agentPlan: FirstAgentPlan
+  setupApplied: boolean
   applying: boolean
-  onApply: () => void
+  scaffolding: boolean
+  running: boolean
+  onOpenProjectStarter: () => void
+  onApplySetup: () => void
+  onScaffold: () => void
+  onRun: () => void
 }) {
+  const setupNeedsAction = projectReady && !setupApplied && (Boolean(setupPlan.installCommand) || setupPlan.missingEnvKeys.length > 0)
+  const setupDone = !setupNeedsAction
+  const scaffoldDone = agentPlan.alreadyScaffolded
+  const runReady = projectReady && agentPlan.canRun
+
+  const nextAction = !projectReady
+    ? {
+      label: 'Open New Project',
+      detail: 'Create or open a Node-based Solana project first so DAEMON has somewhere to install packages, write env files, and scaffold the starter agent.',
+      disabled: false,
+      action: onOpenProjectStarter,
+    }
+    : setupNeedsAction
+    ? {
+      label: applying ? 'Applying project setup...' : 'Apply project setup',
+      detail: setupPlan.installCommand
+        ? `Install ${setupPlan.missingPackages.length} package${setupPlan.missingPackages.length === 1 ? '' : 's'} and add ${setupPlan.missingEnvKeys.length} env template key${setupPlan.missingEnvKeys.length === 1 ? '' : 's'}.`
+        : `Add ${setupPlan.missingEnvKeys.length} env template key${setupPlan.missingEnvKeys.length === 1 ? '' : 's'} so the starter has the right placeholders.`,
+      disabled: applying,
+      action: onApplySetup,
+    }
+    : !scaffoldDone
+      ? {
+        label: scaffolding ? 'Creating starter files...' : 'Create starter files',
+        detail: 'Write the starter agent, README, and one package.json script so this project has a clear first run path.',
+        disabled: scaffolding || !agentPlan.canScaffold,
+        action: onScaffold,
+      }
+      : {
+        label: running ? 'Opening starter check...' : 'Run starter check',
+        detail: 'Open a visible terminal and run the safe readiness check so you can verify the first agent boots cleanly.',
+        disabled: running || !runReady,
+        action: onRun,
+      }
+
   return (
     <div className="icc-setup-workflow">
       <div className="icc-setup-head">
         <div>
-          <span className="icc-section-title">Guided setup</span>
-          <h3>Add Solana Agent Kit to this project</h3>
-          <p>Preview what DAEMON will do, then apply only the package install and env template changes.</p>
+          <span className="icc-section-title">Guided path</span>
+          <h3>Get this project to a first working SendAI agent</h3>
+          <p>Instead of sending you to another drawer, DAEMON can take the project through setup, scaffolding, and a safe first run in order.</p>
         </div>
-        <span className="icc-status-badge partial">{plan.packageManager}</span>
-      </div>
-
-      <div className="icc-plan-grid">
-        <div className="icc-plan-card">
-          <span>Install command</span>
-          <code>{plan.installCommand ?? 'All SendAI packages are already installed'}</code>
-        </div>
-        <div className="icc-plan-card">
-          <span>Env template</span>
-          <code>{plan.envFileName} adds {plan.missingEnvKeys.length} missing key{plan.missingEnvKeys.length === 1 ? '' : 's'}</code>
-        </div>
-      </div>
-
-      <div className="icc-plan-columns">
-        <div>
-          <span className="icc-mini-title">Packages</span>
-          <div className="icc-check-list">
-            {plan.missingPackages.map((name) => <span key={name}>Install {name}</span>)}
-            {plan.missingPackages.length === 0 ? <span>All recommended packages are present</span> : null}
-          </div>
-        </div>
-        <div>
-          <span className="icc-mini-title">Env keys</span>
-          <div className="icc-check-list">
-            {plan.missingEnvKeys.map((key) => <span key={key}>Template {key}</span>)}
-            {plan.missingEnvKeys.length === 0 ? <span>Env template keys already detected</span> : null}
-          </div>
-        </div>
-      </div>
-
-      <div className="icc-safety-notes">
-        {plan.safetyNotes.map((note) => <span key={note}>{note}</span>)}
-      </div>
-
-      <button type="button" className="icc-primary icc-apply-setup" onClick={onApply} disabled={applying}>
-        {applying ? 'Applying setup...' : 'Apply Setup'}
-      </button>
-    </div>
-  )
-}
-
-function SendAiFirstAgentWorkflow({
-  plan,
-  scaffolding,
-  running,
-  onScaffold,
-  onRun,
-}: {
-  plan: FirstAgentPlan
-  scaffolding: boolean
-  running: boolean
-  onScaffold: () => void
-  onRun: () => void
-}) {
-  return (
-    <div className="icc-setup-workflow icc-setup-workflow--secondary">
-      <div className="icc-setup-head">
-        <div>
-          <span className="icc-section-title">First success</span>
-          <h3>Create your first Solana agent</h3>
-          <p>DAEMON can scaffold a starter file, add one package script, and give the project a single command to run.</p>
-        </div>
-        <span className={`icc-status-badge ${plan.alreadyScaffolded ? 'ready' : 'partial'}`}>
-          {plan.alreadyScaffolded ? 'scaffolded' : 'ready to scaffold'}
+        <span className={`icc-status-badge ${runReady ? 'ready' : 'partial'}`}>
+          {runReady ? 'ready to run' : 'guided'}
         </span>
+      </div>
+
+      <div className="icc-guided-next">
+        <span className="icc-mini-title">Next step</span>
+        <strong>{nextAction.label.replace(/\.\.\.$/, '')}</strong>
+        <p>{nextAction.detail}</p>
+      </div>
+
+      <div className="icc-step-list">
+        <div className={`icc-step ${projectReady ? 'ready' : 'active'}`}>
+          <span className="icc-step-index">0</span>
+          <div className="icc-step-main">
+            <strong>Project context</strong>
+            <p>{projectReady ? 'Active Node/Solana project detected.' : 'Open or scaffold a project before SendAI setup can start.'}</p>
+          </div>
+          <span className={`icc-status-badge ${projectReady ? 'ready' : 'partial'}`}>{projectReady ? 'done' : 'next'}</span>
+        </div>
+
+        <div className={`icc-step ${setupDone ? 'ready' : 'active'}`}>
+          <span className="icc-step-index">1</span>
+          <div className="icc-step-main">
+            <strong>Project setup</strong>
+            <p>{setupPlan.installCommand ?? 'Runtime packages already installed'}{setupPlan.installCommand ? '' : '. Env template keys are already present.'}</p>
+          </div>
+          <span className={`icc-status-badge ${setupDone ? 'ready' : 'partial'}`}>{setupDone ? 'done' : 'next'}</span>
+        </div>
+
+        <div className={`icc-step ${setupDone && !scaffoldDone ? 'active' : scaffoldDone ? 'ready' : ''}`}>
+          <span className="icc-step-index">2</span>
+          <div className="icc-step-main">
+            <strong>Starter files</strong>
+            <p>{agentPlan.entryFilePath}, {agentPlan.readmePath}, and {agentPlan.scriptName} in package.json.</p>
+          </div>
+          <span className={`icc-status-badge ${scaffoldDone ? 'ready' : setupDone ? 'partial' : ''}`}>{scaffoldDone ? 'done' : setupDone ? 'next' : 'waiting'}</span>
+        </div>
+
+        <div className={`icc-step ${scaffoldDone && !runReady ? 'active' : runReady ? 'ready' : ''}`}>
+          <span className="icc-step-index">3</span>
+          <div className="icc-step-main">
+            <strong>Safe starter check</strong>
+            <p>Run <code>{agentPlan.runCommand}</code> in a visible terminal so the developer can watch the first-agent readiness check.</p>
+          </div>
+          <span className={`icc-status-badge ${runReady ? 'ready' : scaffoldDone ? 'partial' : ''}`}>{runReady ? 'ready' : scaffoldDone ? 'next' : 'waiting'}</span>
+        </div>
       </div>
 
       <div className="icc-plan-grid">
         <div className="icc-plan-card">
           <span>Starter file</span>
-          <code>{plan.entryFilePath}</code>
+          <code>{agentPlan.entryFilePath}</code>
         </div>
         <div className="icc-plan-card">
           <span>Run command</span>
-          <code>{plan.runCommand}</code>
+          <code>{agentPlan.runCommand}</code>
         </div>
       </div>
 
       <div className="icc-plan-columns">
         <div>
-          <span className="icc-mini-title">What DAEMON adds</span>
+          <span className="icc-mini-title">Readiness</span>
           <div className="icc-check-list">
-            <span>{plan.entryFilePath}</span>
-            <span>{plan.readmePath}</span>
-            <span>{plan.scriptName} in package.json</span>
+            {agentPlan.prerequisites.map((item) => <span key={item}>{item}</span>)}
           </div>
         </div>
         <div>
-          <span className="icc-mini-title">Readiness</span>
+          <span className="icc-mini-title">Safety</span>
           <div className="icc-check-list">
-            {plan.prerequisites.map((item) => <span key={item}>{item}</span>)}
+            {[...setupPlan.safetyNotes, ...agentPlan.safetyNotes].map((note) => <span key={note}>{note}</span>)}
           </div>
         </div>
       </div>
 
-      {plan.missingPackages.length > 0 && (
-        <div className="icc-inline-note">
-          Install the SendAI runtime packages first. The scaffold is safe to create now, but the starter check should wait until install completes.
-        </div>
-      )}
+      <div className="icc-setup-actions">
+        <button type="button" className="icc-primary" onClick={nextAction.action} disabled={nextAction.disabled}>
+          {nextAction.label}
+        </button>
+      </div>
+    </div>
+  )
+}
 
-      <div className="icc-safety-notes">
-        {plan.safetyNotes.map((note) => <span key={note}>{note}</span>)}
+function SendAiSkillsWorkflow({
+  installCommand,
+  suggestions,
+  installing,
+  onInstall,
+}: {
+  installCommand: string
+  suggestions: string[]
+  installing: boolean
+  onInstall: () => void
+}) {
+  return (
+    <div className="icc-setup-workflow icc-setup-workflow--secondary">
+      <div className="icc-setup-head">
+        <div>
+          <span className="icc-section-title">Curated skills</span>
+          <h3>Bring protocol knowledge into this project</h3>
+          <p>DAEMON can install the skills pack here and show the protocol guides that best match the current codebase.</p>
+        </div>
+        <span className="icc-status-badge partial">recommended</span>
+      </div>
+
+      <div className="icc-plan-grid">
+        <div className="icc-plan-card">
+          <span>Install command</span>
+          <code>{installCommand}</code>
+        </div>
+        <div className="icc-plan-card">
+          <span>Best skill matches</span>
+          <code>{suggestions.join(', ')}</code>
+        </div>
+      </div>
+
+      <div className="icc-plan-columns">
+        <div>
+          <span className="icc-mini-title">Suggested skills</span>
+          <div className="icc-check-list">
+            {suggestions.map((suggestion) => <span key={suggestion}>{suggestion}</span>)}
+          </div>
+        </div>
+        <div>
+          <span className="icc-mini-title">What this helps with</span>
+          <div className="icc-check-list">
+            <span>Protocol docs inside DAEMON</span>
+            <span>Cleaner integration recipes</span>
+            <span>Less context-switching to external repos</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="icc-inline-note">
+        This opens a visible terminal and runs the skills install command in the current project. It does not execute any on-chain action.
       </div>
 
       <div className="icc-setup-actions">
-        <button type="button" className="icc-secondary" onClick={onScaffold} disabled={!plan.canScaffold || scaffolding}>
-          {scaffolding ? 'Creating files...' : plan.alreadyScaffolded ? 'Starter files created' : 'Create Starter Files'}
+        <button type="button" className="icc-primary" onClick={onInstall} disabled={installing}>
+          {installing ? 'Opening install terminal...' : 'Install skills in terminal'}
         </button>
-        <button type="button" className="icc-primary" onClick={onRun} disabled={!plan.canRun || running}>
-          {running ? 'Opening terminal...' : 'Run Starter Check'}
+      </div>
+    </div>
+  )
+}
+
+function IntegrationFirstWinWorkflow({
+  sectionTitle,
+  title,
+  description,
+  status,
+  nextLabel,
+  nextDetail,
+  cards,
+  items,
+  primaryLabel,
+  primaryBusyLabel,
+  busy,
+  onPrimary,
+  secondaryLabel,
+  onSecondary,
+  note,
+}: {
+  sectionTitle: string
+  title: string
+  description: string
+  status: 'ready' | 'partial'
+  nextLabel: string
+  nextDetail: string
+  cards: Array<{ label: string; value: string }>
+  items: Array<{ label: string; detail: string; ready: boolean }>
+  primaryLabel: string
+  primaryBusyLabel: string
+  busy: boolean
+  onPrimary: () => void
+  secondaryLabel?: string
+  onSecondary?: () => void
+  note?: string
+}) {
+  return (
+    <div className="icc-setup-workflow">
+      <div className="icc-setup-head">
+        <div>
+          <span className="icc-section-title">{sectionTitle}</span>
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </div>
+        <span className={`icc-status-badge ${status}`}>{status === 'ready' ? 'ready' : 'guided'}</span>
+      </div>
+
+      <div className="icc-guided-next">
+        <span className="icc-mini-title">Next step</span>
+        <strong>{nextLabel}</strong>
+        <p>{nextDetail}</p>
+      </div>
+
+      <div className="icc-plan-grid">
+        {cards.map((card) => (
+          <div key={card.label} className="icc-plan-card">
+            <span>{card.label}</span>
+            <code>{card.value}</code>
+          </div>
+        ))}
+      </div>
+
+      <div className="icc-step-list">
+        {items.map((item, index) => (
+          <div key={item.label} className={`icc-step ${item.ready ? 'ready' : 'active'}`}>
+            <span className="icc-step-index">{index + 1}</span>
+            <div className="icc-step-main">
+              <strong>{item.label}</strong>
+              <p>{item.detail}</p>
+            </div>
+            <span className={`icc-status-badge ${item.ready ? 'ready' : 'partial'}`}>{item.ready ? 'done' : 'next'}</span>
+          </div>
+        ))}
+      </div>
+
+      {note ? <div className="icc-inline-note">{note}</div> : null}
+
+      <div className="icc-setup-actions">
+        <button type="button" className="icc-primary" onClick={onPrimary} disabled={busy}>
+          {busy ? primaryBusyLabel : primaryLabel}
+        </button>
+        {secondaryLabel && onSecondary ? (
+          <button type="button" className="icc-secondary" onClick={onSecondary}>
+            {secondaryLabel}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function PhantomWalletWorkflow({
+  wallet,
+  isMainWallet,
+  signerReady,
+  projectAssigned,
+  hasActiveProject,
+  preferredWallet,
+  executionMode,
+  rpcLabel,
+  rpcReady,
+  busy,
+  onOpenWallet,
+  onSetMainWallet,
+  onAssignProject,
+  onPreferPhantom,
+  onPreviewTransaction,
+}: {
+  wallet: WalletListEntry | null
+  isMainWallet: boolean
+  signerReady: boolean
+  projectAssigned: boolean
+  hasActiveProject: boolean
+  preferredWallet: WalletInfrastructureSettings['preferredWallet']
+  executionMode: WalletInfrastructureSettings['executionMode']
+  rpcLabel: string
+  rpcReady: boolean
+  busy: boolean
+  onOpenWallet: () => void
+  onSetMainWallet: () => void
+  onAssignProject: () => void
+  onPreferPhantom: () => void
+  onPreviewTransaction: () => void
+}) {
+  const readiness = buildSolanaRouteReadiness({
+    walletPresent: Boolean(wallet),
+    walletName: wallet?.name,
+    walletAddress: wallet?.address,
+    isMainWallet,
+    signerReady,
+    hasActiveProject,
+    projectAssigned,
+    preferredWallet,
+    executionMode,
+    rpcLabel,
+    rpcReady,
+    requirePreferredWallet: true,
+  })
+  const nextAction = readiness.nextAction.id === 'set-main-wallet'
+    ? onSetMainWallet
+    : readiness.nextAction.id === 'assign-project'
+      ? onAssignProject
+      : readiness.nextAction.id === 'set-preferred-wallet'
+        ? onPreferPhantom
+        : readiness.nextAction.id === 'preview-transaction'
+          ? onPreviewTransaction
+          : onOpenWallet
+
+  return (
+    <div className="icc-setup-workflow icc-setup-workflow--wallet">
+      <div className="icc-setup-head">
+        <div>
+          <span className="icc-section-title">Wallet workflow</span>
+          <h3>Get the wallet route ready for Phantom-first signing</h3>
+          <p>New Solana developers should be able to see one wallet path, one signer path, and one project route without leaving this drawer.</p>
+        </div>
+        <span className={`icc-status-badge ${readiness.readyCount === readiness.totalCount ? 'ready' : 'partial'}`}>
+          {readiness.readyCount === readiness.totalCount ? 'ready' : 'guided'}
+        </span>
+      </div>
+
+      <div className="icc-guided-next">
+        <span className="icc-mini-title">Next step</span>
+        <strong>{readiness.nextAction.label}</strong>
+        <p>{readiness.nextAction.detail}</p>
+      </div>
+
+      <div className="icc-plan-grid">
+        <div className="icc-plan-card">
+          <span>Default wallet</span>
+          <code>{readiness.walletLabel}</code>
+        </div>
+        <div className="icc-plan-card">
+          <span>Signing path</span>
+          <code>{readiness.signingPathLabel}</code>
+        </div>
+      </div>
+
+      <div className="icc-step-list">
+        {readiness.items.map((item, index) => (
+          <div key={item.label} className={`icc-step ${item.ready ? 'ready' : 'active'}`}>
+            <span className="icc-step-index">{index + 1}</span>
+            <div className="icc-step-main">
+              <strong>{item.label}</strong>
+              <p>{item.detail}</p>
+            </div>
+            <span className={`icc-status-badge ${item.ready ? 'ready' : 'partial'}`}>{item.ready ? 'done' : 'next'}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="icc-setup-actions">
+        <button type="button" className="icc-primary" onClick={nextAction} disabled={busy}>
+          {busy ? 'Applying wallet setup...' : readiness.nextAction.label}
+        </button>
+        <button type="button" className="icc-secondary" onClick={onOpenWallet}>
+          Open wallet workspace
         </button>
       </div>
     </div>
@@ -226,6 +615,8 @@ function IntegrationCard({
 export function IntegrationCommandCenter() {
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
+  const integrationCommandSelectionId = useUIStore((s) => s.integrationCommandSelectionId)
+  const setIntegrationCommandSelectionId = useUIStore((s) => s.setIntegrationCommandSelectionId)
   const openWorkspaceTool = useUIStore((s) => s.openWorkspaceTool)
   const addTerminal = useUIStore((s) => s.addTerminal)
   const focusTerminal = useAppActions((s) => s.focusTerminal)
@@ -243,11 +634,17 @@ export function IntegrationCommandCenter() {
   const [lockfiles, setLockfiles] = useState<Partial<Record<PackageManager, boolean>>>({})
   const [hasStarterAgentFile, setHasStarterAgentFile] = useState(false)
   const [wallets, setWallets] = useState<WalletListEntry[]>([])
+  const [walletSignerReady, setWalletSignerReady] = useState<Record<string, boolean>>({})
+  const [walletInfrastructure, setWalletInfrastructure] = useState<WalletInfrastructureSettings>(DEFAULT_WALLET_INFRASTRUCTURE)
   const [secureKeys, setSecureKeys] = useState<Record<string, boolean>>({})
   const [loading, setLoading] = useState(false)
   const [applyingSetup, setApplyingSetup] = useState(false)
+  const [sendAiSetupApplied, setSendAiSetupApplied] = useState(false)
   const [scaffoldingFirstAgent, setScaffoldingFirstAgent] = useState(false)
   const [runningStarterCheck, setRunningStarterCheck] = useState(false)
+  const [installingSkills, setInstallingSkills] = useState(false)
+  const [updatingWalletFlow, setUpdatingWalletFlow] = useState(false)
+  const [runningGuidedFlow, setRunningGuidedFlow] = useState<string | null>(null)
   const [actionResult, setActionResult] = useState<IntegrationActionResult | null>(null)
   const [runningActionId, setRunningActionId] = useState<string | null>(null)
 
@@ -259,21 +656,36 @@ export function IntegrationCommandCenter() {
       setActionResult(null)
 
       try {
-        const [walletRes, heliusRes, jupiterRes] = await Promise.all([
+        const [walletRes, heliusRes, jupiterRes, infraRes] = await Promise.all([
           daemon.wallet.list(),
           daemon.wallet.hasHeliusKey(),
           daemon.wallet.hasJupiterKey(),
+          daemon.settings.getWalletInfrastructureSettings(),
         ])
 
         if (cancelled) return
 
-        setWallets(walletRes.ok && walletRes.data ? walletRes.data : [])
+        const nextWallets = walletRes.ok && walletRes.data ? walletRes.data : []
+        setWallets(nextWallets)
+        setWalletInfrastructure(infraRes.ok && infraRes.data ? infraRes.data : DEFAULT_WALLET_INFRASTRUCTURE)
         setSecureKeys({
           HELIUS_API_KEY: Boolean(heliusRes.ok && heliusRes.data),
           JUPITER_API_KEY: Boolean(jupiterRes.ok && jupiterRes.data),
         })
 
+        if (nextWallets.length > 0) {
+          const signerEntries = await Promise.all(nextWallets.map(async (wallet) => {
+            const signerRes = await daemon.wallet.hasKeypair(wallet.id)
+            return [wallet.id, Boolean(signerRes.ok && signerRes.data)] as const
+          }))
+          if (cancelled) return
+          setWalletSignerReady(Object.fromEntries(signerEntries))
+        } else {
+          setWalletSignerReady({})
+        }
+
         if (activeProjectPath) {
+          setSendAiSetupApplied(false)
           await Promise.all([
             loadMcps(activeProjectPath),
             loadToolchain(activeProjectPath),
@@ -307,6 +719,7 @@ export function IntegrationCommandCenter() {
           setPackageJsonContent(null)
           setLockfiles({})
           setHasStarterAgentFile(false)
+          setSendAiSetupApplied(false)
           await loadToolchain(undefined)
         }
       } finally {
@@ -324,6 +737,13 @@ export function IntegrationCommandCenter() {
     () => wallets.find((wallet) => wallet.is_default === 1) ?? wallets[0] ?? null,
     [wallets],
   )
+  const defaultWalletIsMain = Boolean(defaultWallet?.is_default === 1)
+  const defaultWalletSignerReady = defaultWallet ? walletSignerReady[defaultWallet.id] === true : false
+  const defaultWalletAssignedToProject = activeProjectId
+    ? Boolean(defaultWallet?.assigned_project_ids.includes(activeProjectId))
+    : true
+  const walletRpcLabel = getWalletRpcLabel(walletInfrastructure)
+  const walletRpcReady = isWalletRpcReady(walletInfrastructure, Boolean(secureKeys.HELIUS_API_KEY))
 
   const context: IntegrationContext = useMemo(() => ({
     envFiles,
@@ -352,6 +772,7 @@ export function IntegrationCommandCenter() {
     }),
     [packageInfo, lockfiles, packageJsonContent, hasStarterAgentFile],
   )
+  const sendAiSkillSuggestions = useMemo(() => buildSendAiSkillSuggestions(context), [context])
 
   const visibleIntegrations = useMemo(() => {
     const query = search.trim().toLowerCase()
@@ -368,8 +789,56 @@ export function IntegrationCommandCenter() {
     })
   }, [category, search])
 
+  useEffect(() => {
+    if (!integrationCommandSelectionId) return
+    const exists = INTEGRATION_REGISTRY.some((integration) => integration.id === integrationCommandSelectionId)
+    if (exists) {
+      setSelectedId(integrationCommandSelectionId)
+      setActionResult(null)
+    }
+    setIntegrationCommandSelectionId(null)
+  }, [integrationCommandSelectionId, setIntegrationCommandSelectionId])
+
   const selectedIntegration = visibleIntegrations.find((integration) => integration.id === selectedId) ?? visibleIntegrations[0] ?? INTEGRATION_REGISTRY[0]
   const selectedSummary = resolveIntegrationStatus(selectedIntegration, context)
+  const detailShortcut = useMemo<DetailShortcut | null>(() => {
+    if (GUIDED_WORKFLOW_INTEGRATIONS.has(selectedIntegration.id)) {
+      return null
+    }
+
+    if (selectedIntegration.id === 'token-launch-stack') {
+      return {
+        label: 'Open Token Launch',
+        onClick: () => openWorkspaceTool('token-launch'),
+      }
+    }
+
+    const nextRequirement = selectedSummary.requirements.find((requirement) => !requirement.optional && !requirement.ready)
+    if (!nextRequirement) return null
+
+    if (nextRequirement.type === 'wallet') {
+      return {
+        label: 'Open wallet manager',
+        onClick: () => openWorkspaceTool('wallet'),
+      }
+    }
+
+    if (nextRequirement.type === 'secure-key' || nextRequirement.type === 'env') {
+      return {
+        label: 'Open env manager',
+        onClick: () => openWorkspaceTool('env'),
+      }
+    }
+
+    if (nextRequirement.type === 'mcp') {
+      return {
+        label: 'Open MCP setup',
+        onClick: () => openWorkspaceTool('solana-toolbox'),
+      }
+    }
+
+    return null
+  }, [openWorkspaceTool, selectedIntegration.id, selectedSummary.requirements])
 
   async function handleRunAction(actionId: string) {
     const action = selectedIntegration.actions.find((candidate) => candidate.id === actionId)
@@ -443,6 +912,7 @@ export function IntegrationCommandCenter() {
           : 'DAEMON updated the env template. Required SendAI packages were already present.',
         items: changedFiles.length > 0 ? changedFiles : ['No changes needed'],
       })
+      setSendAiSetupApplied(true)
     } catch (error) {
       setActionResult({
         title: 'SendAI setup failed',
@@ -458,6 +928,108 @@ export function IntegrationCommandCenter() {
     const result = await daemon.fs.createDir(path)
     if (!result.ok && !/exist/i.test(result.error ?? '')) {
       throw new Error(result.error ?? `Could not create ${path}`)
+    }
+  }
+
+  async function handleSetMainWallet() {
+    if (!defaultWallet) {
+      setActionResult({
+        title: 'No wallet selected',
+        status: 'warning',
+        detail: 'Create or import a wallet before trying to set the main route.',
+      })
+      return
+    }
+
+    setUpdatingWalletFlow(true)
+    setActionResult(null)
+    try {
+      const result = await daemon.wallet.setDefault(defaultWallet.id)
+      if (!result.ok) throw new Error(result.error ?? 'Could not set the main wallet')
+
+      setWallets((current) => current.map((wallet) => ({
+        ...wallet,
+        is_default: wallet.id === defaultWallet.id ? 1 : 0,
+      })))
+      setActionResult({
+        title: 'Main wallet updated',
+        status: 'success',
+        detail: `${defaultWallet.name} is now the default wallet route for DAEMON.`,
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Wallet update failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not update the main wallet route.',
+      })
+    } finally {
+      setUpdatingWalletFlow(false)
+    }
+  }
+
+  async function handleAssignWalletToProject() {
+    if (!defaultWallet || !activeProjectId) {
+      setActionResult({
+        title: 'Open a project first',
+        status: 'warning',
+        detail: 'DAEMON needs both a wallet and an active project before it can bind them together.',
+      })
+      return
+    }
+
+    setUpdatingWalletFlow(true)
+    setActionResult(null)
+    try {
+      const result = await daemon.wallet.assignProject(activeProjectId, defaultWallet.id)
+      if (!result.ok) throw new Error(result.error ?? 'Could not assign the wallet to the current project')
+
+      setWallets((current) => current.map((wallet) => ({
+        ...wallet,
+        assigned_project_ids: wallet.id === defaultWallet.id
+          ? Array.from(new Set([...wallet.assigned_project_ids, activeProjectId]))
+          : wallet.assigned_project_ids,
+      })))
+      setActionResult({
+        title: 'Project wallet linked',
+        status: 'success',
+        detail: `${defaultWallet.name} is now assigned to the active project.`,
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Project assignment failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not assign the wallet to the project.',
+      })
+    } finally {
+      setUpdatingWalletFlow(false)
+    }
+  }
+
+  async function handleSetPhantomPreferred() {
+    setUpdatingWalletFlow(true)
+    setActionResult(null)
+    try {
+      const nextSettings: WalletInfrastructureSettings = {
+        ...walletInfrastructure,
+        preferredWallet: 'phantom',
+      }
+      const result = await daemon.settings.setWalletInfrastructureSettings(nextSettings)
+      if (!result.ok) throw new Error(result.error ?? 'Could not update the preferred wallet path')
+
+      setWalletInfrastructure(nextSettings)
+      setActionResult({
+        title: 'Preferred wallet updated',
+        status: 'success',
+        detail: 'DAEMON will now favor a Phantom-first wallet path for signing flows.',
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Wallet preference failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not update the preferred wallet path.',
+      })
+    } finally {
+      setUpdatingWalletFlow(false)
     }
   }
 
@@ -577,6 +1149,348 @@ export function IntegrationCommandCenter() {
     }
   }
 
+  async function handleInstallSkills(command: string) {
+    if (!activeProjectPath || !activeProjectId) {
+      setActionResult({
+        title: 'Open a project first',
+        status: 'warning',
+        detail: 'DAEMON needs an active project before it can open the skills install command in a terminal.',
+      })
+      return
+    }
+
+    setInstallingSkills(true)
+    setActionResult(null)
+
+    try {
+      const terminalRes = await daemon.terminal.create({
+        cwd: activeProjectPath,
+        startupCommand: command,
+        userInitiated: true,
+      })
+      if (!terminalRes.ok || !terminalRes.data) {
+        throw new Error(terminalRes.error ?? 'Could not start the skills install terminal')
+      }
+
+      addTerminal(activeProjectId, terminalRes.data.id, 'Install SendAI Skills', terminalRes.data.agentId)
+      focusTerminal()
+      setActionResult({
+        title: 'Skills install opened',
+        status: 'success',
+        detail: 'DAEMON opened a terminal so you can install the SendAI skills pack without leaving this drawer.',
+        items: [command, `Suggested skills: ${sendAiSkillSuggestions.join(', ')}`],
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Skills install failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not open the skills install terminal.',
+      })
+    } finally {
+      setInstallingSkills(false)
+    }
+  }
+
+  async function handleOpenProjectInstall(command: string, label: string) {
+    if (!activeProjectPath || !activeProjectId) {
+      setActionResult({
+        title: 'Open a project first',
+        status: 'warning',
+        detail: 'DAEMON needs an active project before it can open an install command in a terminal.',
+      })
+      return
+    }
+
+    setRunningGuidedFlow(label)
+    setActionResult(null)
+
+    try {
+      const terminalRes = await daemon.terminal.create({
+        cwd: activeProjectPath,
+        startupCommand: command,
+        userInitiated: true,
+      })
+      if (!terminalRes.ok || !terminalRes.data) {
+        throw new Error(terminalRes.error ?? 'Could not open the install terminal')
+      }
+
+      addTerminal(activeProjectId, terminalRes.data.id, label, terminalRes.data.agentId)
+      focusTerminal()
+      setActionResult({
+        title: `${label} opened`,
+        status: 'success',
+        detail: 'DAEMON opened a visible terminal so the install stays inside the current Solana workflow.',
+        items: [command],
+      })
+    } catch (error) {
+      setActionResult({
+        title: `${label} failed`,
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not open the install terminal.',
+      })
+    } finally {
+      setRunningGuidedFlow(null)
+    }
+  }
+
+  async function handlePreviewPhantomTransaction() {
+    if (!defaultWallet) {
+      setActionResult({
+        title: 'No wallet selected',
+        status: 'warning',
+        detail: 'Create or import a wallet before previewing a transaction path.',
+      })
+      return
+    }
+
+    setRunningGuidedFlow('phantom-preview')
+    setActionResult(null)
+
+    try {
+      const previewRes = await daemon.wallet.transactionPreview({
+        kind: 'send-sol',
+        walletId: defaultWallet.id,
+        destination: defaultWallet.address,
+        amount: 0.01,
+      })
+      if (!previewRes.ok || !previewRes.data) {
+        throw new Error(previewRes.error ?? 'Could not preview the Phantom signing path')
+      }
+
+      setActionResult({
+        title: 'Phantom signing preview ready',
+        status: 'success',
+        detail: 'DAEMON generated a safe preview so the developer can see the signing path before any real transaction is sent.',
+        items: [
+          previewRes.data.backendLabel,
+          previewRes.data.signerLabel,
+          previewRes.data.amountLabel,
+          previewRes.data.feeLabel,
+        ],
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Phantom preview failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not build the Phantom signing preview.',
+      })
+    } finally {
+      setRunningGuidedFlow(null)
+    }
+  }
+
+  async function handleInspectHeliusWallet() {
+    if (!defaultWallet) {
+      setActionResult({
+        title: 'No wallet selected',
+        status: 'warning',
+        detail: 'Create or import a wallet before running a Helius-backed wallet read.',
+      })
+      return
+    }
+
+    setRunningGuidedFlow('helius-wallet')
+    setActionResult(null)
+
+    try {
+      const [balanceRes, holdingsRes] = await Promise.all([
+        daemon.wallet.balance(defaultWallet.id),
+        daemon.wallet.holdings(defaultWallet.id),
+      ])
+      if (!balanceRes.ok || !balanceRes.data) {
+        throw new Error(balanceRes.error ?? 'Could not load wallet balance')
+      }
+      if (!holdingsRes.ok || !holdingsRes.data) {
+        throw new Error(holdingsRes.error ?? 'Could not load wallet holdings')
+      }
+
+      const topHolding = holdingsRes.data[0]
+      setActionResult({
+        title: 'Helius wallet read complete',
+        status: 'success',
+        detail: 'DAEMON verified the provider-backed wallet data path by reading the default wallet balance and holdings.',
+        items: [
+          `${balanceRes.data.sol} SOL`,
+          `Holdings: ${holdingsRes.data.length}`,
+          topHolding ? `Top token: ${topHolding.symbol} (${topHolding.amount})` : 'Top token: none',
+        ],
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Helius wallet read failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not verify the Helius-backed wallet read path.',
+      })
+    } finally {
+      setRunningGuidedFlow(null)
+    }
+  }
+
+  async function handlePreviewJupiterQuote() {
+    if (!defaultWallet) {
+      setActionResult({
+        title: 'No wallet selected',
+        status: 'warning',
+        detail: 'Create or import a wallet before requesting a Jupiter quote preview.',
+      })
+      return
+    }
+
+    setRunningGuidedFlow('jupiter-quote')
+    setActionResult(null)
+
+    try {
+      const quoteRes = await daemon.wallet.swapQuote({
+        inputMint: SOL_MINT,
+        outputMint: USDC_MINT,
+        amount: 0.1,
+        slippageBps: 50,
+      })
+      if (!quoteRes.ok || !quoteRes.data) {
+        throw new Error(quoteRes.error ?? 'Could not fetch a Jupiter quote')
+      }
+
+      const previewRes = await daemon.wallet.transactionPreview({
+        kind: 'swap',
+        walletId: defaultWallet.id,
+        inputMint: SOL_MINT,
+        outputMint: USDC_MINT,
+        inputSymbol: 'SOL',
+        outputSymbol: 'USDC',
+        inputAmount: quoteRes.data.inAmount,
+        outputAmount: quoteRes.data.outAmount,
+        amount: 0.1,
+        slippageBps: 50,
+        priceImpactPct: quoteRes.data.priceImpactPct,
+      })
+      if (!previewRes.ok || !previewRes.data) {
+        throw new Error(previewRes.error ?? 'Could not build the Jupiter transaction preview')
+      }
+
+      setActionResult({
+        title: 'Jupiter quote ready',
+        status: 'success',
+        detail: 'DAEMON fetched a quote and built the matching transaction preview before any signing step.',
+        items: [
+          `Route: ${quoteRes.data.routePlan.map((step) => `${step.label} ${step.percent}%`).join(', ') || 'Direct route'}`,
+          `Out amount: ${quoteRes.data.outAmount}`,
+          `Price impact: ${quoteRes.data.priceImpactPct}%`,
+        ],
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Jupiter quote failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not run the Jupiter preview flow.',
+      })
+    } finally {
+      setRunningGuidedFlow(null)
+    }
+  }
+
+  async function handleCreateMetaplexDraft() {
+    if (!activeProjectPath) {
+      setActionResult({
+        title: 'Open a project first',
+        status: 'warning',
+        detail: 'DAEMON needs an active project before it can scaffold a metadata draft.',
+      })
+      return
+    }
+
+    setRunningGuidedFlow('metaplex-draft')
+    setActionResult(null)
+
+    try {
+      await ensureDir(joinProjectPath(activeProjectPath, 'assets'))
+      await ensureDir(joinProjectPath(activeProjectPath, METAPLEX_DRAFT_DIR))
+      const writeRes = await daemon.fs.writeFile(
+        joinProjectPath(activeProjectPath, METAPLEX_DRAFT_FILE),
+        buildMetaplexDraftFile(),
+      )
+      if (!writeRes.ok) {
+        throw new Error(writeRes.error ?? 'Could not write the Metaplex metadata draft')
+      }
+
+      setActionResult({
+        title: 'Metaplex draft created',
+        status: 'success',
+        detail: 'DAEMON scaffolded a metadata-first NFT draft so the project has a concrete starting point before any mint flow.',
+        items: [METAPLEX_DRAFT_FILE],
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Metaplex draft failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not scaffold the Metaplex metadata draft.',
+      })
+    } finally {
+      setRunningGuidedFlow(null)
+    }
+  }
+
+  async function handleCreateLightStarter() {
+    if (!activeProjectPath || !packageJsonContent) {
+      setActionResult({
+        title: 'Create a Node project first',
+        status: 'warning',
+        detail: 'DAEMON needs an active project with package.json before it can scaffold a Light Protocol starter.',
+      })
+      return
+    }
+
+    setRunningGuidedFlow('light-starter')
+    setActionResult(null)
+
+    try {
+      const packageJsonPath = joinProjectPath(activeProjectPath, 'package.json')
+      const nextPackageJson = upsertPackageJsonScript(packageJsonContent, LIGHT_STARTER_SCRIPT, `node ${LIGHT_STARTER_FILE}`)
+      if (nextPackageJson !== packageJsonContent) {
+        const packageWriteRes = await daemon.fs.writeFile(packageJsonPath, nextPackageJson)
+        if (!packageWriteRes.ok) {
+          throw new Error(packageWriteRes.error ?? 'Could not update package.json for Light starter')
+        }
+        setPackageJsonContent(nextPackageJson)
+        setPackageInfo(parsePackageInfo(nextPackageJson))
+      }
+
+      await ensureDir(joinProjectPath(activeProjectPath, 'src'))
+      await ensureDir(joinProjectPath(activeProjectPath, LIGHT_STARTER_DIR))
+      const writeRes = await daemon.fs.writeFile(
+        joinProjectPath(activeProjectPath, LIGHT_STARTER_FILE),
+        buildLightCompressionStarter(),
+      )
+      if (!writeRes.ok) {
+        throw new Error(writeRes.error ?? 'Could not write the Light Protocol starter')
+      }
+
+      setActionResult({
+        title: 'Light starter created',
+        status: 'success',
+        detail: 'DAEMON scaffolded a compression starter and added a runnable package script so the first Light check stays inside the project.',
+        items: [LIGHT_STARTER_FILE, `pnpm run ${LIGHT_STARTER_SCRIPT}`],
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Light starter failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not scaffold the Light starter.',
+      })
+    } finally {
+      setRunningGuidedFlow(null)
+    }
+  }
+
+  function handleOpenMcpSetup() {
+    setIntegrationCommandSelectionId('sendai-solana-mcp')
+    openWorkspaceTool('solana-toolbox')
+    setActionResult({
+      title: 'Open MCP setup',
+      status: 'success',
+      detail: 'DAEMON moved you into the Solana toolbox so the MCP path can be enabled and checked from one place.',
+    })
+  }
+
   function openDocs() {
     void daemon.shell.openExternal(selectedIntegration.docsUrl)
   }
@@ -584,9 +1498,9 @@ export function IntegrationCommandCenter() {
   return (
     <div className="icc-shell">
       <header className="drawer-shared-header icc-header">
-        <div className="drawer-shared-kicker">Integration Command Center</div>
-        <div className="drawer-shared-title">Make Solana integrations obvious before anything runs</div>
-        <p className="drawer-shared-subtitle">
+        <div className="drawer-shared-kicker icc-header-kicker">Integration Command Center</div>
+        <div className="drawer-shared-title icc-header-title">Make Solana integrations obvious before anything runs</div>
+        <p className="drawer-shared-subtitle icc-header-subtitle">
           Review setup, safe checks, and next actions for the protocols DAEMON should help with first.
         </p>
       </header>
@@ -660,7 +1574,7 @@ export function IntegrationCommandCenter() {
             </div>
           </div>
 
-          {selectedIntegration.installCommand && (
+          {selectedIntegration.installCommand && !GUIDED_WORKFLOW_INTEGRATIONS.has(selectedIntegration.id) && (
             <div className="icc-install">
               <span>Install</span>
               <code>{selectedIntegration.installCommand}</code>
@@ -668,42 +1582,232 @@ export function IntegrationCommandCenter() {
           )}
 
           {selectedIntegration.id === 'sendai-agent-kit' && (
-            <>
-              <SendAiSetupWorkflow
-                plan={sendAiSetupPlan}
-                applying={applyingSetup}
-                onApply={() => void handleApplySendAiSetup(sendAiSetupPlan)}
-              />
-              <SendAiFirstAgentWorkflow
-                plan={firstAgentPlan}
-                scaffolding={scaffoldingFirstAgent}
-                running={runningStarterCheck}
-                onScaffold={() => void handleCreateFirstAgent(firstAgentPlan)}
-                onRun={() => void handleRunFirstAgent(firstAgentPlan)}
-              />
-            </>
+            <SendAiAgentLaunchpad
+              projectReady={Boolean(activeProjectPath && packageJsonContent)}
+              setupPlan={sendAiSetupPlan}
+              agentPlan={firstAgentPlan}
+              setupApplied={sendAiSetupApplied}
+              applying={applyingSetup}
+              scaffolding={scaffoldingFirstAgent}
+              running={runningStarterCheck}
+              onOpenProjectStarter={() => openWorkspaceTool('starter')}
+              onApplySetup={() => void handleApplySendAiSetup(sendAiSetupPlan)}
+              onScaffold={() => void handleCreateFirstAgent(firstAgentPlan)}
+              onRun={() => void handleRunFirstAgent(firstAgentPlan)}
+            />
           )}
 
-          <div className="icc-detail-section">
-            <div className="icc-section-title">Actions</div>
-            <div className="icc-actions">
-              {selectedIntegration.actions.map((action) => (
-                <button
-                  key={action.id}
-                  type="button"
-                  className="icc-action"
-                  onClick={() => void handleRunAction(action.id)}
-                  disabled={runningActionId === action.id}
-                >
-                  <span className="icc-action-main">
-                    <span>{runningActionId === action.id ? 'Running...' : action.label}</span>
-                    <small>{action.description}</small>
-                  </span>
-                  <RiskPill risk={action.risk} />
-                </button>
-              ))}
+          {selectedIntegration.id === 'protocol-skills' && selectedIntegration.installCommand && (
+            <SendAiSkillsWorkflow
+              installCommand={selectedIntegration.installCommand}
+              suggestions={sendAiSkillSuggestions}
+              installing={installingSkills}
+              onInstall={() => void handleInstallSkills(selectedIntegration.installCommand!)}
+            />
+          )}
+
+          {selectedIntegration.id === 'phantom' && (
+            <PhantomWalletWorkflow
+              wallet={defaultWallet}
+              isMainWallet={defaultWalletIsMain}
+              signerReady={defaultWalletSignerReady}
+              projectAssigned={defaultWalletAssignedToProject}
+              hasActiveProject={Boolean(activeProjectId)}
+              preferredWallet={walletInfrastructure.preferredWallet}
+              executionMode={walletInfrastructure.executionMode}
+              rpcLabel={walletRpcLabel}
+              rpcReady={walletRpcReady}
+              busy={updatingWalletFlow}
+              onOpenWallet={() => openWorkspaceTool('wallet')}
+              onSetMainWallet={() => void handleSetMainWallet()}
+              onAssignProject={() => void handleAssignWalletToProject()}
+              onPreferPhantom={() => void handleSetPhantomPreferred()}
+              onPreviewTransaction={() => void handlePreviewPhantomTransaction()}
+            />
+          )}
+
+          {selectedIntegration.id === 'sendai-solana-mcp' && (
+            <IntegrationFirstWinWorkflow
+              sectionTitle="MCP workflow"
+              title="Route one Solana MCP path inside DAEMON"
+              description="The MCP setup should not be a dead end. DAEMON should guide the developer straight into the server path that exposes read-only Solana tools to agents."
+              status={selectedSummary.status === 'ready' ? 'ready' : 'partial'}
+              nextLabel={selectedSummary.status === 'ready' ? 'Check MCP server state' : 'Open MCP setup'}
+              nextDetail={selectedSummary.status === 'ready'
+                ? 'The MCP server looks configured. Move into toolbox setup to verify which tools are exposed.'
+                : 'The server is not fully configured yet. Open the MCP setup path directly from here.'}
+              cards={[
+                { label: 'Server', value: mcps.some((entry) => entry.name === 'solana-mcp-server' && entry.enabled) ? 'Enabled' : 'Not enabled' },
+                { label: 'RPC env', value: envKeys.has('RPC_URL') ? 'Configured' : 'Missing RPC_URL' },
+              ]}
+              items={[
+                { label: 'Solana MCP enabled', detail: mcps.some((entry) => entry.name === 'solana-mcp-server' && entry.enabled) ? 'The MCP server is enabled for this project.' : 'Enable the MCP server so DAEMON can expose the Solana tool boundary.', ready: mcps.some((entry) => entry.name === 'solana-mcp-server' && entry.enabled) },
+                { label: 'RPC available', detail: envKeys.has('RPC_URL') ? 'The MCP server has an RPC endpoint to target.' : 'Add RPC_URL so MCP-backed tools can read live Solana state.', ready: envKeys.has('RPC_URL') },
+              ]}
+              primaryLabel="Open MCP setup"
+              primaryBusyLabel="Opening MCP setup..."
+              busy={false}
+              onPrimary={handleOpenMcpSetup}
+              secondaryLabel="Open Solana toolbox"
+              onSecondary={() => openWorkspaceTool('solana-toolbox')}
+              note="This keeps the MCP handoff inside DAEMON instead of leaving the user with a generic setup card."
+            />
+          )}
+
+          {selectedIntegration.id === 'helius' && (
+            <IntegrationFirstWinWorkflow
+              sectionTitle="Provider workflow"
+              title="Verify the Helius-backed wallet data path"
+              description="Helius should feel operational immediately. The first win here is reading live wallet data inside DAEMON, not just proving a key exists."
+              status={secureKeys.HELIUS_API_KEY && Boolean(defaultWallet) ? 'ready' : 'partial'}
+              nextLabel={secureKeys.HELIUS_API_KEY ? (defaultWallet ? 'Read default wallet data' : 'Open wallet manager') : 'Open env manager'}
+              nextDetail={secureKeys.HELIUS_API_KEY
+                ? (defaultWallet ? 'Run one safe wallet read to verify balance and holdings flow through the provider route.' : 'Create or connect a wallet so DAEMON has a target for the provider-backed read.')
+                : 'Add the Helius API key first so the provider route is actually available.'}
+              cards={[
+                { label: 'Provider', value: secureKeys.HELIUS_API_KEY ? 'Helius configured' : 'Helius key missing' },
+                { label: 'Wallet target', value: defaultWallet ? defaultWallet.name : 'No default wallet' },
+              ]}
+              items={[
+                { label: 'Helius key', detail: secureKeys.HELIUS_API_KEY ? 'DAEMON has a Helius key available.' : 'Store the Helius key so provider-backed reads can run.', ready: secureKeys.HELIUS_API_KEY },
+                { label: 'Wallet target', detail: defaultWallet ? `Default wallet is ${defaultWallet.name}.` : 'Create or import a wallet before running the provider read.', ready: Boolean(defaultWallet) },
+                { label: 'Safe first read', detail: 'Read balance and holdings before moving toward transaction-related provider flows.', ready: false },
+              ]}
+              primaryLabel={secureKeys.HELIUS_API_KEY ? (defaultWallet ? 'Read wallet with Helius' : 'Open wallet manager') : 'Open env manager'}
+              primaryBusyLabel="Running Helius wallet read..."
+              busy={runningGuidedFlow === 'helius-wallet'}
+              onPrimary={secureKeys.HELIUS_API_KEY ? (defaultWallet ? () => void handleInspectHeliusWallet() : () => openWorkspaceTool('wallet')) : () => openWorkspaceTool('env')}
+              secondaryLabel="Open wallet workspace"
+              onSecondary={() => openWorkspaceTool('wallet')}
+              note="This is read-only. It validates the provider route without sending a transaction."
+            />
+          )}
+
+          {selectedIntegration.id === 'jupiter' && (
+            <IntegrationFirstWinWorkflow
+              sectionTitle="Swap workflow"
+              title="Get to a first Jupiter quote before any signing"
+              description="The Jupiter path should start with a quote and transaction preview, not with docs or abstract swap capability labels."
+              status={Boolean(defaultWallet) && defaultWalletSignerReady ? 'ready' : 'partial'}
+              nextLabel={defaultWallet && defaultWalletSignerReady ? 'Preview SOL to USDC quote' : 'Open wallet manager'}
+              nextDetail={defaultWallet && defaultWalletSignerReady
+                ? 'Fetch a small read-only route preview so the developer sees the swap path and impact before signing exists.'
+                : 'Use a wallet with a signer before trying to preview Jupiter swap routes.'}
+              cards={[
+                { label: 'Swap engine', value: walletInfrastructure.swapProvider === 'jupiter' ? 'Jupiter selected' : walletInfrastructure.swapProvider },
+                { label: 'Wallet route', value: defaultWallet ? defaultWallet.name : 'No default wallet' },
+              ]}
+              items={[
+                { label: 'Wallet route', detail: defaultWallet ? `Default wallet is ${defaultWallet.name}.` : 'Create or import a wallet so Jupiter has a route owner.', ready: Boolean(defaultWallet) },
+                { label: 'Signer path', detail: defaultWalletSignerReady ? 'Signer is available for follow-up transaction previews.' : 'Add or restore the signer keypair for the default wallet.', ready: defaultWalletSignerReady },
+                { label: 'Safe first quote', detail: 'Use a quote preview before moving into any swap execution surface.', ready: false },
+              ]}
+              primaryLabel={defaultWallet && defaultWalletSignerReady ? 'Preview Jupiter quote' : 'Open wallet manager'}
+              primaryBusyLabel="Fetching Jupiter quote..."
+              busy={runningGuidedFlow === 'jupiter-quote'}
+              onPrimary={defaultWallet && defaultWalletSignerReady ? () => void handlePreviewJupiterQuote() : () => openWorkspaceTool('wallet')}
+              secondaryLabel="Open wallet workspace"
+              onSecondary={() => openWorkspaceTool('wallet')}
+              note="DAEMON uses a quote plus transaction preview here so new Solana devs see the full swap path before any signing step."
+            />
+          )}
+
+          {selectedIntegration.id === 'metaplex' && (
+            <IntegrationFirstWinWorkflow
+              sectionTitle="NFT workflow"
+              title="Create a first metadata draft inside the project"
+              description="The first Metaplex success should be a metadata scaffold the project can edit immediately, not a vague promise of NFT support."
+              status={Boolean(activeProjectPath) && packageInfo.packages.has('@metaplex-foundation/umi') ? 'ready' : 'partial'}
+              nextLabel={!activeProjectPath ? 'Open New Project' : !packageInfo.packages.has('@metaplex-foundation/umi') ? 'Install Metaplex packages' : 'Create metadata draft'}
+              nextDetail={!activeProjectPath
+                ? 'Open or scaffold a project first so the metadata draft has somewhere to live.'
+                : !packageInfo.packages.has('@metaplex-foundation/umi')
+                  ? 'Install the common Metaplex packages before DAEMON scaffolds the draft file.'
+                  : 'Write a ready-to-edit metadata JSON draft into the project assets folder.'}
+              cards={[
+                { label: 'Project', value: activeProjectPath ? activeProjectPath.split('/').pop() ?? activeProjectPath : 'No project open' },
+                { label: 'Draft file', value: METAPLEX_DRAFT_FILE },
+              ]}
+              items={[
+                { label: 'Project context', detail: activeProjectPath ? 'A project is open and ready for asset scaffolding.' : 'Open or create a project before running the NFT starter flow.', ready: Boolean(activeProjectPath) },
+                { label: 'Metaplex package', detail: packageInfo.packages.has('@metaplex-foundation/umi') ? 'Core Metaplex package detected in package.json.' : 'Install the Metaplex packages DAEMON expects for metadata workflows.', ready: packageInfo.packages.has('@metaplex-foundation/umi') },
+                { label: 'Metadata-first start', detail: 'Create and edit metadata before pushing the user into mint or collection creation flows.', ready: false },
+              ]}
+              primaryLabel={!activeProjectPath ? 'Open New Project' : !packageInfo.packages.has('@metaplex-foundation/umi') ? 'Install Metaplex packages' : 'Create metadata draft'}
+              primaryBusyLabel={!activeProjectPath ? 'Opening project flow...' : !packageInfo.packages.has('@metaplex-foundation/umi') ? 'Opening install terminal...' : 'Creating metadata draft...'}
+              busy={runningGuidedFlow === 'Install Metaplex' || runningGuidedFlow === 'metaplex-draft'}
+              onPrimary={!activeProjectPath
+                ? () => openWorkspaceTool('starter')
+                : !packageInfo.packages.has('@metaplex-foundation/umi')
+                  ? () => void handleOpenProjectInstall(selectedIntegration.installCommand!, 'Install Metaplex')
+                  : () => void handleCreateMetaplexDraft()}
+              secondaryLabel="Open New Project"
+              onSecondary={() => openWorkspaceTool('starter')}
+              note="This stays deliberately metadata-first so the user gets a concrete asset draft before any mint transaction path."
+            />
+          )}
+
+          {selectedIntegration.id === 'light-protocol' && (
+            <IntegrationFirstWinWorkflow
+              sectionTitle="Compression workflow"
+              title="Scaffold the first Light compression starter"
+              description="Light Protocol should begin with a concrete compression-capable project check, not a generic package status card."
+              status={Boolean(activeProjectPath) && packageInfo.packages.has('@lightprotocol/stateless.js') && envKeys.has('RPC_URL') ? 'ready' : 'partial'}
+              nextLabel={!activeProjectPath ? 'Open New Project' : !packageInfo.packages.has('@lightprotocol/stateless.js') ? 'Install Light SDK' : !envKeys.has('RPC_URL') ? 'Open env manager' : 'Create compression starter'}
+              nextDetail={!activeProjectPath
+                ? 'Open or scaffold a project first so the compression starter can be written into source.'
+                : !packageInfo.packages.has('@lightprotocol/stateless.js')
+                  ? 'Install the Light SDK before DAEMON scaffolds the starter file.'
+                  : !envKeys.has('RPC_URL')
+                    ? 'Add a compression-capable RPC first so the starter has a real target.'
+                    : 'Write a runnable compression starter into the project and add the package script.'}
+              cards={[
+                { label: 'Starter file', value: LIGHT_STARTER_FILE },
+                { label: 'Run command', value: `pnpm run ${LIGHT_STARTER_SCRIPT}` },
+              ]}
+              items={[
+                { label: 'Project context', detail: activeProjectPath ? 'A project is open and ready for source scaffolding.' : 'Open or create a project before DAEMON can scaffold the Light starter.', ready: Boolean(activeProjectPath) },
+                { label: 'Light SDK', detail: packageInfo.packages.has('@lightprotocol/stateless.js') ? 'The Light SDK is already installed.' : 'Install the Light SDK package before scaffolding the starter.', ready: packageInfo.packages.has('@lightprotocol/stateless.js') },
+                { label: 'Compression-capable RPC', detail: envKeys.has('RPC_URL') ? 'RPC_URL is available for the starter check.' : 'Add RPC_URL so the compression starter has a real endpoint.', ready: envKeys.has('RPC_URL') },
+              ]}
+              primaryLabel={!activeProjectPath ? 'Open New Project' : !packageInfo.packages.has('@lightprotocol/stateless.js') ? 'Install Light SDK' : !envKeys.has('RPC_URL') ? 'Open env manager' : 'Create compression starter'}
+              primaryBusyLabel={!activeProjectPath ? 'Opening project flow...' : !packageInfo.packages.has('@lightprotocol/stateless.js') ? 'Opening install terminal...' : !envKeys.has('RPC_URL') ? 'Opening env manager...' : 'Creating compression starter...'}
+              busy={runningGuidedFlow === 'Install Light SDK' || runningGuidedFlow === 'light-starter'}
+              onPrimary={!activeProjectPath
+                ? () => openWorkspaceTool('starter')
+                : !packageInfo.packages.has('@lightprotocol/stateless.js')
+                  ? () => void handleOpenProjectInstall(selectedIntegration.installCommand!, 'Install Light SDK')
+                  : !envKeys.has('RPC_URL')
+                    ? () => openWorkspaceTool('env')
+                    : () => void handleCreateLightStarter()}
+              secondaryLabel="Open env manager"
+              onSecondary={() => openWorkspaceTool('env')}
+              note="This is still safe. The starter only verifies imports and RPC configuration before you add real compression logic."
+            />
+          )}
+
+          {!GUIDED_WORKFLOW_INTEGRATIONS.has(selectedIntegration.id) && (
+            <div className="icc-detail-section">
+              <div className="icc-section-title">Actions</div>
+              <div className="icc-actions">
+                {selectedIntegration.actions.map((action) => (
+                  <button
+                    key={action.id}
+                    type="button"
+                    className="icc-action"
+                    onClick={() => void handleRunAction(action.id)}
+                    disabled={runningActionId === action.id}
+                  >
+                    <span className="icc-action-main">
+                      <span>{runningActionId === action.id ? 'Running...' : action.label}</span>
+                      <small>{action.description}</small>
+                    </span>
+                    <RiskPill risk={action.risk} />
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
 
           {actionResult && (
             <div className={`icc-result ${actionResult.status}`}>
@@ -719,7 +1823,9 @@ export function IntegrationCommandCenter() {
 
           <div className="icc-footer-actions">
             <button type="button" className="icc-secondary" onClick={openDocs}>Open docs</button>
-            <button type="button" className="icc-primary" onClick={() => openWorkspaceTool('solana-toolbox')}>Open Solana Toolbox</button>
+            {detailShortcut ? (
+              <button type="button" className="icc-primary" onClick={detailShortcut.onClick}>{detailShortcut.label}</button>
+            ) : null}
           </div>
 
           {loading && <div className="icc-loading">Refreshing setup context...</div>}

--- a/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
+++ b/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
@@ -171,6 +171,7 @@ function SendAiAgentLaunchpad({
   projectReady,
   setupPlan,
   agentPlan,
+  result,
   setupApplied,
   applying,
   scaffolding,
@@ -183,6 +184,7 @@ function SendAiAgentLaunchpad({
   projectReady: boolean
   setupPlan: SendAiSetupPlan
   agentPlan: FirstAgentPlan
+  result?: IntegrationActionResult | null
   setupApplied: boolean
   applying: boolean
   scaffolding: boolean
@@ -310,6 +312,18 @@ function SendAiAgentLaunchpad({
         </div>
       </div>
 
+      {result ? (
+        <div className={`icc-result ${result.status}`}>
+          <span className="icc-result-title">{result.title}</span>
+          <p>{result.detail}</p>
+          {result.items?.length ? (
+            <div className="icc-result-items">
+              {result.items.map((item) => <code key={item}>{item}</code>)}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       <div className="icc-setup-actions">
         <button type="button" className="icc-primary" onClick={nextAction.action} disabled={nextAction.disabled}>
           {nextAction.label}
@@ -322,11 +336,13 @@ function SendAiAgentLaunchpad({
 function SendAiSkillsWorkflow({
   installCommand,
   suggestions,
+  result,
   installing,
   onInstall,
 }: {
   installCommand: string
   suggestions: string[]
+  result?: IntegrationActionResult | null
   installing: boolean
   onInstall: () => void
 }) {
@@ -373,6 +389,18 @@ function SendAiSkillsWorkflow({
         This opens a visible terminal and runs the skills install command in the current project. It does not execute any on-chain action.
       </div>
 
+      {result ? (
+        <div className={`icc-result ${result.status}`}>
+          <span className="icc-result-title">{result.title}</span>
+          <p>{result.detail}</p>
+          {result.items?.length ? (
+            <div className="icc-result-items">
+              {result.items.map((item) => <code key={item}>{item}</code>)}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       <div className="icc-setup-actions">
         <button type="button" className="icc-primary" onClick={onInstall} disabled={installing}>
           {installing ? 'Opening install terminal...' : 'Install skills in terminal'}
@@ -387,6 +415,7 @@ function IntegrationFirstWinWorkflow({
   title,
   description,
   status,
+  result,
   nextLabel,
   nextDetail,
   cards,
@@ -403,6 +432,7 @@ function IntegrationFirstWinWorkflow({
   title: string
   description: string
   status: 'ready' | 'partial'
+  result?: IntegrationActionResult | null
   nextLabel: string
   nextDetail: string
   cards: Array<{ label: string; value: string }>
@@ -456,6 +486,18 @@ function IntegrationFirstWinWorkflow({
 
       {note ? <div className="icc-inline-note">{note}</div> : null}
 
+      {result ? (
+        <div className={`icc-result ${result.status}`}>
+          <span className="icc-result-title">{result.title}</span>
+          <p>{result.detail}</p>
+          {result.items?.length ? (
+            <div className="icc-result-items">
+              {result.items.map((item) => <code key={item}>{item}</code>)}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       <div className="icc-setup-actions">
         <button type="button" className="icc-primary" onClick={onPrimary} disabled={busy}>
           {busy ? primaryBusyLabel : primaryLabel}
@@ -480,6 +522,7 @@ function PhantomWalletWorkflow({
   executionMode,
   rpcLabel,
   rpcReady,
+  result,
   busy,
   onOpenWallet,
   onSetMainWallet,
@@ -496,6 +539,7 @@ function PhantomWalletWorkflow({
   executionMode: WalletInfrastructureSettings['executionMode']
   rpcLabel: string
   rpcReady: boolean
+  result?: IntegrationActionResult | null
   busy: boolean
   onOpenWallet: () => void
   onSetMainWallet: () => void
@@ -569,6 +613,18 @@ function PhantomWalletWorkflow({
           </div>
         ))}
       </div>
+
+      {result ? (
+        <div className={`icc-result ${result.status}`}>
+          <span className="icc-result-title">{result.title}</span>
+          <p>{result.detail}</p>
+          {result.items?.length ? (
+            <div className="icc-result-items">
+              {result.items.map((item) => <code key={item}>{item}</code>)}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="icc-setup-actions">
         <button type="button" className="icc-primary" onClick={nextAction} disabled={busy}>
@@ -791,8 +847,10 @@ export function IntegrationCommandCenter() {
 
   useEffect(() => {
     if (!integrationCommandSelectionId) return
-    const exists = INTEGRATION_REGISTRY.some((integration) => integration.id === integrationCommandSelectionId)
-    if (exists) {
+    const target = INTEGRATION_REGISTRY.find((integration) => integration.id === integrationCommandSelectionId)
+    if (target) {
+      setCategory('all')
+      setSearch('')
       setSelectedId(integrationCommandSelectionId)
       setActionResult(null)
     }
@@ -1482,7 +1540,6 @@ export function IntegrationCommandCenter() {
   }
 
   function handleOpenMcpSetup() {
-    setIntegrationCommandSelectionId('sendai-solana-mcp')
     openWorkspaceTool('solana-toolbox')
     setActionResult({
       title: 'Open MCP setup',
@@ -1586,6 +1643,7 @@ export function IntegrationCommandCenter() {
               projectReady={Boolean(activeProjectPath && packageJsonContent)}
               setupPlan={sendAiSetupPlan}
               agentPlan={firstAgentPlan}
+              result={actionResult}
               setupApplied={sendAiSetupApplied}
               applying={applyingSetup}
               scaffolding={scaffoldingFirstAgent}
@@ -1601,6 +1659,7 @@ export function IntegrationCommandCenter() {
             <SendAiSkillsWorkflow
               installCommand={selectedIntegration.installCommand}
               suggestions={sendAiSkillSuggestions}
+              result={actionResult}
               installing={installingSkills}
               onInstall={() => void handleInstallSkills(selectedIntegration.installCommand!)}
             />
@@ -1617,6 +1676,7 @@ export function IntegrationCommandCenter() {
               executionMode={walletInfrastructure.executionMode}
               rpcLabel={walletRpcLabel}
               rpcReady={walletRpcReady}
+              result={actionResult}
               busy={updatingWalletFlow}
               onOpenWallet={() => openWorkspaceTool('wallet')}
               onSetMainWallet={() => void handleSetMainWallet()}
@@ -1632,6 +1692,7 @@ export function IntegrationCommandCenter() {
               title="Route one Solana MCP path inside DAEMON"
               description="The MCP setup should not be a dead end. DAEMON should guide the developer straight into the server path that exposes read-only Solana tools to agents."
               status={selectedSummary.status === 'ready' ? 'ready' : 'partial'}
+              result={actionResult}
               nextLabel={selectedSummary.status === 'ready' ? 'Check MCP server state' : 'Open MCP setup'}
               nextDetail={selectedSummary.status === 'ready'
                 ? 'The MCP server looks configured. Move into toolbox setup to verify which tools are exposed.'
@@ -1660,6 +1721,7 @@ export function IntegrationCommandCenter() {
               title="Verify the Helius-backed wallet data path"
               description="Helius should feel operational immediately. The first win here is reading live wallet data inside DAEMON, not just proving a key exists."
               status={secureKeys.HELIUS_API_KEY && Boolean(defaultWallet) ? 'ready' : 'partial'}
+              result={actionResult}
               nextLabel={secureKeys.HELIUS_API_KEY ? (defaultWallet ? 'Read default wallet data' : 'Open wallet manager') : 'Open env manager'}
               nextDetail={secureKeys.HELIUS_API_KEY
                 ? (defaultWallet ? 'Run one safe wallet read to verify balance and holdings flow through the provider route.' : 'Create or connect a wallet so DAEMON has a target for the provider-backed read.')
@@ -1689,6 +1751,7 @@ export function IntegrationCommandCenter() {
               title="Get to a first Jupiter quote before any signing"
               description="The Jupiter path should start with a quote and transaction preview, not with docs or abstract swap capability labels."
               status={Boolean(defaultWallet) && defaultWalletSignerReady ? 'ready' : 'partial'}
+              result={actionResult}
               nextLabel={defaultWallet && defaultWalletSignerReady ? 'Preview SOL to USDC quote' : 'Open wallet manager'}
               nextDetail={defaultWallet && defaultWalletSignerReady
                 ? 'Fetch a small read-only route preview so the developer sees the swap path and impact before signing exists.'
@@ -1718,6 +1781,7 @@ export function IntegrationCommandCenter() {
               title="Create a first metadata draft inside the project"
               description="The first Metaplex success should be a metadata scaffold the project can edit immediately, not a vague promise of NFT support."
               status={Boolean(activeProjectPath) && packageInfo.packages.has('@metaplex-foundation/umi') ? 'ready' : 'partial'}
+              result={actionResult}
               nextLabel={!activeProjectPath ? 'Open New Project' : !packageInfo.packages.has('@metaplex-foundation/umi') ? 'Install Metaplex packages' : 'Create metadata draft'}
               nextDetail={!activeProjectPath
                 ? 'Open or scaffold a project first so the metadata draft has somewhere to live.'
@@ -1753,6 +1817,7 @@ export function IntegrationCommandCenter() {
               title="Scaffold the first Light compression starter"
               description="Light Protocol should begin with a concrete compression-capable project check, not a generic package status card."
               status={Boolean(activeProjectPath) && packageInfo.packages.has('@lightprotocol/stateless.js') && envKeys.has('RPC_URL') ? 'ready' : 'partial'}
+              result={actionResult}
               nextLabel={!activeProjectPath ? 'Open New Project' : !packageInfo.packages.has('@lightprotocol/stateless.js') ? 'Install Light SDK' : !envKeys.has('RPC_URL') ? 'Open env manager' : 'Create compression starter'}
               nextDetail={!activeProjectPath
                 ? 'Open or scaffold a project first so the compression starter can be written into source.'
@@ -1809,7 +1874,7 @@ export function IntegrationCommandCenter() {
             </div>
           )}
 
-          {actionResult && (
+          {actionResult && !GUIDED_WORKFLOW_INTEGRATIONS.has(selectedIntegration.id) && (
             <div className={`icc-result ${actionResult.status}`}>
               <span className="icc-result-title">{actionResult.title}</span>
               <p>{actionResult.detail}</p>

--- a/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
+++ b/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
@@ -8,11 +8,17 @@ import { INTEGRATION_CATEGORIES, INTEGRATION_REGISTRY, type IntegrationCategory,
 import { runIntegrationAction, type IntegrationActionResult } from './actionRunner'
 import { resolveIntegrationStatus, summarizeRegistry, type IntegrationContext, type IntegrationStatusSummary } from './status'
 import {
+  buildFirstSolanaAgentFile,
+  buildFirstSolanaAgentReadme,
+  createFirstAgentPlan,
   createSendAiSetupPlan,
   mergeEnvExample,
   parsePackageInfo,
+  upsertPackageJsonScript,
+  SENDAI_FIRST_AGENT_ENTRY,
   type PackageInfo,
   type PackageManager,
+  type FirstAgentPlan,
   type SendAiSetupPlan,
 } from './sendaiSetup'
 import './IntegrationCommandCenter.css'
@@ -27,7 +33,7 @@ function statusLabel(summary: IntegrationStatusSummary): string {
   return 'Setup needed'
 }
 
-const EMPTY_PACKAGE_INFO: PackageInfo = { packages: new Set(), packageManagerHint: null }
+const EMPTY_PACKAGE_INFO: PackageInfo = { packages: new Set(), scripts: new Set(), packageManagerHint: null }
 
 function RiskPill({ risk }: { risk: string }) {
   return <span className={`icc-risk icc-risk--${risk}`}>{risk.replace('-', ' ')}</span>
@@ -111,6 +117,82 @@ function SendAiSetupWorkflow({
   )
 }
 
+function SendAiFirstAgentWorkflow({
+  plan,
+  scaffolding,
+  running,
+  onScaffold,
+  onRun,
+}: {
+  plan: FirstAgentPlan
+  scaffolding: boolean
+  running: boolean
+  onScaffold: () => void
+  onRun: () => void
+}) {
+  return (
+    <div className="icc-setup-workflow icc-setup-workflow--secondary">
+      <div className="icc-setup-head">
+        <div>
+          <span className="icc-section-title">First success</span>
+          <h3>Create your first Solana agent</h3>
+          <p>DAEMON can scaffold a starter file, add one package script, and give the project a single command to run.</p>
+        </div>
+        <span className={`icc-status-badge ${plan.alreadyScaffolded ? 'ready' : 'partial'}`}>
+          {plan.alreadyScaffolded ? 'scaffolded' : 'ready to scaffold'}
+        </span>
+      </div>
+
+      <div className="icc-plan-grid">
+        <div className="icc-plan-card">
+          <span>Starter file</span>
+          <code>{plan.entryFilePath}</code>
+        </div>
+        <div className="icc-plan-card">
+          <span>Run command</span>
+          <code>{plan.runCommand}</code>
+        </div>
+      </div>
+
+      <div className="icc-plan-columns">
+        <div>
+          <span className="icc-mini-title">What DAEMON adds</span>
+          <div className="icc-check-list">
+            <span>{plan.entryFilePath}</span>
+            <span>{plan.readmePath}</span>
+            <span>{plan.scriptName} in package.json</span>
+          </div>
+        </div>
+        <div>
+          <span className="icc-mini-title">Readiness</span>
+          <div className="icc-check-list">
+            {plan.prerequisites.map((item) => <span key={item}>{item}</span>)}
+          </div>
+        </div>
+      </div>
+
+      {plan.missingPackages.length > 0 && (
+        <div className="icc-inline-note">
+          Install the SendAI runtime packages first. The scaffold is safe to create now, but the starter check should wait until install completes.
+        </div>
+      )}
+
+      <div className="icc-safety-notes">
+        {plan.safetyNotes.map((note) => <span key={note}>{note}</span>)}
+      </div>
+
+      <div className="icc-setup-actions">
+        <button type="button" className="icc-secondary" onClick={onScaffold} disabled={!plan.canScaffold || scaffolding}>
+          {scaffolding ? 'Creating files...' : plan.alreadyScaffolded ? 'Starter files created' : 'Create Starter Files'}
+        </button>
+        <button type="button" className="icc-primary" onClick={onRun} disabled={!plan.canRun || running}>
+          {running ? 'Opening terminal...' : 'Run Starter Check'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
 function IntegrationCard({
   integration,
   selected,
@@ -157,11 +239,15 @@ export function IntegrationCommandCenter() {
   const [selectedId, setSelectedId] = useState(INTEGRATION_REGISTRY[0]?.id ?? '')
   const [envFiles, setEnvFiles] = useState<EnvFile[]>([])
   const [packageInfo, setPackageInfo] = useState<PackageInfo>(EMPTY_PACKAGE_INFO)
+  const [packageJsonContent, setPackageJsonContent] = useState<string | null>(null)
   const [lockfiles, setLockfiles] = useState<Partial<Record<PackageManager, boolean>>>({})
+  const [hasStarterAgentFile, setHasStarterAgentFile] = useState(false)
   const [wallets, setWallets] = useState<WalletListEntry[]>([])
   const [secureKeys, setSecureKeys] = useState<Record<string, boolean>>({})
   const [loading, setLoading] = useState(false)
   const [applyingSetup, setApplyingSetup] = useState(false)
+  const [scaffoldingFirstAgent, setScaffoldingFirstAgent] = useState(false)
+  const [runningStarterCheck, setRunningStarterCheck] = useState(false)
   const [actionResult, setActionResult] = useState<IntegrationActionResult | null>(null)
   const [runningActionId, setRunningActionId] = useState<string | null>(null)
 
@@ -193,29 +279,34 @@ export function IntegrationCommandCenter() {
             loadToolchain(activeProjectPath),
           ])
 
-          const [envRes, packageRes, pnpmLockRes, npmLockRes, yarnLockRes, bunLockRes] = await Promise.all([
+          const [envRes, packageRes, pnpmLockRes, npmLockRes, yarnLockRes, bunLockRes, starterFileRes] = await Promise.all([
             daemon.env.projectVars(activeProjectPath),
             daemon.fs.readFile(joinProjectPath(activeProjectPath, 'package.json')),
             daemon.fs.readFile(joinProjectPath(activeProjectPath, 'pnpm-lock.yaml')),
             daemon.fs.readFile(joinProjectPath(activeProjectPath, 'package-lock.json')),
             daemon.fs.readFile(joinProjectPath(activeProjectPath, 'yarn.lock')),
             daemon.fs.readFile(joinProjectPath(activeProjectPath, 'bun.lockb')),
+            daemon.fs.readFile(joinProjectPath(activeProjectPath, SENDAI_FIRST_AGENT_ENTRY)),
           ])
 
           if (cancelled) return
 
           setEnvFiles(envRes.ok && envRes.data ? envRes.data : [])
           setPackageInfo(packageRes.ok && packageRes.data ? parsePackageInfo(packageRes.data.content) : EMPTY_PACKAGE_INFO)
+          setPackageJsonContent(packageRes.ok && packageRes.data ? packageRes.data.content : null)
           setLockfiles({
             pnpm: Boolean(pnpmLockRes.ok),
             npm: Boolean(npmLockRes.ok),
             yarn: Boolean(yarnLockRes.ok),
             bun: Boolean(bunLockRes.ok),
           })
+          setHasStarterAgentFile(Boolean(starterFileRes.ok))
         } else {
           setEnvFiles([])
           setPackageInfo(EMPTY_PACKAGE_INFO)
+          setPackageJsonContent(null)
           setLockfiles({})
+          setHasStarterAgentFile(false)
           await loadToolchain(undefined)
         }
       } finally {
@@ -251,6 +342,15 @@ export function IntegrationCommandCenter() {
   const sendAiSetupPlan = useMemo(
     () => createSendAiSetupPlan({ packageInfo, lockfiles, envKeys }),
     [packageInfo, lockfiles, envKeys],
+  )
+  const firstAgentPlan = useMemo(
+    () => createFirstAgentPlan({
+      packageInfo,
+      lockfiles,
+      hasPackageJson: Boolean(packageJsonContent),
+      hasStarterFile: hasStarterAgentFile,
+    }),
+    [packageInfo, lockfiles, packageJsonContent, hasStarterAgentFile],
   )
 
   const visibleIntegrations = useMemo(() => {
@@ -354,6 +454,129 @@ export function IntegrationCommandCenter() {
     }
   }
 
+  async function ensureDir(path: string) {
+    const result = await daemon.fs.createDir(path)
+    if (!result.ok && !/exist/i.test(result.error ?? '')) {
+      throw new Error(result.error ?? `Could not create ${path}`)
+    }
+  }
+
+  async function handleCreateFirstAgent(plan: FirstAgentPlan) {
+    if (!activeProjectPath || !packageJsonContent) {
+      setActionResult({
+        title: 'Create a Node project first',
+        status: 'warning',
+        detail: 'DAEMON needs an active project with package.json before it can scaffold a first SendAI agent.',
+      })
+      return
+    }
+
+    setScaffoldingFirstAgent(true)
+    setActionResult(null)
+
+    try {
+      const packageJsonPath = joinProjectPath(activeProjectPath, 'package.json')
+      const packageRes = await daemon.fs.readFile(packageJsonPath)
+      if (!packageRes.ok || !packageRes.data) {
+        throw new Error(packageRes.error ?? 'Could not read package.json')
+      }
+
+      const nextPackageJson = upsertPackageJsonScript(packageRes.data.content, plan.scriptName, plan.scriptCommand)
+      const srcDir = joinProjectPath(activeProjectPath, 'src')
+      const agentsDir = joinProjectPath(activeProjectPath, 'src/agents')
+      const changedFiles: string[] = []
+
+      if (nextPackageJson !== packageRes.data.content) {
+        const writePackageRes = await daemon.fs.writeFile(packageJsonPath, nextPackageJson)
+        if (!writePackageRes.ok) {
+          throw new Error(writePackageRes.error ?? 'Could not update package.json')
+        }
+        changedFiles.push('package.json')
+        setPackageJsonContent(nextPackageJson)
+        setPackageInfo(parsePackageInfo(nextPackageJson))
+      }
+
+      await ensureDir(srcDir)
+      await ensureDir(agentsDir)
+
+      const entryRes = await daemon.fs.writeFile(
+        joinProjectPath(activeProjectPath, plan.entryFilePath),
+        buildFirstSolanaAgentFile(),
+      )
+      if (!entryRes.ok) {
+        throw new Error(entryRes.error ?? `Could not write ${plan.entryFilePath}`)
+      }
+      changedFiles.push(plan.entryFilePath)
+
+      const readmeRes = await daemon.fs.writeFile(
+        joinProjectPath(activeProjectPath, plan.readmePath),
+        buildFirstSolanaAgentReadme(plan.runCommand),
+      )
+      if (!readmeRes.ok) {
+        throw new Error(readmeRes.error ?? `Could not write ${plan.readmePath}`)
+      }
+      changedFiles.push(plan.readmePath)
+      setHasStarterAgentFile(true)
+
+      setActionResult({
+        title: 'Starter agent scaffolded',
+        status: 'success',
+        detail: 'DAEMON wrote a first Solana agent file, added a simple package script, and left the run step as a visible terminal action.',
+        items: changedFiles,
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Starter scaffold failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not create the starter agent files.',
+      })
+    } finally {
+      setScaffoldingFirstAgent(false)
+    }
+  }
+
+  async function handleRunFirstAgent(plan: FirstAgentPlan) {
+    if (!activeProjectPath || !activeProjectId) {
+      setActionResult({
+        title: 'Open a project first',
+        status: 'warning',
+        detail: 'DAEMON needs an active project before it can open the starter run command in a terminal.',
+      })
+      return
+    }
+
+    setRunningStarterCheck(true)
+    setActionResult(null)
+
+    try {
+      const terminalRes = await daemon.terminal.create({
+        cwd: activeProjectPath,
+        startupCommand: plan.runCommand,
+        userInitiated: true,
+      })
+      if (!terminalRes.ok || !terminalRes.data) {
+        throw new Error(terminalRes.error ?? 'Could not start starter terminal')
+      }
+
+      addTerminal(activeProjectId, terminalRes.data.id, 'SendAI Starter Check', terminalRes.data.agentId)
+      focusTerminal()
+      setActionResult({
+        title: 'Starter check opened',
+        status: 'success',
+        detail: 'DAEMON opened a visible terminal so you can watch the first-agent readiness check run.',
+        items: [plan.runCommand],
+      })
+    } catch (error) {
+      setActionResult({
+        title: 'Starter check failed',
+        status: 'error',
+        detail: error instanceof Error ? error.message : 'DAEMON could not open the starter terminal.',
+      })
+    } finally {
+      setRunningStarterCheck(false)
+    }
+  }
+
   function openDocs() {
     void daemon.shell.openExternal(selectedIntegration.docsUrl)
   }
@@ -445,11 +668,20 @@ export function IntegrationCommandCenter() {
           )}
 
           {selectedIntegration.id === 'sendai-agent-kit' && (
-            <SendAiSetupWorkflow
-              plan={sendAiSetupPlan}
-              applying={applyingSetup}
-              onApply={() => void handleApplySendAiSetup(sendAiSetupPlan)}
-            />
+            <>
+              <SendAiSetupWorkflow
+                plan={sendAiSetupPlan}
+                applying={applyingSetup}
+                onApply={() => void handleApplySendAiSetup(sendAiSetupPlan)}
+              />
+              <SendAiFirstAgentWorkflow
+                plan={firstAgentPlan}
+                scaffolding={scaffoldingFirstAgent}
+                running={runningStarterCheck}
+                onScaffold={() => void handleCreateFirstAgent(firstAgentPlan)}
+                onRun={() => void handleRunFirstAgent(firstAgentPlan)}
+              />
+            </>
           )}
 
           <div className="icc-detail-section">

--- a/src/panels/IntegrationCommandCenter/registry.ts
+++ b/src/panels/IntegrationCommandCenter/registry.ts
@@ -49,7 +49,7 @@ export const INTEGRATION_REGISTRY: IntegrationDefinition[] = [
     description: 'Use SendAI action plugins for token, NFT, DeFi, Blink, price, staking, and bridge workflows once DAEMON has previewed the risk.',
     category: 'agent',
     docsUrl: 'https://github.com/sendaifun/solana-agent-kit',
-    installCommand: 'pnpm add solana-agent-kit @solana-agent-kit/plugin-token @solana-agent-kit/plugin-defi @solana-agent-kit/plugin-nft',
+    installCommand: 'pnpm add solana-agent-kit @solana-agent-kit/plugin-token @solana-agent-kit/plugin-defi @solana-agent-kit/plugin-nft @solana-agent-kit/plugin-misc @solana-agent-kit/plugin-blinks @solana/web3.js bs58',
     recommendedFor: ['agent workflows', 'guided Solana actions', 'protocol automation'],
     requirements: [
       { type: 'package', key: 'solana-agent-kit', label: 'solana-agent-kit package' },

--- a/src/panels/IntegrationCommandCenter/registry.ts
+++ b/src/panels/IntegrationCommandCenter/registry.ts
@@ -120,6 +120,7 @@ export const INTEGRATION_REGISTRY: IntegrationDefinition[] = [
     description: 'Use Jupiter for quote previews, swap routing, token metadata, recurring orders, lend, perps, and wallet portfolio flows.',
     category: 'defi',
     docsUrl: 'https://dev.jup.ag/',
+    installCommand: 'pnpm add @solana/kit',
     recommendedFor: ['swap previews', 'token routing', 'DeFi app UX'],
     requirements: [
       { type: 'secure-key', key: 'JUPITER_API_KEY', label: 'Jupiter API key', optional: true },
@@ -137,6 +138,7 @@ export const INTEGRATION_REGISTRY: IntegrationDefinition[] = [
     description: 'Use Metaplex for NFT collections, metadata, compressed NFTs, Candy Machine, and digital asset workflows.',
     category: 'nft',
     docsUrl: 'https://developers.metaplex.com/',
+    installCommand: 'pnpm add @metaplex-foundation/umi @metaplex-foundation/mpl-token-metadata',
     recommendedFor: ['NFT minting', 'metadata', 'collections'],
     requirements: [
       { type: 'package', key: '@metaplex-foundation/umi', label: 'Umi package', optional: true },
@@ -171,6 +173,7 @@ export const INTEGRATION_REGISTRY: IntegrationDefinition[] = [
     description: 'Use Light Protocol when the app needs rent-efficient compressed state, compressed tokens, or large-scale drops.',
     category: 'infra',
     docsUrl: 'https://www.lightprotocol.com/docs',
+    installCommand: 'pnpm add @lightprotocol/stateless.js',
     recommendedFor: ['compressed airdrops', 'rent reduction', 'high-scale state'],
     requirements: [
       { type: 'env', key: 'RPC_URL', label: 'Compression-capable RPC' },

--- a/src/panels/IntegrationCommandCenter/sendaiSetup.ts
+++ b/src/panels/IntegrationCommandCenter/sendaiSetup.ts
@@ -224,7 +224,7 @@ export function upsertPackageJsonScript(packageJson: string, scriptName: string,
 
 export function buildFirstSolanaAgentFile(): string {
   return `import bs58 from 'bs58'
-import { Keypair } from '@solana/web3.js'
+import { Connection, Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { SolanaAgentKit, KeypairWallet } from 'solana-agent-kit'
 import TokenPlugin from '@solana-agent-kit/plugin-token'
 import NFTPlugin from '@solana-agent-kit/plugin-nft'
@@ -257,6 +257,7 @@ async function main() {
 
   const keypair = Keypair.fromSecretKey(secretKey)
   const wallet = new KeypairWallet(keypair)
+  const connection = new Connection(rpcUrl, 'confirmed')
 
   const agent = new SolanaAgentKit(
     wallet,
@@ -270,13 +271,16 @@ async function main() {
     .use(BlinksPlugin)
 
   const methods = Object.keys(agent.methods ?? {}).sort()
+  const balanceLamports = await connection.getBalance(keypair.publicKey)
+  const balanceSol = balanceLamports / LAMPORTS_PER_SOL
 
   console.log('SendAI Solana agent is ready.')
   console.log(\`Wallet: \${keypair.publicKey.toBase58()}\`)
   console.log(\`RPC: \${rpcUrl}\`)
+  console.log(\`Wallet balance: \${balanceSol.toFixed(6)} SOL\`)
   console.log(\`Methods loaded: \${methods.length}\`)
   console.log(\`Sample methods: \${methods.slice(0, 12).join(', ')}\`)
-  console.log('Next step: replace this inventory script with a read-only method like price, asset, or wallet inspection.')
+  console.log('Next step: replace this starter with the first protocol action you want DAEMON to own.')
 }
 
 main().catch((error) => {
@@ -310,14 +314,15 @@ This folder is the first runnable Solana agent scaffold created by DAEMON.
 ${runCommand}
 \`\`\`
 
-The starter does a safe readiness check only:
+The starter does a safe first-read only flow:
 
 - builds the agent
 - loads the plugins
+- reads the current wallet balance from the configured RPC
 - prints the available methods
 - does not send a transaction
 
-After that, the next safe upgrade is replacing the inventory log with a read-only method such as token price, asset lookup, or wallet inspection.
+After that, the next safe upgrade is replacing the balance check with a protocol-specific read such as token price, asset lookup, or wallet inspection.
 `
 }
 

--- a/src/panels/IntegrationCommandCenter/sendaiSetup.ts
+++ b/src/panels/IntegrationCommandCenter/sendaiSetup.ts
@@ -2,6 +2,7 @@ export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
 export interface PackageInfo {
   packages: Set<string>
+  scripts: Set<string>
   packageManagerHint: PackageManager | null
 }
 
@@ -23,6 +24,22 @@ export interface EnvTemplateEntry {
   comment: string
 }
 
+export interface FirstAgentPlan {
+  packageManager: PackageManager
+  entryFilePath: string
+  readmePath: string
+  scriptName: string
+  scriptCommand: string
+  runCommand: string
+  missingPackages: string[]
+  alreadyScaffolded: boolean
+  scriptPresent: boolean
+  canScaffold: boolean
+  canRun: boolean
+  prerequisites: string[]
+  safetyNotes: string[]
+}
+
 export const SENDAI_AGENT_KIT_PACKAGES = [
   'solana-agent-kit',
   '@solana-agent-kit/plugin-token',
@@ -30,7 +47,13 @@ export const SENDAI_AGENT_KIT_PACKAGES = [
   '@solana-agent-kit/plugin-nft',
   '@solana-agent-kit/plugin-misc',
   '@solana-agent-kit/plugin-blinks',
+  '@solana/web3.js',
+  'bs58',
 ]
+
+export const SENDAI_FIRST_AGENT_SCRIPT = 'agent:first-solana'
+export const SENDAI_FIRST_AGENT_ENTRY = 'src/agents/first-solana-agent.mjs'
+export const SENDAI_FIRST_AGENT_README = 'src/agents/README.md'
 
 export const SENDAI_ENV_TEMPLATE: EnvTemplateEntry[] = [
   {
@@ -61,6 +84,7 @@ export function parsePackageInfo(packageJson: string): PackageInfo {
       dependencies?: Record<string, string>
       devDependencies?: Record<string, string>
       optionalDependencies?: Record<string, string>
+      scripts?: Record<string, string>
       packageManager?: string
     }
     return {
@@ -69,10 +93,11 @@ export function parsePackageInfo(packageJson: string): PackageInfo {
         ...Object.keys(parsed.devDependencies ?? {}),
         ...Object.keys(parsed.optionalDependencies ?? {}),
       ]),
+      scripts: new Set(Object.keys(parsed.scripts ?? {})),
       packageManagerHint: parsePackageManagerHint(parsed.packageManager),
     }
   } catch {
-    return { packages: new Set(), packageManagerHint: null }
+    return { packages: new Set(), scripts: new Set(), packageManagerHint: null }
   }
 }
 
@@ -115,7 +140,7 @@ export function createSendAiSetupPlan(input: {
     enabledActions: [
       'Create token and NFT action tools',
       'Preview DeFi routes before signing',
-      'Expose agent-readable Solana actions through MCP later',
+      'Scaffold a first runnable Solana agent inside the active project',
     ],
     safetyNotes: [
       'Apply Setup writes placeholders to .env.example, not real secrets.',
@@ -151,6 +176,151 @@ export function mergeEnvExample(currentContent: string, entries: EnvTemplateEntr
   return lines.join('\n')
 }
 
+export function createFirstAgentPlan(input: {
+  packageInfo: PackageInfo
+  lockfiles: Partial<Record<PackageManager, boolean>>
+  hasPackageJson: boolean
+  hasStarterFile: boolean
+}): FirstAgentPlan {
+  const packageManager = detectPackageManager(input.packageInfo, input.lockfiles)
+  const missingPackages = SENDAI_AGENT_KIT_PACKAGES.filter((name) => !input.packageInfo.packages.has(name))
+  const scriptCommand = `node ${SENDAI_FIRST_AGENT_ENTRY}`
+  const scriptPresent = input.packageInfo.scripts.has(SENDAI_FIRST_AGENT_SCRIPT)
+
+  return {
+    packageManager,
+    entryFilePath: SENDAI_FIRST_AGENT_ENTRY,
+    readmePath: SENDAI_FIRST_AGENT_README,
+    scriptName: SENDAI_FIRST_AGENT_SCRIPT,
+    scriptCommand,
+    runCommand: buildRunCommand(packageManager, SENDAI_FIRST_AGENT_SCRIPT),
+    missingPackages,
+    alreadyScaffolded: input.hasStarterFile,
+    scriptPresent,
+    canScaffold: input.hasPackageJson && !input.hasStarterFile,
+    canRun: input.hasPackageJson && input.hasStarterFile && missingPackages.length === 0,
+    prerequisites: [
+      input.hasPackageJson ? 'package.json detected' : 'Create or open a Node project first',
+      missingPackages.length === 0 ? 'Runtime packages are installed' : `${missingPackages.length} package${missingPackages.length === 1 ? '' : 's'} still need install`,
+      input.hasStarterFile ? 'Starter agent file already exists' : 'Starter agent file will be created',
+    ],
+    safetyNotes: [
+      'Scaffold only writes starter files and a package.json script.',
+      'The generated example only initializes the agent and prints method inventory.',
+      'Run Starter Check uses a visible terminal and does not submit transactions.',
+    ],
+  }
+}
+
+export function upsertPackageJsonScript(packageJson: string, scriptName: string, scriptCommand: string): string {
+  const parsed = JSON.parse(packageJson) as {
+    scripts?: Record<string, string>
+  } & Record<string, unknown>
+
+  const nextScripts = { ...(parsed.scripts ?? {}), [scriptName]: scriptCommand }
+  const next = { ...parsed, scripts: nextScripts }
+  return `${JSON.stringify(next, null, 2)}\n`
+}
+
+export function buildFirstSolanaAgentFile(): string {
+  return `import bs58 from 'bs58'
+import { Keypair } from '@solana/web3.js'
+import { SolanaAgentKit, KeypairWallet } from 'solana-agent-kit'
+import TokenPlugin from '@solana-agent-kit/plugin-token'
+import NFTPlugin from '@solana-agent-kit/plugin-nft'
+import DefiPlugin from '@solana-agent-kit/plugin-defi'
+import MiscPlugin from '@solana-agent-kit/plugin-misc'
+import BlinksPlugin from '@solana-agent-kit/plugin-blinks'
+
+function requireEnv(key) {
+  const value = process.env[key]?.trim()
+  if (!value) {
+    throw new Error(\`Missing \${key}. Copy .env.example into .env and fill the value first.\`)
+  }
+  return value
+}
+
+function parseSecretKey(value) {
+  const trimmed = value.trim()
+
+  if (trimmed.startsWith('[')) {
+    return Uint8Array.from(JSON.parse(trimmed))
+  }
+
+  return bs58.decode(trimmed)
+}
+
+async function main() {
+  const rpcUrl = requireEnv('RPC_URL')
+  const secretKey = parseSecretKey(requireEnv('SOLANA_PRIVATE_KEY'))
+  const openAiKey = process.env.OPENAI_API_KEY?.trim()
+
+  const keypair = Keypair.fromSecretKey(secretKey)
+  const wallet = new KeypairWallet(keypair)
+
+  const agent = new SolanaAgentKit(
+    wallet,
+    rpcUrl,
+    openAiKey ? { OPENAI_API_KEY: openAiKey } : {}
+  )
+    .use(TokenPlugin)
+    .use(NFTPlugin)
+    .use(DefiPlugin)
+    .use(MiscPlugin)
+    .use(BlinksPlugin)
+
+  const methods = Object.keys(agent.methods ?? {}).sort()
+
+  console.log('SendAI Solana agent is ready.')
+  console.log(\`Wallet: \${keypair.publicKey.toBase58()}\`)
+  console.log(\`RPC: \${rpcUrl}\`)
+  console.log(\`Methods loaded: \${methods.length}\`)
+  console.log(\`Sample methods: \${methods.slice(0, 12).join(', ')}\`)
+  console.log('Next step: replace this inventory script with a read-only method like price, asset, or wallet inspection.')
+}
+
+main().catch((error) => {
+  console.error('Starter check failed.')
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})
+`
+}
+
+export function buildFirstSolanaAgentReadme(runCommand = `pnpm run ${SENDAI_FIRST_AGENT_SCRIPT}`): string {
+  return `# SendAI Starter Agent
+
+This folder is the first runnable Solana agent scaffold created by DAEMON.
+
+## Files
+
+- \`${SENDAI_FIRST_AGENT_ENTRY}\` initializes Solana Agent Kit with the standard SendAI plugins.
+- \`package.json\` gets an \`${SENDAI_FIRST_AGENT_SCRIPT}\` script so the example is easy to run.
+
+## Before you run it
+
+1. Copy \`.env.example\` to \`.env\`.
+2. Set \`RPC_URL\` to a devnet or local validator endpoint.
+3. Set \`SOLANA_PRIVATE_KEY\` to a dev wallet secret in base58 or JSON-array form.
+4. Optionally set \`OPENAI_API_KEY\` if you plan to wire the agent into model tools next.
+
+## Run
+
+\`\`\`bash
+${runCommand}
+\`\`\`
+
+The starter does a safe readiness check only:
+
+- builds the agent
+- loads the plugins
+- prints the available methods
+- does not send a transaction
+
+After that, the next safe upgrade is replacing the inventory log with a read-only method such as token price, asset lookup, or wallet inspection.
+`
+}
+
 function parsePackageManagerHint(value: string | undefined): PackageManager | null {
   if (!value) return null
   if (value.startsWith('pnpm@')) return 'pnpm'
@@ -158,4 +328,11 @@ function parsePackageManagerHint(value: string | undefined): PackageManager | nu
   if (value.startsWith('yarn@')) return 'yarn'
   if (value.startsWith('bun@')) return 'bun'
   return null
+}
+
+function buildRunCommand(packageManager: PackageManager, scriptName: string): string {
+  if (packageManager === 'npm') return `npm run ${scriptName}`
+  if (packageManager === 'pnpm') return `pnpm run ${scriptName}`
+  if (packageManager === 'yarn') return `yarn ${scriptName}`
+  return `bun run ${scriptName}`
 }

--- a/src/panels/SolanaToolbox/ProtocolPacksSection.tsx
+++ b/src/panels/SolanaToolbox/ProtocolPacksSection.tsx
@@ -1,14 +1,35 @@
 import { useCallback, useState } from 'react'
 import { SOLANA_PROTOCOL_PACKS } from './catalog'
+import { useUIStore } from '../../store/ui'
+
+const PACK_INTEGRATION_MAP: Partial<Record<string, string>> = {
+  jupiter: 'jupiter',
+  metaplex: 'metaplex',
+  raydium: 'token-launch-stack',
+  meteora: 'token-launch-stack',
+}
 
 export function ProtocolPacksSection() {
   const [copied, setCopied] = useState<string | null>(null)
+  const openWorkspaceTool = useUIStore((s) => s.openWorkspaceTool)
+  const setIntegrationCommandSelectionId = useUIStore((s) => s.setIntegrationCommandSelectionId)
 
   const copyText = useCallback((value: string) => {
     navigator.clipboard.writeText(value).catch(() => {})
     setCopied(value)
     setTimeout(() => setCopied(null), 1500)
   }, [])
+
+  const openPackFlow = useCallback((packId: string) => {
+    const integrationId = PACK_INTEGRATION_MAP[packId]
+    if (integrationId) {
+      setIntegrationCommandSelectionId(integrationId)
+      openWorkspaceTool('integrations')
+      return
+    }
+
+    openWorkspaceTool('solana-toolbox')
+  }, [openWorkspaceTool, setIntegrationCommandSelectionId])
 
   return (
     <div className="solana-protocol-packs">
@@ -40,6 +61,9 @@ export function ProtocolPacksSection() {
             </div>
             <div className="solana-protocol-footer">
               <div className="solana-protocol-actions">
+                <button className="sol-btn green" onClick={() => openPackFlow(pack.id)}>
+                  {pack.status === 'native' ? 'Open Flow' : 'Open Integration'}
+                </button>
                 <button className="sol-btn" onClick={() => copyText(pack.skill)}>
                   {copied === pack.skill ? 'Copied Skill' : 'Copy Skill'}
                 </button>

--- a/src/panels/SolanaToolbox/SolanaToolbox.tsx
+++ b/src/panels/SolanaToolbox/SolanaToolbox.tsx
@@ -15,9 +15,9 @@ import './SolanaToolbox.css'
 
 const SOLANA_VIEWS = [
   {
-    id: 'overview',
-    label: 'Overview',
-    summary: 'Runtime, validator, and project state',
+    id: 'start',
+    label: 'Start',
+    summary: 'Readiness, runtime, and first moves',
   },
   {
     id: 'connect',
@@ -25,24 +25,24 @@ const SOLANA_VIEWS = [
     summary: 'Providers, MCPs, and wallet paths',
   },
   {
-    id: 'build',
-    label: 'Build',
-    summary: 'Scaffolds, skills, and payment setup',
+    id: 'transact',
+    label: 'Transact',
+    summary: 'Quotes, execution, and agent capabilities',
   },
   {
-    id: 'integrate',
-    label: 'Integrate',
-    summary: 'Protocol packs and ecosystem coverage',
+    id: 'launch',
+    label: 'Launch',
+    summary: 'Protocol flows and launch-oriented surfaces',
   },
   {
-    id: 'diagnose',
-    label: 'Diagnose',
+    id: 'debug',
+    label: 'Debug',
     summary: 'Toolchain readiness and environment checks',
   },
 ] as const
 
 export function SolanaToolbox() {
-  const [activeView, setActiveView] = useState<(typeof SOLANA_VIEWS)[number]['id']>('overview')
+  const [activeView, setActiveView] = useState<(typeof SOLANA_VIEWS)[number]['id']>('start')
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
   const mcps = useSolanaToolboxStore((s) => s.mcps)
@@ -83,9 +83,9 @@ export function SolanaToolbox() {
         <div className="solana-workflow-header">
           <div>
             <div className="solana-token-launch-kicker">Solana Workspace</div>
-            <h1 className="solana-workflow-title">Choose the task you need right now</h1>
+            <h1 className="solana-workflow-title">Work through one Solana task at a time</h1>
             <p className="solana-workflow-copy">
-              Keep DAEMON focused on the next Solana job instead of making you scroll through one oversized toolbox page.
+              Use the same task language as Wallet and Integrations so setup, execution, launch, and debugging feel like one Solana workflow.
             </p>
           </div>
         </div>
@@ -107,10 +107,34 @@ export function SolanaToolbox() {
         </div>
 
         <div className="solana-view-panel">
-          {activeView === 'overview' && (
+          {activeView === 'start' && (
             <>
               <div className="solana-validator-zone">
+                <DaemonRuntimeSection mcps={mcps} toolchain={toolchain} />
+              </div>
+              <div className="solana-validator-zone">
                 <ValidatorCard />
+              </div>
+              <div className="solana-validator-zone">
+                <CapabilitiesSection
+                  mcps={mcps}
+                  projectPath={activeProjectPath}
+                  onToggle={toggleMcp}
+                  onScaffoldX402={handleScaffoldX402}
+                  onScaffoldMpp={handleScaffoldMpp}
+                />
+              </div>
+            </>
+          )}
+
+          {activeView === 'connect' && (
+            <>
+              <div className="solana-validator-zone">
+                <ConnectedServices
+                  mcps={mcps}
+                  projectPath={activeProjectPath}
+                  onToggle={toggleMcp}
+                />
               </div>
               <div className="solana-validator-zone">
                 <RuntimeStackSection />
@@ -118,33 +142,25 @@ export function SolanaToolbox() {
             </>
           )}
 
-          {activeView === 'connect' && (
-            <div className="solana-validator-zone">
-              <ConnectedServices
-                mcps={mcps}
-                projectPath={activeProjectPath}
-                onToggle={toggleMcp}
-              />
-            </div>
-          )}
-
-          {activeView === 'build' && (
-            <div className="solana-validator-zone">
-              <CapabilitiesSection
-                mcps={mcps}
-                projectPath={activeProjectPath}
-                onToggle={toggleMcp}
-                onScaffoldX402={handleScaffoldX402}
-                onScaffoldMpp={handleScaffoldMpp}
-              />
-            </div>
-          )}
-
-          {activeView === 'integrate' && (
+          {activeView === 'transact' && (
             <>
               <div className="solana-validator-zone">
-                <DaemonRuntimeSection mcps={mcps} toolchain={toolchain} />
+                <RuntimeStackSection />
               </div>
+              <div className="solana-validator-zone">
+                <CapabilitiesSection
+                  mcps={mcps}
+                  projectPath={activeProjectPath}
+                  onToggle={toggleMcp}
+                  onScaffoldX402={handleScaffoldX402}
+                  onScaffoldMpp={handleScaffoldMpp}
+                />
+              </div>
+            </>
+          )}
+
+          {activeView === 'launch' && (
+            <>
               <div className="solana-validator-zone">
                 <ProtocolPacksSection />
               </div>
@@ -154,10 +170,15 @@ export function SolanaToolbox() {
             </>
           )}
 
-          {activeView === 'diagnose' && (
-            <div className="solana-validator-zone">
-              <ToolchainSection toolchain={toolchain} />
-            </div>
+          {activeView === 'debug' && (
+            <>
+              <div className="solana-validator-zone">
+                <ToolchainSection toolchain={toolchain} />
+              </div>
+              <div className="solana-validator-zone">
+                <ValidatorCard />
+              </div>
+            </>
           )}
         </div>
       </section>

--- a/src/panels/WalletPanel/WalletPanel.css
+++ b/src/panels/WalletPanel/WalletPanel.css
@@ -974,6 +974,102 @@
   gap: 14px;
 }
 
+.wallet-readiness-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 14px;
+}
+
+.wallet-readiness-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, var(--green) 18%, var(--border) 82%);
+  border-radius: var(--drawer-card-radius);
+  background:
+    radial-gradient(circle at top left, rgba(62, 207, 142, 0.12), transparent 42%),
+    linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.012));
+  box-shadow:
+    0 14px 28px rgba(0, 0, 0, 0.16),
+    0 1px 0 rgba(255, 255, 255, 0.03) inset;
+}
+
+.wallet-readiness-hero strong {
+  font-size: 20px;
+  line-height: 1.16;
+  color: var(--t1);
+}
+
+.wallet-readiness-hero p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--t3);
+}
+
+.wallet-readiness-progress {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--t4);
+  font-size: 11px;
+}
+
+.wallet-readiness-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.wallet-readiness-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: flex-start;
+  padding: 14px;
+  border: 1px solid var(--s4);
+  border-radius: var(--drawer-card-radius);
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.022), rgba(255,255,255,0.01)),
+    color-mix(in srgb, var(--s2) 88%, black 12%);
+}
+
+.wallet-readiness-item.ready {
+  border-color: color-mix(in srgb, var(--green) 16%, var(--border) 84%);
+}
+
+.wallet-readiness-item strong {
+  display: block;
+  font-size: 13px;
+  line-height: 1.2;
+  color: var(--t1);
+}
+
+.wallet-readiness-item p {
+  margin: 5px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--t3);
+}
+
+.wallet-readiness-dot {
+  width: 9px;
+  height: 9px;
+  margin-top: 4px;
+  border-radius: 999px;
+  background: var(--t4);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.03);
+}
+
+.wallet-readiness-dot.ready {
+  background: var(--green);
+  box-shadow: 0 0 0 4px rgba(62, 207, 142, 0.1);
+}
+
 .wallet-overview-card,
 .wallet-move-card {
   display: flex;
@@ -1046,6 +1142,8 @@
     width: 100%;
   }
 
+  .wallet-readiness-shell,
+  .wallet-readiness-grid,
   .wallet-overview-grid,
   .wallet-move-grid {
     grid-template-columns: 1fr;
@@ -1053,6 +1151,12 @@
 
   .wallet-quick-actions {
     flex-wrap: wrap;
+  }
+}
+
+@container wallet (max-width: 980px) {
+  .wallet-readiness-shell {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/panels/WalletPanel/tabs/WalletTab.tsx
+++ b/src/panels/WalletPanel/tabs/WalletTab.tsx
@@ -468,15 +468,21 @@ export function WalletTab({ onRefresh }: Props) {
     rpcReady,
   })
   const walletPrimaryAction = walletReadiness.nextAction.id === 'open-wallet'
-    ? { label: 'Open manage', onClick: () => setActiveView('manage') }
+    ? {
+      label: activeWallet ? 'Add signer' : 'Create wallet',
+      onClick: () => setActiveView('manage'),
+    }
     : walletReadiness.nextAction.id === 'assign-project' && activeWallet
       ? { label: 'Use for current project', onClick: () => void handleAssignProject(activeWallet.id) }
       : walletReadiness.nextAction.id === 'set-main-wallet' && activeWallet
         ? { label: 'Make main wallet', onClick: () => void handleSetDefault(activeWallet.id) }
         : walletReadiness.nextAction.id === 'open-infrastructure'
-          ? { label: 'Open infrastructure', onClick: () => setShowInfrastructure(true) }
+          ? { label: 'Finish infrastructure', onClick: () => setShowInfrastructure(true) }
           : activeWallet
-            ? { label: walletReadiness.nextAction.label, onClick: () => openSend(activeWallet.id, 'sol') }
+            ? {
+              label: walletReadiness.nextAction.id === 'transact' ? 'Send SOL' : walletReadiness.nextAction.label,
+              onClick: () => openSend(activeWallet.id, 'sol'),
+            }
             : null
   const walletSecondaryAction = hasKeypair
     ? { label: 'Open holdings', onClick: () => setActiveView('holdings') }

--- a/src/panels/WalletPanel/tabs/WalletTab.tsx
+++ b/src/panels/WalletPanel/tabs/WalletTab.tsx
@@ -10,6 +10,7 @@ import { WalletSwapForm } from '../WalletSwapForm'
 import { VaultSection } from '../VaultSection'
 import { PnlHoldings } from '../PnlHoldings'
 import { WalletSendForm } from '../WalletSendForm'
+import { buildSolanaRouteReadiness } from '../../../lib/solanaReadiness'
 
 interface Props {
   onRefresh: () => Promise<void>
@@ -439,6 +440,48 @@ export function WalletTab({ onRefresh }: Props) {
     />
   )
 
+  const rpcProviderLabel = walletInfrastructure.rpcProvider === 'helius'
+    ? 'Helius RPC'
+    : walletInfrastructure.rpcProvider === 'quicknode'
+      ? 'QuickNode RPC'
+      : walletInfrastructure.rpcProvider === 'custom'
+        ? 'Custom RPC'
+        : 'Public RPC'
+  const rpcReady = walletInfrastructure.rpcProvider === 'helius'
+    ? dashboard.heliusConfigured
+    : walletInfrastructure.rpcProvider === 'quicknode'
+      ? walletInfrastructure.quicknodeRpcUrl.trim().length > 0
+      : walletInfrastructure.rpcProvider === 'custom'
+        ? walletInfrastructure.customRpcUrl.trim().length > 0
+        : true
+  const walletReadiness = buildSolanaRouteReadiness({
+    walletPresent: Boolean(activeWallet),
+    walletName: activeWallet?.name,
+    walletAddress: activeWallet?.address,
+    isMainWallet: Boolean(activeWalletMeta?.isDefault),
+    signerReady: hasKeypair,
+    hasActiveProject: Boolean(activeProjectId),
+    projectAssigned: activeProjectId ? Boolean(activeWalletMeta?.assignedProjectIds.includes(activeProjectId)) : true,
+    preferredWallet: walletInfrastructure.preferredWallet,
+    executionMode: walletInfrastructure.executionMode,
+    rpcLabel: rpcProviderLabel,
+    rpcReady,
+  })
+  const walletPrimaryAction = walletReadiness.nextAction.id === 'open-wallet'
+    ? { label: 'Open manage', onClick: () => setActiveView('manage') }
+    : walletReadiness.nextAction.id === 'assign-project' && activeWallet
+      ? { label: 'Use for current project', onClick: () => void handleAssignProject(activeWallet.id) }
+      : walletReadiness.nextAction.id === 'set-main-wallet' && activeWallet
+        ? { label: 'Make main wallet', onClick: () => void handleSetDefault(activeWallet.id) }
+        : walletReadiness.nextAction.id === 'open-infrastructure'
+          ? { label: 'Open infrastructure', onClick: () => setShowInfrastructure(true) }
+          : activeWallet
+            ? { label: walletReadiness.nextAction.label, onClick: () => openSend(activeWallet.id, 'sol') }
+            : null
+  const walletSecondaryAction = hasKeypair
+    ? { label: 'Open holdings', onClick: () => setActiveView('holdings') }
+    : { label: 'Receive', onClick: () => setActiveView('receive') }
+
   if (activeView === 'vault') return <VaultSection onBack={() => setActiveView('overview')} />
 
   if (activeView === 'receive' && activeWallet) {
@@ -531,29 +574,45 @@ export function WalletTab({ onRefresh }: Props) {
                 {hasKeypair && <button className="wallet-btn primary-soft" onClick={() => handleExportKeyStart(activeWallet.id)}>Export key</button>}
               </div>
             </div>
-            <div className="wallet-overview-grid">
-              <div className="wallet-overview-card">
-                <span className="wallet-overview-label">Best next action</span>
-                <strong>{hasKeypair ? 'Move funds or sell a holding' : 'Turn this into a signer'}</strong>
-                <p>{hasKeypair ? 'Use Move for transfers and Holdings for quick sell and swap actions.' : 'Import or generate a signing wallet so this workspace can send and trade.'}</p>
+            <div className="wallet-readiness-shell">
+              <div className="wallet-readiness-hero">
+                <span className="wallet-overview-label">Wallet readiness</span>
+                <strong>{walletReadiness.headline}</strong>
+                <p>{walletReadiness.description}</p>
+                <div className="wallet-readiness-progress">
+                  <span>{walletReadiness.readyCount}/{walletReadiness.totalCount} checks ready</span>
+                  <span>{activeProjectId ? 'Project-aware route' : 'Workspace route'}</span>
+                </div>
                 <div className="wallet-actions wallet-actions-wrap">
-                  {hasKeypair ? (
-                    <>
-                      <button className="wallet-btn primary" onClick={() => openSend(activeWallet.id, 'sol')}>Move funds</button>
-                      <button className="wallet-btn" onClick={() => setActiveView('holdings')}>Open holdings</button>
-                    </>
-                  ) : (
-                    <button className="wallet-btn primary" onClick={() => setActiveView('manage')}>Open manage</button>
-                  )}
+                  {walletPrimaryAction ? (
+                    <button className="wallet-btn primary" onClick={walletPrimaryAction.onClick}>{walletPrimaryAction.label}</button>
+                  ) : null}
+                  <button className="wallet-btn" onClick={walletSecondaryAction.onClick}>{walletSecondaryAction.label}</button>
                 </div>
               </div>
-              <div className="wallet-overview-card">
-                <span className="wallet-overview-label">Quick status</span>
-                <strong>{activeWallet.holdings.length} assets tracked</strong>
-                <p>{transactions?.length ? `${transactions.length} recent transaction${transactions.length === 1 ? '' : 's'} loaded.` : 'No recent transactions loaded yet.'}</p>
-                <div className="wallet-actions wallet-actions-wrap">
-                  <button className="wallet-btn" onClick={() => setActiveView('history')}>View history</button>
-                  <button className="wallet-btn" onClick={() => setActiveView('manage')}>Switch wallet</button>
+              <div className="wallet-readiness-grid">
+                {walletReadiness.items.map((item) => (
+                  <div key={item.label} className={`wallet-readiness-item${item.ready ? ' ready' : ''}`}>
+                    <span className={`wallet-readiness-dot${item.ready ? ' ready' : ''}`} />
+                    <div>
+                      <strong>{item.label}</strong>
+                      <p>{item.detail}</p>
+                    </div>
+                  </div>
+                ))}
+                <div className="wallet-readiness-item">
+                  <span className="wallet-readiness-dot ready" />
+                  <div>
+                    <strong>Activity snapshot</strong>
+                    <p>{transactions?.length ? `${transactions.length} recent transaction${transactions.length === 1 ? '' : 's'} loaded.` : 'No recent transactions loaded yet.'}</p>
+                  </div>
+                </div>
+                <div className="wallet-readiness-item">
+                  <span className="wallet-readiness-dot ready" />
+                  <div>
+                    <strong>Asset coverage</strong>
+                    <p>{activeWallet.holdings.length} asset{activeWallet.holdings.length === 1 ? '' : 's'} tracked for this wallet.</p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -43,6 +43,7 @@ interface UIState {
   browserTabActive: boolean
   workspaceToolTabs: string[]
   activeWorkspaceToolId: string | null
+  integrationCommandSelectionId: string | null
   rightPanelTab: RightPanelTab
   dashboardTabOpen: boolean
   dashboardTabActive: boolean
@@ -72,6 +73,7 @@ interface UIState {
   openWorkspaceTool: (toolId: string) => void
   closeWorkspaceTool: (toolId: string) => void
   setActiveWorkspaceTool: (toolId: string | null) => void
+  setIntegrationCommandSelectionId: (integrationId: string | null) => void
   toggleWorkspaceTool: (toolId: string) => void
   setRightPanelTab: (tab: RightPanelTab) => void
   toggleDashboardTab: () => void
@@ -120,6 +122,7 @@ export const useUIStore = create<UIState>((set) => ({
   browserTabActive: false,
   workspaceToolTabs: [],
   activeWorkspaceToolId: null,
+  integrationCommandSelectionId: null,
   rightPanelTab: 'claude' as RightPanelTab,
   dashboardTabOpen: false,
   dashboardTabActive: false,
@@ -302,6 +305,7 @@ export const useUIStore = create<UIState>((set) => ({
         }
       : { activeWorkspaceToolId: null })
   },
+  setIntegrationCommandSelectionId: (integrationId) => set({ integrationCommandSelectionId: integrationId }),
   toggleWorkspaceTool: (toolId) => set((state) => {
     if (toolId === 'browser') {
       if (state.browserTabActive) {

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -419,6 +419,35 @@ describe('App surface DOM coverage', () => {
     expect(await screen.findByRole('heading', { name: 'Metaplex' })).toBeInTheDocument()
   })
 
+  it('resets hidden integration filters when another surface targets a workflow', async () => {
+    render(<IntegrationCommandCenter />)
+
+    expect(await screen.findByText('Integration Command Center')).toBeInTheDocument()
+
+    await userEvent.type(screen.getByPlaceholderText('Search integrations, actions, protocols...'), 'phantom')
+    expect(screen.getByDisplayValue('phantom')).toBeInTheDocument()
+
+    useUIStore.getState().setIntegrationCommandSelectionId('sendai-solana-mcp')
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'SendAI Solana MCP' })).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('')).toBeInTheDocument()
+  })
+
+  it('opens MCP setup without leaving stale integration selection behind', async () => {
+    render(<IntegrationCommandCenter />)
+
+    expect(await screen.findByText('Integration Command Center')).toBeInTheDocument()
+
+    await userEvent.click(screen.getAllByText('SendAI Solana MCP')[0].closest('button')!)
+    await userEvent.click(screen.getByRole('button', { name: 'Open MCP setup' }))
+
+    expect(useUIStore.getState().integrationCommandSelectionId).toBeNull()
+    expect(useUIStore.getState().activeWorkspaceToolId).toBe('solana-toolbox')
+    expect(await screen.findByText('Open MCP setup', { selector: '.icc-result-title' })).toBeInTheDocument()
+  })
+
   it('renders Solana toolbox workflow tabs and switches views', async () => {
     render(<SolanaToolbox />)
 

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -33,6 +33,9 @@ function installDaemonBridge() {
               'solana-agent-kit': '^2.0.0',
               '@metaplex-foundation/umi': '^1.0.0',
             },
+            scripts: {
+              dev: 'vite',
+            },
           }),
         },
       }
@@ -45,7 +48,15 @@ function installDaemonBridge() {
     return { ok: false, error: 'File not found' }
   })
   const writeFile = vi.fn().mockResolvedValue({ ok: true })
-  const createTerminal = vi.fn().mockResolvedValue({ ok: true, data: { id: 'terminal-sendai', pid: 123, agentId: null } })
+  const createDir = vi.fn().mockResolvedValue({ ok: true })
+  const createTerminal = vi.fn().mockImplementation(async ({ startupCommand }: { startupCommand?: string }) => ({
+    ok: true,
+    data: {
+      id: startupCommand?.includes('agent:first-solana') ? 'terminal-sendai-run' : 'terminal-sendai',
+      pid: 123,
+      agentId: null,
+    },
+  }))
   const transactionPreview = vi.fn().mockResolvedValue({
     ok: true,
     data: {
@@ -91,6 +102,7 @@ function installDaemonBridge() {
       fs: {
         readFile,
         writeFile,
+        createDir,
       },
       terminal: {
         create: createTerminal,
@@ -168,7 +180,7 @@ function installDaemonBridge() {
     },
   })
 
-  return { createTerminal, readFile, transactionPreview, writeFile }
+  return { createDir, createTerminal, readFile, transactionPreview, writeFile }
 }
 
 function resetStores() {
@@ -233,6 +245,7 @@ describe('App surface DOM coverage', () => {
     expect(screen.getAllByText('Helius').length).toBeGreaterThan(0)
     expect(screen.getByText('safe checks')).toBeInTheDocument()
     expect(screen.getByText('Add Solana Agent Kit to this project')).toBeInTheDocument()
+    expect(screen.getByText('Create your first Solana agent')).toBeInTheDocument()
     expect(await screen.findByText(/pnpm add @solana-agent-kit\/plugin-token/)).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: 'Apply Setup' }))
@@ -247,6 +260,24 @@ describe('App surface DOM coverage', () => {
       startupCommand: expect.stringContaining('pnpm add @solana-agent-kit/plugin-token'),
     }))
     expect(useUIStore.getState().terminals.some((terminal) => terminal.id === 'terminal-sendai')).toBe(true)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create Starter Files' }))
+
+    expect(await screen.findByText('Starter agent scaffolded')).toBeInTheDocument()
+    expect(window.daemon.fs.createDir).toHaveBeenCalledWith('C:/work/daemon-app/src')
+    expect(window.daemon.fs.createDir).toHaveBeenCalledWith('C:/work/daemon-app/src/agents')
+    expect(window.daemon.fs.writeFile).toHaveBeenCalledWith(
+      'C:/work/daemon-app/package.json',
+      expect.stringContaining('"agent:first-solana": "node src/agents/first-solana-agent.mjs"'),
+    )
+    expect(window.daemon.fs.writeFile).toHaveBeenCalledWith(
+      'C:/work/daemon-app/src/agents/first-solana-agent.mjs',
+      expect.stringContaining("console.log('SendAI Solana agent is ready.')"),
+    )
+    expect(window.daemon.fs.writeFile).toHaveBeenCalledWith(
+      'C:/work/daemon-app/src/agents/README.md',
+      expect.stringContaining('pnpm run agent:first-solana'),
+    )
 
     await userEvent.click(screen.getByRole('button', { name: 'DeFi' }))
     expect(screen.getByRole('heading', { name: 'Jupiter' })).toBeInTheDocument()

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -52,7 +52,11 @@ function installDaemonBridge() {
   const createTerminal = vi.fn().mockImplementation(async ({ startupCommand }: { startupCommand?: string }) => ({
     ok: true,
     data: {
-      id: startupCommand?.includes('agent:first-solana') ? 'terminal-sendai-run' : 'terminal-sendai',
+      id: startupCommand?.includes('agent:first-solana')
+        ? 'terminal-sendai-run'
+        : startupCommand?.includes('npx skills add')
+          ? 'terminal-sendai-skills'
+          : 'terminal-sendai',
       pid: 123,
       agentId: null,
     },
@@ -68,6 +72,41 @@ function installDaemonBridge() {
       feeLabel: '~0.00001 SOL',
       warnings: ['Check the destination before signing.'],
       notes: ['This transaction is simulated before send.'],
+    },
+  })
+  const holdings = vi.fn().mockResolvedValue({
+    ok: true,
+    data: [
+      {
+        mint: 'So11111111111111111111111111111111111111112',
+        symbol: 'SOL',
+        name: 'Solana',
+        amount: 2.5,
+        priceUsd: 150,
+        valueUsd: 375,
+        logoUri: null,
+      },
+      {
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        symbol: 'USDC',
+        name: 'USD Coin',
+        amount: 45,
+        priceUsd: 1,
+        valueUsd: 45,
+        logoUri: null,
+      },
+    ],
+  })
+  const swapQuote = vi.fn().mockResolvedValue({
+    ok: true,
+    data: {
+      inputMint: 'So11111111111111111111111111111111111111112',
+      outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      inAmount: '100000000',
+      outAmount: '14.82',
+      priceImpactPct: '0.17',
+      routePlan: [{ label: 'Jupiter', percent: 100 }],
+      rawQuoteResponse: {},
     },
   })
 
@@ -126,7 +165,20 @@ function installDaemonBridge() {
             meteora: { configId: '', quoteMint: '', baseSupply: '' },
           },
         }),
+        getWalletInfrastructureSettings: vi.fn().mockResolvedValue({
+          ok: true,
+          data: {
+            rpcProvider: 'helius',
+            quicknodeRpcUrl: '',
+            customRpcUrl: '',
+            swapProvider: 'jupiter',
+            preferredWallet: 'wallet-standard',
+            executionMode: 'rpc',
+            jitoBlockEngineUrl: 'https://mainnet.block-engine.jito.wtf/api/v1/transactions',
+          },
+        }),
         setLayout: vi.fn().mockResolvedValue({ ok: true }),
+        setWalletInfrastructureSettings: vi.fn().mockResolvedValue({ ok: true }),
         getSolanaRuntimeStatus: vi.fn().mockResolvedValue({
           ok: true,
           data: {
@@ -172,15 +224,20 @@ function installDaemonBridge() {
       },
       wallet: {
         list: vi.fn().mockResolvedValue({ ok: true, data: [{ id: 'wallet-1', name: 'Main Wallet', address: '7Y12wallet9AbC', is_default: 1, created_at: 1, assigned_project_ids: [] }] }),
+        hasKeypair: vi.fn().mockResolvedValue({ ok: true, data: true }),
         hasHeliusKey: vi.fn().mockResolvedValue({ ok: true, data: true }),
         hasJupiterKey: vi.fn().mockResolvedValue({ ok: true, data: false }),
+        assignProject: vi.fn().mockResolvedValue({ ok: true }),
+        setDefault: vi.fn().mockResolvedValue({ ok: true }),
         balance: vi.fn().mockResolvedValue({ ok: true, data: { sol: 2.5, lamports: 2500000000 } }),
+        holdings,
+        swapQuote,
         transactionPreview,
       },
     },
   })
 
-  return { createDir, createTerminal, readFile, transactionPreview, writeFile }
+  return { createDir, createTerminal, holdings, readFile, swapQuote, transactionPreview, writeFile }
 }
 
 function resetStores() {
@@ -198,6 +255,7 @@ function resetStores() {
     drawerToolOrder: [],
     workspaceToolTabs: [],
     activeWorkspaceToolId: null,
+    integrationCommandSelectionId: null,
     browserTabOpen: false,
     browserTabActive: false,
     dashboardTabOpen: false,
@@ -244,11 +302,11 @@ describe('App surface DOM coverage', () => {
     expect(screen.getAllByText('SendAI Agent Kit').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Helius').length).toBeGreaterThan(0)
     expect(screen.getByText('safe checks')).toBeInTheDocument()
-    expect(screen.getByText('Add Solana Agent Kit to this project')).toBeInTheDocument()
-    expect(screen.getByText('Create your first Solana agent')).toBeInTheDocument()
+    expect(screen.getByText('Get this project to a first working SendAI agent')).toBeInTheDocument()
+    expect(screen.getByText('Next step')).toBeInTheDocument()
     expect(await screen.findByText(/pnpm add @solana-agent-kit\/plugin-token/)).toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('button', { name: 'Apply Setup' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Apply project setup' }))
 
     expect(await screen.findByText('SendAI setup started')).toBeInTheDocument()
     expect(window.daemon.fs.writeFile).toHaveBeenCalledWith(
@@ -260,8 +318,9 @@ describe('App surface DOM coverage', () => {
       startupCommand: expect.stringContaining('pnpm add @solana-agent-kit/plugin-token'),
     }))
     expect(useUIStore.getState().terminals.some((terminal) => terminal.id === 'terminal-sendai')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Create starter files' })).toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('button', { name: 'Create Starter Files' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Create starter files' }))
 
     expect(await screen.findByText('Starter agent scaffolded')).toBeInTheDocument()
     expect(window.daemon.fs.createDir).toHaveBeenCalledWith('C:/work/daemon-app/src')
@@ -272,22 +331,92 @@ describe('App surface DOM coverage', () => {
     )
     expect(window.daemon.fs.writeFile).toHaveBeenCalledWith(
       'C:/work/daemon-app/src/agents/first-solana-agent.mjs',
-      expect.stringContaining("console.log('SendAI Solana agent is ready.')"),
+      expect.stringContaining('Wallet balance:'),
     )
     expect(window.daemon.fs.writeFile).toHaveBeenCalledWith(
       'C:/work/daemon-app/src/agents/README.md',
       expect.stringContaining('pnpm run agent:first-solana'),
     )
+    expect(screen.getByRole('button', { name: 'Run starter check' })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('SendAI Skills'))
+    expect(screen.getByText('Bring protocol knowledge into this project')).toBeInTheDocument()
+    expect(screen.getByText(/solana-agent-kit, helius, metaplex/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Install skills in terminal' }))
+    expect(await screen.findByText('Skills install opened')).toBeInTheDocument()
+    expect(window.daemon.terminal.create).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: 'C:/work/daemon-app',
+      startupCommand: 'npx skills add sendaifun/skills',
+    }))
+    expect(useUIStore.getState().terminals.some((terminal) => terminal.id === 'terminal-sendai-skills')).toBe(true)
 
     await userEvent.click(screen.getByRole('button', { name: 'DeFi' }))
     expect(screen.getByRole('heading', { name: 'Jupiter' })).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: 'All' }))
-    await userEvent.click(screen.getByText('Phantom'))
-    await userEvent.click(screen.getByRole('button', { name: /Check balance/ }))
+    await userEvent.click(screen.getByText('Token Launch Stack'))
+    expect(screen.getByRole('button', { name: 'Open Token Launch' })).toBeInTheDocument()
 
-    expect(await screen.findByText('Wallet balance')).toBeInTheDocument()
-    expect(screen.getByText(/2.5 SOL/)).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Phantom'))
+    expect(screen.getByText('Get the wallet route ready for Phantom-first signing')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Use wallet for current project' })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Use wallet for current project' }))
+    expect(await screen.findByText('Project wallet linked')).toBeInTheDocument()
+    expect(window.daemon.wallet.assignProject).toHaveBeenCalledWith('project-1', 'wallet-1')
+    expect(screen.getByRole('button', { name: 'Set Phantom as preferred wallet' })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Set Phantom as preferred wallet' }))
+    expect(await screen.findByText('Preferred wallet updated')).toBeInTheDocument()
+    expect(window.daemon.settings.setWalletInfrastructureSettings).toHaveBeenCalledWith(expect.objectContaining({
+      preferredWallet: 'phantom',
+    }))
+    expect(screen.getByRole('button', { name: 'Preview first transaction' })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Preview first transaction' }))
+
+    expect(await screen.findByText('Phantom signing preview ready')).toBeInTheDocument()
+    expect(window.daemon.wallet.transactionPreview).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'send-sol',
+      walletId: 'wallet-1',
+      destination: '7Y12wallet9AbC',
+      amount: 0.01,
+    }))
+
+    await userEvent.click(screen.getByText('Helius'))
+    expect(screen.getByText('Verify the Helius-backed wallet data path')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Read wallet with Helius' }))
+    expect(await screen.findByText('Helius wallet read complete')).toBeInTheDocument()
+    expect(window.daemon.wallet.holdings).toHaveBeenCalledWith('wallet-1')
+
+    await userEvent.click(screen.getByText('Jupiter'))
+    expect(screen.getByText('Get to a first Jupiter quote before any signing')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Preview Jupiter quote' }))
+    expect(await screen.findByText('Jupiter quote ready')).toBeInTheDocument()
+    expect(window.daemon.wallet.swapQuote).toHaveBeenCalledWith({
+      inputMint: 'So11111111111111111111111111111111111111112',
+      outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      amount: 0.1,
+      slippageBps: 50,
+    })
+
+    await userEvent.click(screen.getByText('Metaplex'))
+    expect(screen.getByText('Create a first metadata draft inside the project')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Create metadata draft' }))
+    expect(await screen.findByText('Metaplex draft created')).toBeInTheDocument()
+    expect(window.daemon.fs.writeFile).toHaveBeenCalledWith(
+      'C:/work/daemon-app/assets/metaplex/metadata.example.json',
+      expect.stringContaining('"name": "DAEMON Collection Example"'),
+    )
+
+    await userEvent.click(screen.getByText('Light Protocol'))
+    expect(screen.getByText('Scaffold the first Light compression starter')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Install Light SDK' }))
+    expect(await screen.findByText('Install Light SDK opened')).toBeInTheDocument()
+    expect(window.daemon.terminal.create).toHaveBeenCalledWith(expect.objectContaining({
+      startupCommand: 'pnpm add @lightprotocol/stateless.js',
+    }))
+
+    useUIStore.getState().setIntegrationCommandSelectionId('metaplex')
+    expect(await screen.findByRole('heading', { name: 'Metaplex' })).toBeInTheDocument()
   })
 
   it('renders Solana toolbox workflow tabs and switches views', async () => {
@@ -298,11 +427,15 @@ describe('App surface DOM coverage', () => {
     await userEvent.click(screen.getByRole('tab', { name: /Connect/ }))
     expect(screen.getByRole('tab', { name: /Connect/ })).toHaveAttribute('aria-selected', 'true')
 
-    await userEvent.click(screen.getByRole('tab', { name: /Integrate/ }))
-    expect(screen.getByRole('tab', { name: /Integrate/ })).toHaveAttribute('aria-selected', 'true')
+    await userEvent.click(screen.getByRole('tab', { name: /Launch/ }))
+    expect(screen.getByRole('tab', { name: /Launch/ })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText('Onboard ecosystem integrations deliberately')).toBeInTheDocument()
+    await userEvent.click(screen.getAllByRole('button', { name: 'Open Integration' })[0]!)
+    expect(useUIStore.getState().activeWorkspaceToolId).toBe('integrations')
+    expect(useUIStore.getState().integrationCommandSelectionId).toBe('jupiter')
 
-    await userEvent.click(screen.getByRole('tab', { name: /Diagnose/ }))
-    expect(screen.getByRole('tab', { name: /Diagnose/ })).toHaveAttribute('aria-selected', 'true')
+    await userEvent.click(screen.getByRole('tab', { name: /Debug/ }))
+    expect(screen.getByRole('tab', { name: /Debug/ })).toHaveAttribute('aria-selected', 'true')
   })
 
   it('keeps Token Launch actions and config obvious', async () => {

--- a/test/panels/IntegrationCommandCenter.sendaiSetup.test.ts
+++ b/test/panels/IntegrationCommandCenter.sendaiSetup.test.ts
@@ -97,6 +97,8 @@ describe('SendAI Agent Kit setup planner', () => {
     const file = buildFirstSolanaAgentFile()
 
     expect(file).toContain("console.log('SendAI Solana agent is ready.')")
+    expect(file).toContain('connection.getBalance(keypair.publicKey)')
+    expect(file).toContain('Wallet balance:')
     expect(file).toContain('Object.keys(agent.methods ?? {}).sort()')
     expect(file).not.toContain('deployToken(')
     expect(file).not.toContain('trade(')

--- a/test/panels/IntegrationCommandCenter.sendaiSetup.test.ts
+++ b/test/panels/IntegrationCommandCenter.sendaiSetup.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildFirstSolanaAgentFile,
+  createFirstAgentPlan,
   createSendAiSetupPlan,
   mergeEnvExample,
   parsePackageInfo,
+  upsertPackageJsonScript,
 } from '../../src/panels/IntegrationCommandCenter/sendaiSetup'
 
 describe('SendAI Agent Kit setup planner', () => {
@@ -12,6 +15,10 @@ describe('SendAI Agent Kit setup planner', () => {
       dependencies: {
         'solana-agent-kit': '^2.0.0',
         '@solana-agent-kit/plugin-token': '^2.0.0',
+        '@solana/web3.js': '^1.98.0',
+      },
+      scripts: {
+        test: 'vitest',
       },
     }))
 
@@ -24,6 +31,7 @@ describe('SendAI Agent Kit setup planner', () => {
     expect(plan.packageManager).toBe('pnpm')
     expect(plan.installCommand).toContain('pnpm add @solana-agent-kit/plugin-defi')
     expect(plan.installCommand).not.toContain('pnpm add solana-agent-kit')
+    expect(plan.installCommand).toContain('bs58')
     expect(plan.presentEnvKeys).toEqual(['RPC_URL'])
     expect(plan.missingEnvKeys).toContain('SOLANA_PRIVATE_KEY')
   })
@@ -35,5 +43,62 @@ describe('SendAI Agent Kit setup planner', () => {
     expect(merged).toContain('OPENAI_API_KEY=replace_with_model_provider_key')
     expect(merged).toContain('SOLANA_PRIVATE_KEY=replace_with_devnet_wallet_private_key_or_use_daemon_wallet')
     expect(merged.match(/^RPC_URL=/gm)).toHaveLength(1)
+  })
+
+  it('builds a first-agent scaffold plan with a simple run command', () => {
+    const packageInfo = parsePackageInfo(JSON.stringify({
+      packageManager: 'pnpm@9.15.3',
+      dependencies: {
+        'solana-agent-kit': '^2.0.0',
+        '@solana-agent-kit/plugin-token': '^2.0.0',
+        '@solana-agent-kit/plugin-defi': '^2.0.0',
+        '@solana-agent-kit/plugin-nft': '^2.0.0',
+        '@solana-agent-kit/plugin-misc': '^2.0.0',
+        '@solana-agent-kit/plugin-blinks': '^2.0.0',
+        '@solana/web3.js': '^1.98.0',
+        bs58: '^6.0.0',
+      },
+      scripts: {
+        dev: 'vite',
+      },
+    }))
+
+    const plan = createFirstAgentPlan({
+      packageInfo,
+      lockfiles: {},
+      hasPackageJson: true,
+      hasStarterFile: false,
+    })
+
+    expect(plan.canScaffold).toBe(true)
+    expect(plan.canRun).toBe(false)
+    expect(plan.runCommand).toBe('pnpm run agent:first-solana')
+    expect(plan.scriptCommand).toBe('node src/agents/first-solana-agent.mjs')
+  })
+
+  it('updates package.json scripts without removing existing ones', () => {
+    const next = upsertPackageJsonScript(
+      JSON.stringify({
+        name: 'demo-app',
+        scripts: {
+          dev: 'vite',
+        },
+      }),
+      'agent:first-solana',
+      'node src/agents/first-solana-agent.mjs',
+    )
+
+    const parsed = JSON.parse(next) as { scripts: Record<string, string> }
+    expect(parsed.scripts.dev).toBe('vite')
+    expect(parsed.scripts['agent:first-solana']).toBe('node src/agents/first-solana-agent.mjs')
+  })
+
+  it('creates a starter file that stays in safe, read-only territory by default', () => {
+    const file = buildFirstSolanaAgentFile()
+
+    expect(file).toContain("console.log('SendAI Solana agent is ready.')")
+    expect(file).toContain('Object.keys(agent.methods ?? {}).sort()')
+    expect(file).not.toContain('deployToken(')
+    expect(file).not.toContain('trade(')
   })
 })

--- a/test/panels/WalletTab.dom.test.tsx
+++ b/test/panels/WalletTab.dom.test.tsx
@@ -142,4 +142,14 @@ describe('WalletTab readiness UX', () => {
       expect(onRefresh).toHaveBeenCalled()
     })
   })
+
+  it('uses a specific add-signer CTA when the active wallet is watch-only', async () => {
+    window.daemon.wallet.hasKeypair.mockResolvedValueOnce({ ok: true, data: false })
+    const onRefresh = vi.fn().mockResolvedValue(undefined)
+
+    render(<WalletTab onRefresh={onRefresh} />)
+
+    expect(await screen.findByText('Wallet readiness')).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: 'Add signer' })).toBeInTheDocument()
+  })
 })

--- a/test/panels/WalletTab.dom.test.tsx
+++ b/test/panels/WalletTab.dom.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WalletTab } from '../../src/panels/WalletPanel/tabs/WalletTab'
+import { useUIStore } from '../../src/store/ui'
+import { useWalletStore } from '../../src/store/wallet'
+import { useNotificationsStore } from '../../src/store/notifications'
+
+function installDaemonBridge() {
+  const assignProject = vi.fn().mockResolvedValue({ ok: true })
+
+  Object.defineProperty(window, 'daemon', {
+    configurable: true,
+    value: {
+      activity: {
+        append: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      env: {
+        copyValue: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      settings: {
+        getWalletInfrastructureSettings: vi.fn().mockResolvedValue({
+          ok: true,
+          data: {
+            rpcProvider: 'helius',
+            quicknodeRpcUrl: '',
+            customRpcUrl: '',
+            swapProvider: 'jupiter',
+            preferredWallet: 'phantom',
+            executionMode: 'rpc',
+            jitoBlockEngineUrl: 'https://mainnet.block-engine.jito.wtf/api/v1/transactions',
+          },
+        }),
+      },
+      wallet: {
+        hasJupiterKey: vi.fn().mockResolvedValue({ ok: true, data: false }),
+        hasKeypair: vi.fn().mockResolvedValue({ ok: true, data: true }),
+        balance: vi.fn().mockResolvedValue({ ok: true, data: { sol: 4.2, lamports: 4200000000 } }),
+        assignProject,
+      },
+    },
+  })
+
+  return { assignProject }
+}
+
+describe('WalletTab readiness UX', () => {
+  beforeEach(() => {
+    installDaemonBridge()
+    useNotificationsStore.setState({ toasts: [], activity: [] })
+    useUIStore.setState({
+      activeProjectId: 'project-1',
+      activeProjectPath: 'C:/work/daemon-app',
+      drawerToolOrder: [],
+      workspaceToolTabs: [],
+      activeWorkspaceToolId: null,
+      browserTabOpen: false,
+      browserTabActive: false,
+      dashboardTabOpen: false,
+      dashboardTabActive: false,
+    })
+    useWalletStore.setState({
+      dashboard: {
+        heliusConfigured: true,
+        market: [],
+        portfolio: {
+          totalUsd: 1250,
+          delta24hUsd: 42,
+          delta24hPct: 3.2,
+          walletCount: 1,
+        },
+        wallets: [
+          {
+            id: 'wallet-1',
+            name: 'Main Wallet',
+            address: '7Y12wallet9AbC',
+            isDefault: true,
+            totalUsd: 1250,
+            tokenCount: 3,
+            assignedProjectIds: [],
+          },
+        ],
+        activeWallet: {
+          id: 'wallet-1',
+          name: 'Main Wallet',
+          address: '7Y12wallet9AbC',
+          holdings: [
+            {
+              mint: 'So11111111111111111111111111111111111111112',
+              symbol: 'SOL',
+              name: 'Solana',
+              amount: 4.2,
+              priceUsd: 150,
+              valueUsd: 630,
+              logoUri: null,
+            },
+          ],
+        },
+        feed: [],
+        recentActivity: [],
+      },
+      showMarketTape: true,
+      showTitlebarWallet: true,
+      loading: false,
+      error: null,
+      agentWallets: null,
+      transactions: [
+        {
+          id: 'tx-1',
+          type: 'transfer',
+          signature: 'abc123',
+          from_address: '7Y12wallet9AbC',
+          to_address: '4abcDestxxx',
+          amount: 1,
+          mint: null,
+          status: 'confirmed',
+          created_at: Date.now(),
+        },
+      ],
+      activeView: 'overview',
+      activeTab: 'wallet',
+    })
+  })
+
+  it('shows wallet readiness and lets the user assign the active wallet to the current project', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined)
+
+    render(<WalletTab onRefresh={onRefresh} />)
+
+    expect(await screen.findByText('Wallet readiness')).toBeInTheDocument()
+    expect(screen.getByText('Route this wallet into the current project')).toBeInTheDocument()
+    expect(screen.getByText('The active project is not assigned to this wallet yet.')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Use for current project' }))
+
+    await waitFor(() => {
+      expect(window.daemon.wallet.assignProject).toHaveBeenCalledWith('project-1', 'wallet-1')
+    })
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a guided "Create your first Solana agent" workflow to Integration Command Center
- scaffold a safe SendAI starter agent, README, and package.json run script
- expand planner and UI coverage for package/env readiness and starter generation

## Validation
- pnpm run typecheck
- pnpm test
- pnpm run test:layout
- pnpm run test:responsive
