### PR TITLE
Add Solana project readiness entry point

### DIFF
--- a/scripts/smoke/app-responsive.mjs
+++ b/scripts/smoke/app-responsive.mjs
@@ -30,6 +30,7 @@ const toolChecks = [
   { name: 'Env', readySelector: '.env-center', expectedText: 'Environment' },
   { name: 'Wallet', readySelector: '.wallet-panel', expectedText: 'Wallet workspace' },
   { name: 'Token Launch', readySelector: '.token-launch-tool', expectedText: 'Launch Token' },
+  { name: 'Project Readiness', readySelector: '.project-readiness', expectedText: 'Project Readiness' },
   { name: 'Solana', readySelector: '.solana-toolbox', expectedText: 'Solana Workspace' },
   { name: 'Settings', readySelector: '.settings-center', expectedText: 'Settings' },
   { name: 'Dashboard', readySelector: '.dash-canvas', expectedText: 'Dashboard' },

--- a/src/components/CommandDrawer/CommandDrawer.tsx
+++ b/src/components/CommandDrawer/CommandDrawer.tsx
@@ -297,6 +297,21 @@ function IntegrationsIcon({ size = 18 }: { size?: number }) {
     </svg>
   )
 }
+function ReadinessIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <defs>
+        <linearGradient id="readiness-flow" x1="4" y1="20" x2="20" y2="4" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="#14f195" />
+          <stop offset="100%" stopColor="#38bdf8" />
+        </linearGradient>
+      </defs>
+      <circle cx="12" cy="12" r="8.5" stroke="url(#readiness-flow)" />
+      <path d="M8 12.4 10.8 15.1 16.3 8.8" stroke="url(#readiness-flow)" strokeWidth="1.8" />
+      <path d="M12 3.5v2M20.5 12h-2M12 20.5v-2M3.5 12h2" stroke="currentColor" opacity="0.58" />
+    </svg>
+  )
+}
 function TokenLaunchIcon({ size = 18 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -328,7 +343,7 @@ export const TOOL_ICONS: Record<string, ComponentType<{ size?: number }>> = {
   wallet: WalletIcon, email: EmailIcon, browser: BrowserIcon,
   ports: PortsIcon, processes: ProcessIcon, settings: SettingsIcon,
   'image-editor': PaintIcon, 'solana-toolbox': SolanaIcon, 'block-scanner': ScannerIcon, docs: DocsIcon, starter: StarterIcon,
-  'token-launch': TokenLaunchIcon, integrations: IntegrationsIcon,
+  'token-launch': TokenLaunchIcon, integrations: IntegrationsIcon, 'project-readiness': ReadinessIcon,
   dashboard: DashboardIcon, sessions: SessionsIcon, hackathon: HackathonIcon, plugins: PluginsIcon, recovery: RecoveryIcon, pro: ProIcon,
 }
 
@@ -338,7 +353,7 @@ export const TOOL_NAMES: Record<string, string> = {
   wallet: 'Wallet', email: 'Email', browser: 'Browser',
   ports: 'Ports', processes: 'Processes', settings: 'Settings',
   'image-editor': 'Image Editor', 'solana-toolbox': 'Solana', 'block-scanner': 'Block Scanner', docs: 'Docs', starter: 'New Project',
-  'token-launch': 'Token Launch', integrations: 'Integrations',
+  'token-launch': 'Token Launch', integrations: 'Integrations', 'project-readiness': 'Project Readiness',
   dashboard: 'Dashboard', sessions: 'Sessions', hackathon: 'Hackathon', plugins: 'Plugins', recovery: 'Recovery', pro: 'Daemon Pro',
 }
 
@@ -354,6 +369,7 @@ const loadProcessManager = () => import('../../panels/ProcessManager/ProcessMana
 const loadImageEditor = () => import('../../panels/ImageEditor/ImageEditor')
 const loadSolanaToolbox = () => import('../../panels/SolanaToolbox/SolanaToolbox')
 const loadIntegrationCommandCenter = () => import('../../panels/IntegrationCommandCenter/IntegrationCommandCenter')
+const loadProjectReadiness = () => import('../../panels/ProjectReadiness/ProjectReadiness')
 const loadTokenLaunchTool = () => import('../../panels/TokenLaunchTool/TokenLaunchTool')
 const loadBlockScanner = () => import('../../panels/BlockScanner/BlockScanner')
 const loadDocsPanel = () => import('../../panels/DocsPanel/DocsPanel')
@@ -376,6 +392,7 @@ const ProcessManager = lazyNamedWithReload('process-manager', loadProcessManager
 const ImageEditor = lazyWithReload('image-editor', loadImageEditor)
 const SolanaToolbox = lazyWithReload('solana-toolbox', loadSolanaToolbox)
 const IntegrationCommandCenter = lazyWithReload('integration-command-center', loadIntegrationCommandCenter)
+const ProjectReadiness = lazyWithReload('project-readiness', loadProjectReadiness)
 const TokenLaunchTool = lazyWithReload('token-launch-tool', loadTokenLaunchTool)
 const BlockScanner = lazyWithReload('block-scanner', loadBlockScanner)
 const DocsPanel = lazyNamedWithReload('docs-panel', loadDocsPanel, (m) => m.DocsPanel)
@@ -402,6 +419,7 @@ export const TOOL_COLORS: Record<string, string> = {
   'image-editor': '#e879f9',
   'solana-toolbox': '#14f195',
   integrations: '#38bdf8',
+  'project-readiness': '#14f195',
   'token-launch': '#38d39f',
   'block-scanner': '#38bdf8',
   docs: '#f59e0b',
@@ -427,6 +445,7 @@ export const BUILTIN_TOOLS: DrawerTool[] = [
   { id: 'settings', name: 'Settings', description: 'App configuration', icon: SettingsIcon, component: SettingsPanel, preload: () => { void loadSettingsPanel() }, category: 'system' },
   { id: 'image-editor', name: 'Image Editor', description: 'Edit images with layers & filters', icon: PaintIcon, component: ImageEditor, preload: () => { void loadImageEditor() }, category: 'create' },
   { id: 'token-launch', name: 'Token Launch', description: 'Unified Pump.fun, Raydium, and Meteora launch workflow', icon: TokenLaunchIcon, component: TokenLaunchTool, preload: () => { void loadTokenLaunchTool() }, category: 'crypto' },
+  { id: 'project-readiness', name: 'Project Readiness', description: 'Solana project, wallet, RPC, MCP, and first-action checklist', icon: ReadinessIcon, component: ProjectReadiness, preload: () => { void loadProjectReadiness() }, category: 'crypto' },
   { id: 'solana-toolbox', name: 'Solana', description: 'Solana tools, MCPs, validator', icon: SolanaIcon, component: SolanaToolbox, preload: () => { void loadSolanaToolbox() }, category: 'crypto' },
   { id: 'integrations', name: 'Integrations', description: 'Guided Solana integration setup and safe checks', icon: IntegrationsIcon, component: IntegrationCommandCenter, preload: () => { void loadIntegrationCommandCenter() }, category: 'crypto' },
   { id: 'block-scanner', name: 'Block Scanner', description: 'Solana explorer powered by Orb', icon: ScannerIcon, component: BlockScanner, preload: () => { void loadBlockScanner() }, category: 'crypto' },

--- a/src/components/CommandPalette/commands.ts
+++ b/src/components/CommandPalette/commands.ts
@@ -83,6 +83,12 @@ export function buildCommands(deps: CommandDeps): Command[] {
       action: () => openWorkspaceTool('wallet'),
     },
     {
+      id: 'nav:project-readiness',
+      label: 'Open Solana Project Readiness',
+      category: 'Navigation',
+      action: () => openWorkspaceTool('project-readiness'),
+    },
+    {
       id: 'nav:starter',
       label: 'New Project from Template',
       category: 'Navigation',

--- a/src/components/SolanaOnboarding/SolanaOnboardingBanner.tsx
+++ b/src/components/SolanaOnboarding/SolanaOnboardingBanner.tsx
@@ -46,8 +46,8 @@ export function SolanaOnboardingBanner() {
             Enable Suggested MCPs
           </button>
         )}
-        <button className="solana-onboarding-btn" onClick={() => { useUIStore.getState().openWorkspaceTool('solana-toolbox'); dismiss() }}>
-          Open Solana Toolbox
+        <button className="solana-onboarding-btn" onClick={() => { useUIStore.getState().openWorkspaceTool('project-readiness'); dismiss() }}>
+          Open Readiness
         </button>
         <button className="solana-onboarding-btn dismiss" onClick={dismiss}>
           Dismiss

--- a/src/constants/toolIds.ts
+++ b/src/constants/toolIds.ts
@@ -4,6 +4,6 @@
 export const BUILTIN_TOOL_IDS: string[] = [
   'starter', 'git', 'deploy', 'env', 'wallet', 'email',
   'ports', 'processes', 'settings', 'image-editor',
-  'token-launch', 'solana-toolbox', 'integrations', 'block-scanner', 'docs', 'dashboard',
+  'token-launch', 'project-readiness', 'solana-toolbox', 'integrations', 'block-scanner', 'docs', 'dashboard',
   'sessions', 'hackathon', 'pro', 'plugins', 'recovery',
 ]

--- a/src/constants/workspaceProfiles.ts
+++ b/src/constants/workspaceProfiles.ts
@@ -12,7 +12,7 @@ const WEB_TOOLS = [
 ]
 
 const SOLANA_TOOLS = [
-  ...WEB_TOOLS, 'wallet', 'token-launch', 'solana-toolbox', 'integrations', 'block-scanner',
+  ...WEB_TOOLS, 'wallet', 'token-launch', 'project-readiness', 'solana-toolbox', 'integrations', 'block-scanner',
   'dashboard', 'hackathon', 'pro',
 ]
 

--- a/src/panels/ProjectReadiness/ProjectReadiness.css
+++ b/src/panels/ProjectReadiness/ProjectReadiness.css
@@ -1,0 +1,355 @@
+.project-readiness {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(20, 241, 149, 0.08), transparent 30%),
+    radial-gradient(circle at 88% 8%, rgba(56, 189, 248, 0.08), transparent 30%),
+    var(--bg);
+  color: var(--t2);
+  scrollbar-gutter: stable;
+}
+
+.project-readiness::-webkit-scrollbar {
+  width: 10px;
+}
+
+.project-readiness::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--s5) 78%, rgba(255, 255, 255, 0.08));
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+.project-readiness-hero {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px;
+  border-bottom: 1px solid rgba(62, 207, 142, 0.08);
+}
+
+.project-readiness-hero-copy {
+  max-width: 780px;
+}
+
+.project-readiness-kicker,
+.project-readiness-mini {
+  display: inline-flex;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.project-readiness h1,
+.project-readiness h2 {
+  margin: 0;
+  color: var(--t1);
+  letter-spacing: -0.04em;
+}
+
+.project-readiness h1 {
+  margin-top: 8px;
+  font-size: clamp(32px, 5vw, 58px);
+  line-height: 0.96;
+}
+
+.project-readiness h2 {
+  margin-top: 6px;
+  font-size: clamp(22px, 3vw, 34px);
+  line-height: 1;
+}
+
+.project-readiness p {
+  margin: 8px 0 0;
+  color: var(--t3);
+  line-height: 1.55;
+}
+
+.project-readiness-score {
+  min-width: 170px;
+  border-radius: 30px;
+  border: 1px solid rgba(62, 207, 142, 0.22);
+  background:
+    linear-gradient(135deg, rgba(62, 207, 142, 0.13), rgba(56, 189, 248, 0.08)),
+    rgba(255, 255, 255, 0.03);
+  box-shadow: var(--shadow-lifted);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.project-readiness-score span {
+  font-size: 46px;
+  line-height: 1;
+  font-weight: 900;
+  color: var(--t1);
+}
+
+.project-readiness-score small {
+  margin-top: 8px;
+  color: var(--t4);
+  font-size: var(--font-sm);
+}
+
+.project-readiness-error,
+.project-readiness-loading {
+  margin: 14px 22px 0;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  background: rgba(248, 113, 113, 0.08);
+  color: #fecaca;
+  padding: 12px 14px;
+  font-size: var(--font-sm);
+}
+
+.project-readiness-loading {
+  border-color: rgba(62, 207, 142, 0.18);
+  background: rgba(62, 207, 142, 0.06);
+  color: var(--t3);
+}
+
+.project-readiness-next {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 18px 22px 0;
+  border-radius: 28px;
+  border: 1px solid rgba(62, 207, 142, 0.18);
+  background:
+    radial-gradient(circle at top right, rgba(62, 207, 142, 0.12), transparent 34%),
+    rgba(255, 255, 255, 0.035);
+  padding: 18px;
+  box-shadow: var(--shadow-lifted);
+}
+
+.project-readiness-next strong {
+  display: block;
+  margin-top: 6px;
+  font-size: clamp(22px, 3vw, 34px);
+  color: var(--t1);
+  letter-spacing: -0.03em;
+}
+
+.project-readiness-primary,
+.project-readiness-secondary,
+.project-readiness-link,
+.project-readiness-shortcuts button {
+  border: 1px solid rgba(62, 207, 142, 0.24);
+  border-radius: 999px;
+  background: rgba(62, 207, 142, 0.12);
+  color: var(--t1);
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.project-readiness-primary {
+  flex: 0 0 auto;
+  padding: 13px 18px;
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #04130c;
+}
+
+.project-readiness-secondary {
+  padding: 10px 14px;
+}
+
+.project-readiness-link {
+  margin-top: 10px;
+  padding: 8px 11px;
+  font-size: var(--font-sm);
+}
+
+.project-readiness-primary:hover,
+.project-readiness-secondary:hover,
+.project-readiness-link:hover,
+.project-readiness-shortcuts button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(62, 207, 142, 0.42);
+  background: rgba(62, 207, 142, 0.18);
+}
+
+.project-readiness-primary:hover {
+  background: color-mix(in srgb, var(--accent) 88%, white 12%);
+}
+
+.project-readiness-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px 22px;
+}
+
+.project-readiness-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  min-width: 0;
+  border-radius: 22px;
+  border: 1px solid var(--s5);
+  background: rgba(255, 255, 255, 0.025);
+  padding: 15px;
+}
+
+.project-readiness-card.ready {
+  border-color: rgba(62, 207, 142, 0.2);
+  background: rgba(62, 207, 142, 0.045);
+}
+
+.project-readiness-card strong {
+  display: block;
+  color: var(--t1);
+  font-size: var(--font-md);
+}
+
+.project-readiness-card p {
+  font-size: var(--font-sm);
+}
+
+.project-readiness-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  margin-top: 5px;
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.04);
+}
+
+.project-readiness-dot.ready {
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(62, 207, 142, 0.12);
+}
+
+.project-readiness-section {
+  padding: 2px 22px 18px;
+}
+
+.project-readiness-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.project-readiness-action-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.project-readiness-action {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  border-radius: 22px;
+  border: 1px solid var(--s5);
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--t2);
+  padding: 15px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.project-readiness-action.ready {
+  border-color: rgba(62, 207, 142, 0.22);
+}
+
+.project-readiness-action.partial {
+  border-color: rgba(240, 180, 41, 0.22);
+}
+
+.project-readiness-action span {
+  color: var(--t1);
+  font-weight: 800;
+}
+
+.project-readiness-action strong {
+  color: var(--accent);
+  font-size: var(--font-sm);
+}
+
+.project-readiness-action small {
+  color: var(--t4);
+  line-height: 1.4;
+}
+
+.project-readiness-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 0 22px 18px;
+}
+
+.project-readiness-strip > div {
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.02);
+  padding: 14px;
+}
+
+.project-readiness-strip strong {
+  display: block;
+  margin-top: 5px;
+  color: var(--t2);
+  font-size: var(--font-sm);
+  line-height: 1.45;
+}
+
+.project-readiness-shortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 0 22px 22px;
+}
+
+.project-readiness-shortcuts button {
+  padding: 9px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--t2);
+}
+
+@media (max-width: 920px) {
+  .project-readiness-hero,
+  .project-readiness-next,
+  .project-readiness-section-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .project-readiness-score {
+    min-width: 0;
+  }
+
+  .project-readiness-grid,
+  .project-readiness-action-grid,
+  .project-readiness-strip {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .project-readiness-hero,
+  .project-readiness-grid,
+  .project-readiness-section,
+  .project-readiness-strip,
+  .project-readiness-shortcuts {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .project-readiness-next {
+    margin-left: 14px;
+    margin-right: 14px;
+  }
+}

--- a/src/panels/ProjectReadiness/ProjectReadiness.tsx
+++ b/src/panels/ProjectReadiness/ProjectReadiness.tsx
@@ -1,0 +1,408 @@
+import { useEffect, useMemo, useState } from 'react'
+import { daemon } from '../../lib/daemonBridge'
+import { useUIStore } from '../../store/ui'
+import { useSolanaToolboxStore, type SolanaToolchainStatus } from '../../store/solanaToolbox'
+import type { EnvFile, WalletListEntry } from '../../types/daemon'
+import { buildSolanaRouteReadiness } from '../../lib/solanaReadiness'
+import { INTEGRATION_REGISTRY } from '../IntegrationCommandCenter/registry'
+import { resolveIntegrationStatus, summarizeRegistry, type IntegrationContext } from '../IntegrationCommandCenter/status'
+import { parsePackageInfo, SENDAI_FIRST_AGENT_ENTRY, type PackageInfo } from '../IntegrationCommandCenter/sendaiSetup'
+import './ProjectReadiness.css'
+
+const EMPTY_PACKAGE_INFO: PackageInfo = { packages: new Set(), scripts: new Set(), packageManagerHint: null }
+
+const DEFAULT_WALLET_INFRASTRUCTURE: WalletInfrastructureSettings = {
+  rpcProvider: 'helius',
+  quicknodeRpcUrl: '',
+  customRpcUrl: '',
+  swapProvider: 'jupiter',
+  preferredWallet: 'phantom',
+  executionMode: 'rpc',
+  jitoBlockEngineUrl: 'https://mainnet.block-engine.jito.wtf/api/v1/transactions',
+}
+
+interface ReadinessItem {
+  id: string
+  label: string
+  detail: string
+  ready: boolean
+  actionLabel?: string
+  action?: () => void
+}
+
+function joinProjectPath(projectPath: string, child: string): string {
+  return `${projectPath.replace(/[\\/]+$/, '')}/${child}`
+}
+
+function hasEnvKey(envFiles: EnvFile[], key: string): boolean {
+  return envFiles.some((file) => file.vars.some((entry) => !entry.isComment && entry.key === key && entry.value.trim().length > 0))
+}
+
+function getRpcLabel(settings: WalletInfrastructureSettings): string {
+  if (settings.rpcProvider === 'helius') return 'Helius RPC'
+  if (settings.rpcProvider === 'quicknode') return 'QuickNode RPC'
+  if (settings.rpcProvider === 'custom') return 'Custom RPC'
+  return 'Public RPC'
+}
+
+function isRpcReady(settings: WalletInfrastructureSettings, heliusReady: boolean): boolean {
+  if (settings.rpcProvider === 'helius') return heliusReady
+  if (settings.rpcProvider === 'quicknode') return settings.quicknodeRpcUrl.trim().length > 0
+  if (settings.rpcProvider === 'custom') return settings.customRpcUrl.trim().length > 0
+  return true
+}
+
+function compactPath(path: string | null): string {
+  if (!path) return 'No project open'
+  const parts = path.split(/[\\/]/).filter(Boolean)
+  return parts.slice(-2).join('/')
+}
+
+function formatToolchain(toolchain: SolanaToolchainStatus | null): string {
+  if (!toolchain) return 'Toolchain not checked yet'
+  const ready = [
+    toolchain.solanaCli.installed ? 'Solana CLI' : null,
+    toolchain.anchor.installed ? 'Anchor' : null,
+    toolchain.testValidator.installed ? 'test-validator' : null,
+    toolchain.surfpool.installed ? 'Surfpool' : null,
+    toolchain.litesvm.installed ? 'LiteSVM' : null,
+  ].filter(Boolean)
+  return ready.length ? ready.join(', ') : 'No local Solana toolchain detected'
+}
+
+export function ProjectReadiness() {
+  const activeProjectPath = useUIStore((s) => s.activeProjectPath)
+  const activeProjectId = useUIStore((s) => s.activeProjectId)
+  const openWorkspaceTool = useUIStore((s) => s.openWorkspaceTool)
+  const setIntegrationCommandSelectionId = useUIStore((s) => s.setIntegrationCommandSelectionId)
+  const mcps = useSolanaToolboxStore((s) => s.mcps)
+  const projectInfo = useSolanaToolboxStore((s) => s.projectInfo)
+  const toolchain = useSolanaToolboxStore((s) => s.toolchain)
+  const loadMcps = useSolanaToolboxStore((s) => s.loadMcps)
+  const detectProject = useSolanaToolboxStore((s) => s.detectProject)
+  const loadToolchain = useSolanaToolboxStore((s) => s.loadToolchain)
+
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [envFiles, setEnvFiles] = useState<EnvFile[]>([])
+  const [packageInfo, setPackageInfo] = useState<PackageInfo>(EMPTY_PACKAGE_INFO)
+  const [wallets, setWallets] = useState<WalletListEntry[]>([])
+  const [walletSignerReady, setWalletSignerReady] = useState<Record<string, boolean>>({})
+  const [walletInfrastructure, setWalletInfrastructure] = useState<WalletInfrastructureSettings>(DEFAULT_WALLET_INFRASTRUCTURE)
+  const [secureKeys, setSecureKeys] = useState<Record<string, boolean>>({})
+  const [hasFirstAgent, setHasFirstAgent] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadReadiness() {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const [walletRes, heliusRes, jupiterRes, infraRes] = await Promise.all([
+          daemon.wallet.list(),
+          daemon.wallet.hasHeliusKey(),
+          daemon.wallet.hasJupiterKey(),
+          daemon.settings.getWalletInfrastructureSettings(),
+        ])
+
+        if (cancelled) return
+
+        const nextWallets = walletRes.ok && walletRes.data ? walletRes.data : []
+        setWallets(nextWallets)
+        setWalletInfrastructure(infraRes.ok && infraRes.data ? infraRes.data : DEFAULT_WALLET_INFRASTRUCTURE)
+        setSecureKeys({
+          HELIUS_API_KEY: Boolean(heliusRes.ok && heliusRes.data),
+          JUPITER_API_KEY: Boolean(jupiterRes.ok && jupiterRes.data),
+        })
+
+        const signerEntries = await Promise.all(nextWallets.map(async (wallet) => {
+          const signerRes = await daemon.wallet.hasKeypair(wallet.id)
+          return [wallet.id, Boolean(signerRes.ok && signerRes.data)] as const
+        }))
+        if (cancelled) return
+        setWalletSignerReady(Object.fromEntries(signerEntries))
+
+        if (activeProjectPath) {
+          await Promise.all([
+            loadMcps(activeProjectPath),
+            detectProject(activeProjectPath),
+            loadToolchain(activeProjectPath),
+          ])
+
+          const [envRes, packageRes, agentRes] = await Promise.all([
+            daemon.env.projectVars(activeProjectPath),
+            daemon.fs.readFile(joinProjectPath(activeProjectPath, 'package.json')),
+            daemon.fs.readFile(joinProjectPath(activeProjectPath, SENDAI_FIRST_AGENT_ENTRY)),
+          ])
+
+          if (cancelled) return
+          setEnvFiles(envRes.ok && envRes.data ? envRes.data : [])
+          setPackageInfo(packageRes.ok && packageRes.data ? parsePackageInfo(packageRes.data.content) : EMPTY_PACKAGE_INFO)
+          setHasFirstAgent(Boolean(agentRes.ok))
+        } else {
+          await loadToolchain(undefined)
+          if (cancelled) return
+          setEnvFiles([])
+          setPackageInfo(EMPTY_PACKAGE_INFO)
+          setHasFirstAgent(false)
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(loadError instanceof Error ? loadError.message : 'Could not load Solana readiness.')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void loadReadiness()
+    return () => { cancelled = true }
+  }, [activeProjectPath, detectProject, loadMcps, loadToolchain])
+
+  const defaultWallet = wallets.find((wallet) => wallet.is_default === 1) ?? wallets[0] ?? null
+  const defaultWalletSignerReady = defaultWallet ? walletSignerReady[defaultWallet.id] === true : false
+  const defaultWalletAssignedToProject = activeProjectId && defaultWallet
+    ? defaultWallet.assigned_project_ids.includes(activeProjectId)
+    : true
+  const rpcLabel = getRpcLabel(walletInfrastructure)
+  const rpcReady = isRpcReady(walletInfrastructure, Boolean(secureKeys.HELIUS_API_KEY))
+  const envRpcReady = hasEnvKey(envFiles, 'RPC_URL')
+  const solanaMcpReady = mcps.some((entry) => entry.name === 'solana-mcp-server' && entry.enabled)
+  const heliusMcpReady = mcps.some((entry) => entry.name === 'helius' && entry.enabled)
+  const agentKitReady = packageInfo.packages.has('solana-agent-kit')
+
+  const walletRoute = buildSolanaRouteReadiness({
+    walletPresent: Boolean(defaultWallet),
+    walletName: defaultWallet?.name,
+    walletAddress: defaultWallet?.address,
+    isMainWallet: Boolean(defaultWallet?.is_default === 1),
+    signerReady: defaultWalletSignerReady,
+    hasActiveProject: Boolean(activeProjectId),
+    projectAssigned: defaultWalletAssignedToProject,
+    preferredWallet: walletInfrastructure.preferredWallet,
+    executionMode: walletInfrastructure.executionMode,
+    rpcLabel,
+    rpcReady,
+  })
+
+  const context = useMemo<IntegrationContext>(() => ({
+    envFiles,
+    mcps,
+    packages: packageInfo.packages,
+    walletReady: Boolean(defaultWallet),
+    defaultWallet,
+    secureKeys,
+    toolchain,
+  }), [defaultWallet, envFiles, mcps, packageInfo.packages, secureKeys, toolchain])
+
+  const integrationSummary = useMemo(() => summarizeRegistry(INTEGRATION_REGISTRY, context), [context])
+  const starterIntegrations = useMemo(() => (
+    ['sendai-agent-kit', 'helius', 'phantom', 'jupiter', 'metaplex', 'light-protocol']
+      .map((id) => {
+        const integration = INTEGRATION_REGISTRY.find((entry) => entry.id === id)!
+        return { integration, summary: resolveIntegrationStatus(integration, context) }
+      })
+  ), [context])
+
+  const openIntegration = (integrationId: string) => {
+    setIntegrationCommandSelectionId(integrationId)
+    openWorkspaceTool('integrations')
+  }
+
+  const items: ReadinessItem[] = [
+    {
+      id: 'project',
+      label: 'Project open',
+      ready: Boolean(activeProjectPath),
+      detail: activeProjectPath ? compactPath(activeProjectPath) : 'Open or scaffold a project so DAEMON can inspect packages, env, and MCPs.',
+      actionLabel: 'Open New Project',
+      action: () => openWorkspaceTool('starter'),
+    },
+    {
+      id: 'solana-project',
+      label: 'Solana project detected',
+      ready: Boolean(projectInfo?.isSolanaProject),
+      detail: projectInfo?.isSolanaProject
+        ? `${projectInfo.framework ?? 'Solana'} project indicators: ${projectInfo.indicators.join(', ') || 'detected by DAEMON'}`
+        : activeProjectPath
+          ? 'This project is open, but DAEMON has not detected Anchor, Solana, or client indicators yet.'
+          : 'Open a project before DAEMON can detect Solana framework details.',
+      actionLabel: 'Open Solana Toolbox',
+      action: () => openWorkspaceTool('solana-toolbox'),
+    },
+    {
+      id: 'wallet',
+      label: 'Wallet route',
+      ready: Boolean(defaultWallet),
+      detail: defaultWallet ? `${defaultWallet.name} is available for Solana actions.` : 'Create or import one wallet before checking balances, quotes, or launch flows.',
+      actionLabel: 'Open Wallet',
+      action: () => openWorkspaceTool('wallet'),
+    },
+    {
+      id: 'signer',
+      label: 'Signer ready',
+      ready: defaultWalletSignerReady,
+      detail: defaultWalletSignerReady ? 'The default wallet can sign follow-up previews and transactions.' : 'The wallet is watch-only until a signer is generated or imported.',
+      actionLabel: 'Add signer',
+      action: () => openWorkspaceTool('wallet'),
+    },
+    {
+      id: 'project-wallet',
+      label: 'Project wallet assigned',
+      ready: defaultWalletAssignedToProject,
+      detail: defaultWalletAssignedToProject ? 'The active project already has a wallet route.' : 'Assign the default wallet to this project so Solana flows do not guess.',
+      actionLabel: 'Assign wallet',
+      action: () => openWorkspaceTool('wallet'),
+    },
+    {
+      id: 'provider',
+      label: 'Provider path',
+      ready: rpcReady,
+      detail: rpcReady ? `${rpcLabel} is ready for DAEMON execution paths.` : `${rpcLabel} is selected but not fully configured.`,
+      actionLabel: walletInfrastructure.rpcProvider === 'helius' ? 'Open Env' : 'Open Wallet Infra',
+      action: () => openWorkspaceTool(walletInfrastructure.rpcProvider === 'helius' ? 'env' : 'wallet'),
+    },
+    {
+      id: 'env',
+      label: 'RPC env',
+      ready: envRpcReady,
+      detail: envRpcReady ? 'RPC_URL is present for project scripts and agent checks.' : 'Add RPC_URL so generated scripts and MCP-backed reads have a project-local endpoint.',
+      actionLabel: 'Open Env',
+      action: () => openWorkspaceTool('env'),
+    },
+    {
+      id: 'mcp',
+      label: 'MCP tools',
+      ready: solanaMcpReady || heliusMcpReady,
+      detail: solanaMcpReady || heliusMcpReady ? 'At least one Solana MCP path is enabled for agents.' : 'Enable Solana or Helius MCP so agents can read chain state through a clear boundary.',
+      actionLabel: 'Open MCP setup',
+      action: () => openWorkspaceTool('solana-toolbox'),
+    },
+    {
+      id: 'sendai',
+      label: 'SendAI first agent',
+      ready: agentKitReady && hasFirstAgent,
+      detail: agentKitReady
+        ? hasFirstAgent ? 'SendAI package and first starter agent are present.' : 'SendAI package is installed. Create the starter agent next.'
+        : 'Install Agent Kit and scaffold the starter before using agent actions.',
+      actionLabel: 'Open SendAI setup',
+      action: () => openIntegration('sendai-agent-kit'),
+    },
+  ]
+
+  const readyCount = items.filter((item) => item.ready).length
+  const readinessPct = Math.round((readyCount / items.length) * 100)
+  const nextItem = items.find((item) => !item.ready) ?? {
+    id: 'first-action',
+    label: 'Run first safe action',
+    detail: 'The project route is ready. Pick a read-only wallet read, Jupiter quote, metadata draft, or token-launch preflight.',
+    ready: false,
+    actionLabel: 'Open Integrations',
+    action: () => openWorkspaceTool('integrations'),
+  }
+
+  return (
+    <div className="project-readiness">
+      <section className="project-readiness-hero">
+        <div className="project-readiness-hero-copy">
+          <span className="project-readiness-kicker">Project Readiness</span>
+          <h1>Start Solana development from one checklist</h1>
+          <p>
+            DAEMON checks the active project, wallet route, RPC path, MCPs, and first-action integrations so new Solana developers know exactly what to do next.
+          </p>
+        </div>
+        <div className="project-readiness-score" aria-label="Solana readiness score">
+          <span>{readinessPct}%</span>
+          <small>{readyCount}/{items.length} ready</small>
+        </div>
+      </section>
+
+      {error ? <div className="project-readiness-error">{error}</div> : null}
+
+      <section className="project-readiness-next">
+        <div>
+          <span className="project-readiness-mini">Next best step</span>
+          <strong>{nextItem.label}</strong>
+          <p>{nextItem.detail}</p>
+        </div>
+        {nextItem.action && nextItem.actionLabel ? (
+          <button type="button" className="project-readiness-primary" onClick={nextItem.action}>
+            {nextItem.actionLabel}
+          </button>
+        ) : null}
+      </section>
+
+      <section className="project-readiness-grid" aria-label="Readiness checks">
+        {items.map((item) => (
+          <article key={item.id} className={`project-readiness-card${item.ready ? ' ready' : ''}`}>
+            <span className={`project-readiness-dot${item.ready ? ' ready' : ''}`} />
+            <div>
+              <strong>{item.label}</strong>
+              <p>{item.detail}</p>
+              {!item.ready && item.action && item.actionLabel ? (
+                <button type="button" className="project-readiness-link" onClick={item.action}>
+                  {item.actionLabel}
+                </button>
+              ) : null}
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <section className="project-readiness-section">
+        <div className="project-readiness-section-head">
+          <div>
+            <span className="project-readiness-mini">First safe actions</span>
+            <h2>Pick the workflow that proves the project works</h2>
+          </div>
+          <button type="button" className="project-readiness-secondary" onClick={() => openWorkspaceTool('integrations')}>
+            Open all integrations
+          </button>
+        </div>
+        <div className="project-readiness-action-grid">
+          {starterIntegrations.map(({ integration, summary }) => (
+            <button
+              key={integration.id}
+              type="button"
+              className={`project-readiness-action ${summary.status}`}
+              onClick={() => openIntegration(integration.id)}
+            >
+              <span>{integration.name}</span>
+              <strong>{summary.status === 'ready' ? 'Ready' : summary.status === 'partial' ? 'Needs one step' : 'Setup needed'}</strong>
+              <small>{integration.tagline}</small>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="project-readiness-strip">
+        <div>
+          <span className="project-readiness-mini">Runtime</span>
+          <strong>{formatToolchain(toolchain)}</strong>
+        </div>
+        <div>
+          <span className="project-readiness-mini">Integrations</span>
+          <strong>{integrationSummary.ready} ready · {integrationSummary.partial} partial · {integrationSummary.missing} missing</strong>
+        </div>
+        <div>
+          <span className="project-readiness-mini">Wallet route</span>
+          <strong>{walletRoute.headline}</strong>
+        </div>
+      </section>
+
+      <section className="project-readiness-shortcuts" aria-label="Project readiness shortcuts">
+        <button type="button" onClick={() => openWorkspaceTool('starter')}>New Project</button>
+        <button type="button" onClick={() => openWorkspaceTool('wallet')}>Wallet</button>
+        <button type="button" onClick={() => openWorkspaceTool('env')}>Env</button>
+        <button type="button" onClick={() => openWorkspaceTool('solana-toolbox')}>Solana Toolbox</button>
+        <button type="button" onClick={() => openWorkspaceTool('token-launch')}>Token Launch</button>
+      </section>
+
+      {loading ? <div className="project-readiness-loading">Refreshing readiness...</div> : null}
+    </div>
+  )
+}
+
+export default ProjectReadiness

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -132,7 +132,7 @@ export const useUIStore = create<UIState>((set) => ({
   grindPages: {},
   walletQuickViewOpen: false,
   emailQuickViewOpen: false,
-  pinnedTools: ['git', 'browser', 'solana-toolbox', 'integrations', 'token-launch', 'pro'],
+  pinnedTools: ['git', 'browser', 'project-readiness', 'solana-toolbox', 'integrations', 'token-launch', 'pro'],
   drawerToolOrder: [],
 
   setActiveProject: (id, path) => set({ activeProjectId: id, activeProjectPath: path }),

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -12,6 +12,7 @@ import { WalletSendForm } from '../../src/panels/WalletPanel/WalletSendForm'
 import { SolanaToolbox } from '../../src/panels/SolanaToolbox/SolanaToolbox'
 import { TokenLaunchTool } from '../../src/panels/TokenLaunchTool/TokenLaunchTool'
 import { IntegrationCommandCenter } from '../../src/panels/IntegrationCommandCenter/IntegrationCommandCenter'
+import { ProjectReadiness } from '../../src/panels/ProjectReadiness/ProjectReadiness'
 
 vi.mock('../../src/utils/lazyWithReload', () => ({
   lazyWithReload: () => () => null,
@@ -287,6 +288,7 @@ describe('App surface DOM coverage', () => {
     expect(screen.getByText('Token Launch')).toBeInTheDocument()
     expect(screen.getByText('Solana')).toBeInTheDocument()
     expect(screen.getByText('Integrations')).toBeInTheDocument()
+    expect(screen.getByText('Project Readiness')).toBeInTheDocument()
 
     await userEvent.type(screen.getByPlaceholderText('Search tools...'), 'solana')
     await userEvent.click(screen.getByText('Solana').closest('button')!)
@@ -417,6 +419,28 @@ describe('App surface DOM coverage', () => {
 
     useUIStore.getState().setIntegrationCommandSelectionId('metaplex')
     expect(await screen.findByRole('heading', { name: 'Metaplex' })).toBeInTheDocument()
+  })
+
+  it('renders Project Readiness as the Solana entry point and routes into first actions', async () => {
+    render(<ProjectReadiness />)
+
+    expect(await screen.findByText('Project Readiness')).toBeInTheDocument()
+    expect(screen.getByText('Start Solana development from one checklist')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText('Refreshing readiness...')).not.toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Solana readiness score')).toBeInTheDocument()
+    expect(screen.getByText('Project open')).toBeInTheDocument()
+    expect(screen.getAllByText('Wallet route').length).toBeGreaterThan(0)
+    expect(screen.getByText('Provider path')).toBeInTheDocument()
+    expect(screen.getByText('MCP tools')).toBeInTheDocument()
+    expect(screen.getByText('SendAI first agent')).toBeInTheDocument()
+    expect(screen.getByText('Pick the workflow that proves the project works')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('SendAI Agent Kit').closest('button')!)
+
+    expect(useUIStore.getState().activeWorkspaceToolId).toBe('integrations')
+    expect(useUIStore.getState().integrationCommandSelectionId).toBe('sendai-agent-kit')
   })
 
   it('resets hidden integration filters when another surface targets a workflow', async () => {

--- a/test/shared/workspaceProfiles.test.ts
+++ b/test/shared/workspaceProfiles.test.ts
@@ -18,6 +18,7 @@ describe('getDefaultVisibility — web profile', () => {
   it('shows recovery', () => expect(vis['recovery']).toBe(true))
 
   it('hides wallet', () => expect(vis['wallet']).toBe(false))
+  it('hides project-readiness', () => expect(vis['project-readiness']).toBe(false))
   it('hides solana-toolbox', () => expect(vis['solana-toolbox']).toBe(false))
   it('hides block-scanner', () => expect(vis['block-scanner']).toBe(false))
   it('hides dashboard', () => expect(vis['dashboard']).toBe(false))
@@ -28,6 +29,7 @@ describe('getDefaultVisibility — solana profile', () => {
   const vis = getDefaultVisibility('solana', BUILTIN_TOOL_IDS)
 
   it('shows wallet', () => expect(vis['wallet']).toBe(true))
+  it('shows project-readiness', () => expect(vis['project-readiness']).toBe(true))
   it('shows solana-toolbox', () => expect(vis['solana-toolbox']).toBe(true))
   it('shows block-scanner', () => expect(vis['block-scanner']).toBe(true))
   it('shows dashboard', () => expect(vis['dashboard']).toBe(true))

--- a/test/store/workspaceProfile.test.ts
+++ b/test/store/workspaceProfile.test.ts
@@ -33,6 +33,7 @@ describe('getDefaultVisibility — web profile', () => {
   it('hides solana-specific tools', () => {
     const vis = getDefaultVisibility('web', BUILTIN_TOOL_IDS)
     expect(vis['wallet']).toBe(false)
+    expect(vis['project-readiness']).toBe(false)
     expect(vis['solana-toolbox']).toBe(false)
     expect(vis['dashboard']).toBe(false)
   })
@@ -42,6 +43,7 @@ describe('getDefaultVisibility — solana profile', () => {
   it('shows solana drawer tools', () => {
     const vis = getDefaultVisibility('solana', BUILTIN_TOOL_IDS)
     expect(vis['wallet']).toBe(true)
+    expect(vis['project-readiness']).toBe(true)
     expect(vis['solana-toolbox']).toBe(true)
     expect(vis['dashboard']).toBe(true)
   })


### PR DESCRIPTION
## Summary
- Add a first-class Project Readiness panel for Solana projects
- Surface wallet, signer, RPC/env, MCP, SendAI, and integration readiness in one guided entry point
- Wire the readiness tool into the Solana profile, drawer, command palette, onboarding banner, and responsive smoke checks

## Validation
- pnpm run typecheck
- pnpm test -- test/panels/AppSurfaces.dom.test.tsx test/shared/workspaceProfiles.test.ts test/store/workspaceProfile.test.ts
- pnpm run test:responsive
- pnpm run test:layout