### PR TITLE
ci: disable publishing during package checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm run test:visual
-      - run: pnpm run package
+      - run: pnpm exec electron-builder --publish never
 
   build-macos:
     name: build-macos
@@ -86,4 +86,4 @@ jobs:
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      - run: pnpm run package
+      - run: pnpm exec electron-builder --publish never


### PR DESCRIPTION
## Summary
- Use electron-builder --publish never in CI package checks
- Prevent normal branch builds from failing when GH_TOKEN is not present
- Keep release workflow unchanged; tag pushes still use the dedicated release pipeline

## Validation
- pnpm run typecheck
- pnpm test -- test/panels/AppSurfaces.dom.test.tsx