### PR TITLE
fix: harden wallet and agent security paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ yarn.lock
 *.p12
 credentials.json
 keypair.json
+target/deploy/*-keypair.json
+programs/*/target/deploy/*-keypair.json
 
 # SQLite
 *.db

--- a/electron/ipc/agents.ts
+++ b/electron/ipc/agents.ts
@@ -4,9 +4,23 @@ import { listClaudeAgents } from '../services/ClaudeAgentService'
 import { ipcHandler } from '../services/IpcHandlerFactory'
 import type { Agent, AgentCreateInput } from '../shared/types'
 
-const ALLOWED_AGENT_COLUMNS = new Set([
-  'name', 'system_prompt', 'model', 'mcps', 'provider', 'project_id', 'shortcut', 'source', 'external_path',
-])
+const AGENT_COLUMN_MAP = {
+  name: 'name',
+  system_prompt: 'system_prompt',
+  model: 'model',
+  mcps: 'mcps',
+  provider: 'provider',
+  project_id: 'project_id',
+  shortcut: 'shortcut',
+  source: 'source',
+  external_path: 'external_path',
+} as const
+
+function getAgentColumn(field: string): string | null {
+  return Object.prototype.hasOwnProperty.call(AGENT_COLUMN_MAP, field)
+    ? AGENT_COLUMN_MAP[field as keyof typeof AGENT_COLUMN_MAP]
+    : null
+}
 
 export function registerAgentHandlers() {
   ipcMain.handle('agents:list', ipcHandler(async () => {
@@ -84,15 +98,14 @@ export function registerAgentHandlers() {
 
   ipcMain.handle('agents:update', ipcHandler(async (_event, id: string, data: Record<string, unknown>) => {
     const db = getDb()
-    const fields = Object.keys(data).filter((f) => ALLOWED_AGENT_COLUMNS.has(f))
-    if (fields.length === 0) throw new Error('No valid fields to update')
+    const updates = Object.keys(data)
+      .map((field) => ({ field, column: getAgentColumn(field) }))
+      .filter((entry): entry is { field: string; column: string } => entry.column !== null)
+    if (updates.length === 0) throw new Error('No valid fields to update')
 
-    // Secondary guard: ensure each column name is safe for interpolation
-    if (fields.some((f) => !/^[a-z_]+$/.test(f))) throw new Error('Invalid field name')
-
-    const sets = fields.map((f) => `${f} = ?`).join(', ')
-    const values = fields.map((f) => {
-      const v = data[f]
+    const sets = updates.map(({ column }) => `${column} = ?`).join(', ')
+    const values = updates.map(({ field }) => {
+      const v = data[field]
       return Array.isArray(v) ? JSON.stringify(v) : v
     })
     db.prepare(`UPDATE agents SET ${sets} WHERE id = ?`).run(...values, id)

--- a/electron/ipc/wallet.ts
+++ b/electron/ipc/wallet.ts
@@ -169,6 +169,6 @@ export function registerWalletHandlers() {
     setTimeout(() => {
       if (clipboard.readText() === keyString) clipboard.writeText('')
     }, 30000)
-    return keyString
+    return true
   }))
 }

--- a/electron/services/EmailService.ts
+++ b/electron/services/EmailService.ts
@@ -162,16 +162,18 @@ export async function removeAccount(accountId: string): Promise<void> {
   const db = getDb()
   const row = getAccountRow(accountId)
 
-  // Clean up secure keys for Gmail
-  if (row.client_id_ref) {
-    db.prepare('DELETE FROM secure_keys WHERE key_name = ?').run(row.client_id_ref)
-  }
-  if (row.client_secret_ref) {
-    db.prepare('DELETE FROM secure_keys WHERE key_name = ?').run(row.client_secret_ref)
-  }
+  db.transaction(() => {
+    // Clean up secure keys for Gmail
+    if (row.client_id_ref) {
+      db.prepare('DELETE FROM secure_keys WHERE key_name = ?').run(row.client_id_ref)
+    }
+    if (row.client_secret_ref) {
+      db.prepare('DELETE FROM secure_keys WHERE key_name = ?').run(row.client_secret_ref)
+    }
 
-  db.prepare('DELETE FROM email_message_cache WHERE account_id = ?').run(accountId)
-  db.prepare('DELETE FROM email_accounts WHERE id = ?').run(accountId)
+    db.prepare('DELETE FROM email_message_cache WHERE account_id = ?').run(accountId)
+    db.prepare('DELETE FROM email_accounts WHERE id = ?').run(accountId)
+  })()
 }
 
 export async function getMessages(accountId: string, query?: string, max?: number): Promise<EmailMessage[]> {

--- a/electron/services/EnvService.ts
+++ b/electron/services/EnvService.ts
@@ -20,6 +20,7 @@ const SECRET_PATTERNS: Array<{ pattern: string; label: string }> = [
 ]
 
 const ENV_FILE_NAMES = ['.env', '.env.local', '.env.production', '.env.staging', '.env.development']
+const VALID_ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/
 const VERCEL_TOKEN_PATTERN = /^[A-Za-z0-9]{24,}$/
 const VERCEL_API_BASE = 'https://api.vercel.com'
 
@@ -152,6 +153,7 @@ export function scanAllProjects(): UnifiedKey[] {
 }
 
 export function writeEnvVar(filePath: string, key: string, newValue: string): void {
+  if (!VALID_ENV_KEY.test(key)) throw new Error(`Invalid environment variable name: "${key}"`)
   const content = fs.readFileSync(filePath, 'utf8')
   const lines = content.split('\n')
   let found = false
@@ -186,6 +188,7 @@ export function writeEnvVar(filePath: string, key: string, newValue: string): vo
 }
 
 export function addEnvVar(filePath: string, key: string, value: string): void {
+  if (!VALID_ENV_KEY.test(key)) throw new Error(`Invalid environment variable name: "${key}"`)
   let content = ''
   if (fs.existsSync(filePath)) {
     content = fs.readFileSync(filePath, 'utf8')

--- a/electron/services/PumpFunService.ts
+++ b/electron/services/PumpFunService.ts
@@ -210,7 +210,7 @@ export async function buyToken(input: TradeInput): Promise<TxResult> {
     user: keypair.publicKey,
     amount: tokenAmount,
     solAmount: solLamports,
-    slippage: input.slippageBps / 100,
+    slippage: input.slippageBps / 10_000,
     tokenProgram: TOKEN_PROGRAM_ID,
   })
 
@@ -256,7 +256,7 @@ export async function sellToken(input: TradeInput): Promise<TxResult> {
     user: keypair.publicKey,
     amount: tokenAmount,
     solAmount,
-    slippage: input.slippageBps / 100,
+    slippage: input.slippageBps / 10_000,
     tokenProgram: TOKEN_PROGRAM_ID,
   })
 

--- a/electron/services/RecoveryService.ts
+++ b/electron/services/RecoveryService.ts
@@ -117,12 +117,15 @@ export function loadCsvFile(csvPath: string): { count: number; path: string } {
       if (line.includes(',')) {
         const hex = line.split(',')[1]?.trim()
         if (!hex) continue
-        kp = Keypair.fromSecretKey(Buffer.from(hex, 'hex'))
+        const keyBuffer = Buffer.from(hex, 'hex')
+        kp = Keypair.fromSecretKey(keyBuffer)
+        keyBuffer.fill(0)
       } else {
         const decoded = bs58.decode(line)
         kp = decoded.length === 64
           ? Keypair.fromSecretKey(decoded)
           : Keypair.fromSeed(decoded.slice(0, 32))
+        decoded.fill(0)
       }
       const pub = kp.publicKey.toBase58()
       if (!keypairs.has(pub)) keypairs.set(pub, kp)
@@ -221,6 +224,7 @@ export async function executeRecovery(
 
   const priorityFee = await getPriorityFee(conn)
 
+  try {
   // ─── Phase 1: Close empty token accounts ──────────────────────────────
   currentStatus.currentPhase = 1
   emit(win, { type: 'phase-start', phase: 1, message: 'Phase 1: Closing empty token accounts...' })
@@ -414,9 +418,12 @@ export async function executeRecovery(
   currentStatus.state = 'complete'
   emit(win, { type: 'complete', totalRecovered, message: `Recovery complete: ${totalRecovered.toFixed(6)} SOL` })
 
-  abortController = null
-  clearLoadedWallets()
   return { totalRecovered }
+  } finally {
+    abortController = null
+    clearLoadedWallets()
+    if (currentStatus.state !== 'complete') currentStatus.state = 'idle'
+  }
 }
 
 // ─── Public API ────────────────────────────────────────────────────────────

--- a/electron/services/WalletService.ts
+++ b/electron/services/WalletService.ts
@@ -292,8 +292,10 @@ export function deleteWallet(id: string) {
 
 export function setDefaultWallet(id: string) {
   const db = getDb()
-  db.prepare('UPDATE wallets SET is_default = 0').run()
-  db.prepare('UPDATE wallets SET is_default = 1 WHERE id = ?').run(id)
+  db.transaction(() => {
+    db.prepare('UPDATE wallets SET is_default = 0').run()
+    db.prepare('UPDATE wallets SET is_default = 1 WHERE id = ?').run(id)
+  })()
 }
 
 export function assignWalletToProject(projectId: string, walletId: string | null) {

--- a/electron/services/providers/ClaudeProvider.ts
+++ b/electron/services/providers/ClaudeProvider.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
+import { randomUUID } from 'node:crypto'
 import { spawn, execSync } from 'node:child_process'
 import { getDb } from '../../db/db'
 import * as SecureKey from '../SecureKeyService'
@@ -221,8 +222,8 @@ export const ClaudeProvider: ProviderInterface = {
     sections.push('</daemon-context>')
 
     const contextContent = sections.filter(Boolean).join('\n')
-    const contextFilePath = path.join(os.tmpdir(), `daemon_agent_${agent.id}_${Date.now()}.txt`)
-    fs.writeFileSync(contextFilePath, contextContent, 'utf8')
+    const contextFilePath = path.join(os.tmpdir(), `daemon_agent_${agent.id}_${randomUUID()}.txt`)
+    fs.writeFileSync(contextFilePath, contextContent, { encoding: 'utf8', mode: 0o600 })
 
     bootstrapAgentMcps(project.path, agent.mcps)
 
@@ -359,8 +360,8 @@ async function runPromptViaCli(
 
   let systemPromptFile: string | null = null
   if (systemPrompt) {
-    systemPromptFile = path.join(os.tmpdir(), `daemon_prompt_${Date.now()}.txt`)
-    fs.writeFileSync(systemPromptFile, systemPrompt, 'utf8')
+    systemPromptFile = path.join(os.tmpdir(), `daemon_prompt_${randomUUID()}.txt`)
+    fs.writeFileSync(systemPromptFile, systemPrompt, { encoding: 'utf8', mode: 0o600 })
     args.push('--append-system-prompt-file', systemPromptFile)
   }
 

--- a/electron/services/providers/CodexProvider.ts
+++ b/electron/services/providers/CodexProvider.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
+import { randomUUID } from 'node:crypto'
 import { spawn, execSync } from 'node:child_process'
 import { getDb } from '../../db/db'
 import * as SecureKey from '../SecureKeyService'
@@ -191,8 +192,8 @@ export const CodexProvider: ProviderInterface = {
     sections.push('</daemon-context>')
 
     const contextContent = sections.filter(Boolean).join('\n')
-    const contextFilePath = path.join(os.tmpdir(), `daemon_codex_${agent.id}_${Date.now()}.txt`)
-    fs.writeFileSync(contextFilePath, contextContent, 'utf8')
+    const contextFilePath = path.join(os.tmpdir(), `daemon_codex_${agent.id}_${randomUUID()}.txt`)
+    fs.writeFileSync(contextFilePath, contextContent, { encoding: 'utf8', mode: 0o600 })
 
     // Resolve model — map Claude models to Codex equivalents
     const model = resolveCodexModel(agent.model)
@@ -232,7 +233,7 @@ export const CodexProvider: ProviderInterface = {
     const codexPath = this.resolvePath()
     const resolvedModel = resolveCodexModel(model)
 
-    const outputFile = path.join(os.tmpdir(), `daemon_codex_out_${Date.now()}.txt`)
+    const outputFile = path.join(os.tmpdir(), `daemon_codex_out_${randomUUID()}.txt`)
 
     const args: string[] = [
       'exec',
@@ -245,8 +246,8 @@ export const CodexProvider: ProviderInterface = {
     // Write system prompt to temp file and pass via -c instructions_file
     let contextFile: string | null = null
     if (systemPrompt) {
-      contextFile = path.join(os.tmpdir(), `daemon_codex_prompt_${Date.now()}.txt`)
-      fs.writeFileSync(contextFile, systemPrompt, 'utf8')
+      contextFile = path.join(os.tmpdir(), `daemon_codex_prompt_${randomUUID()}.txt`)
+      fs.writeFileSync(contextFile, systemPrompt, { encoding: 'utf8', mode: 0o600 })
       args.push('-c', `instructions_file=${contextFile}`)
     }
 

--- a/src/panels/WalletPanel/tabs/AgentsTab.tsx
+++ b/src/panels/WalletPanel/tabs/AgentsTab.tsx
@@ -133,7 +133,7 @@ export function AgentsTab() {
     if (!activeWalletId || exportConfirmText !== 'EXPORT') return
     const res = await window.daemon.wallet.exportPrivateKey(activeWalletId)
     if (res.ok && res.data) {
-      setRevealedKey(res.data as string)
+      setRevealedKey('Private key copied to clipboard for 30 seconds.')
       setExportConfirmText('')
       setTimeout(() => { setRevealedKey(null); clearAction() }, 5000)
     } else { setError(res.error ?? 'Export failed') }

--- a/src/panels/WalletPanel/tabs/WalletTab.tsx
+++ b/src/panels/WalletPanel/tabs/WalletTab.tsx
@@ -380,15 +380,9 @@ export function WalletTab({ onRefresh }: Props) {
     if (!exportConfirmId || exportConfirmText !== 'EXPORT') return
     const res = await window.daemon.wallet.exportPrivateKey(exportConfirmId)
     if (res.ok && res.data) {
-      setRevealKeyId(exportConfirmId)
-      setRevealedKey(res.data)
       setExportConfirmId(null)
       setExportConfirmText('')
       pushSuccess('Private key copied to clipboard for 30 seconds', 'Wallet')
-      setTimeout(() => {
-        setRevealKeyId(null)
-        setRevealedKey(null)
-      }, 5_000)
     } else {
       setError(res.error ?? 'Failed to export key')
       setExportConfirmId(null)

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -416,7 +416,7 @@ declare global {
     createAgentWallet: (agentId: string, agentName: string) => Promise<IpcResponse<{ id: string; name: string; address: string; is_default: number; wallet_type: string; agent_id: string | null; created_at: number }>>
     hasKeypair: (walletId: string) => Promise<IpcResponse<boolean>>
     transactionHistory: (walletId: string, limit?: number) => Promise<IpcResponse<Array<{ id: string; wallet_id: string; type: string; signature: string | null; from_address: string; to_address: string; amount: number; mint: string | null; symbol: string | null; status: string; error: string | null; created_at: number }>>>
-    exportPrivateKey: (walletId: string) => Promise<IpcResponse<string>>
+    exportPrivateKey: (walletId: string) => Promise<IpcResponse<boolean>>
   }
 
   interface DaemonPnl {


### PR DESCRIPTION
Consolidates corrected versions of the stale security PRs into one fresh branch from current main.\n\nIncluded fixes:\n- Stop returning exported private keys to the renderer; copy to clipboard only.\n- Use static own-property agent column mapping for agents:update.\n- Wrap default-wallet and email account deletion changes in DB transactions.\n- Validate environment variable names before writing .env files.\n- Correct PumpFun slippage basis-point conversion.\n- Zero temporary CSV key buffers after keypair creation.\n- Always clean recovery key material/abort controller after recovery runs.\n- Use random temp file names and restrictive mode for agent context/prompt temp files.\n- Ignore generated Anchor deploy keypairs.\n\nValidation:\n- pnpm run typecheck\n- pnpm test -- test/panels/AppSurfaces.dom.test.tsx\n- pnpm test