### PR TITLE
ci: retry electron binary downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             ~/.cache/electron-builder
             ~\AppData\Local\electron\cache
             ~\AppData\Local\electron-builder\cache
-          key: electron-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: electron-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile
@@ -81,9 +81,19 @@ jobs:
           path: |
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: electron-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: electron-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
+      - name: Pre-cache Electron binary
+        shell: bash
+        run: |
+          ELECTRON_VERSION="$(node -p "require('./package.json').devDependencies.electron.replace(/^[^0-9]*/, '')")"
+          ELECTRON_CACHE="$HOME/.cache/electron"
+          ELECTRON_ZIP="electron-v${ELECTRON_VERSION}-darwin-arm64.zip"
+          mkdir -p "$ELECTRON_CACHE"
+          curl --fail --location --retry 5 --retry-delay 10 --retry-all-errors \
+            --output "$ELECTRON_CACHE/$ELECTRON_ZIP" \
+            "https://github.com/electron/electron/releases/download/v${ELECTRON_VERSION}/${ELECTRON_ZIP}"
       - run: pnpm exec electron-builder --publish never

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
             ~/.cache/electron-builder
             ~\AppData\Local\electron\cache
             ~\AppData\Local\electron-builder\cache
-          key: electron-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: electron-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile
@@ -104,11 +104,23 @@ jobs:
           path: |
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: electron-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: electron-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
+      - name: Pre-cache Electron binaries
+        shell: bash
+        run: |
+          ELECTRON_VERSION="$(node -p "require('./package.json').devDependencies.electron.replace(/^[^0-9]*/, '')")"
+          ELECTRON_CACHE="$HOME/.cache/electron"
+          mkdir -p "$ELECTRON_CACHE"
+          for arch in arm64 x64; do
+            ELECTRON_ZIP="electron-v${ELECTRON_VERSION}-darwin-${arch}.zip"
+            curl --fail --location --retry 5 --retry-delay 10 --retry-all-errors \
+              --output "$ELECTRON_CACHE/$ELECTRON_ZIP" \
+              "https://github.com/electron/electron/releases/download/v${ELECTRON_VERSION}/${ELECTRON_ZIP}"
+          done
       - name: Package
         run: |
           if [ -n "${{ secrets.CSC_LINK }}" ]; then
@@ -169,7 +181,7 @@ jobs:
           path: |
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: electron-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: electron-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Fixes flaky macOS package checks caused by GitHub returning 504 while electron-builder downloads Electron.\n\nChanges:\n- Use pnpm-lock.yaml for Electron cache keys instead of missing package-lock.json.\n- Pre-cache macOS Electron binaries with curl retry before electron-builder runs.\n- Applies the same cache-key fix to release packaging.\n\nContext: main CI after #75 passed validation and Windows, but macOS failed twice on a 504 fetching electron-v33.4.11-darwin-arm64.zip.