### PR TITLE
fix: count pending agent transfers toward daily spend limit

### DIFF
--- a/electron/services/WalletService.ts
+++ b/electron/services/WalletService.ts
@@ -593,7 +593,7 @@ export async function transferSOL(
     // Agent spend limit check — only count SOL transfers toward the SOL-denominated limit
     if (walletRow?.wallet_type === 'agent') {
       const dayAgo = Date.now() - 86_400_000
-      const row = db.prepare('SELECT COALESCE(SUM(amount), 0) as total FROM transaction_history WHERE wallet_id = ? AND status = ? AND type = ? AND created_at > ?').get(fromWalletId, 'confirmed', 'sol_transfer', dayAgo) as { total: number }
+      const row = db.prepare('SELECT COALESCE(SUM(amount), 0) as total FROM transaction_history WHERE wallet_id = ? AND status IN (?, ?) AND type = ? AND created_at > ?').get(fromWalletId, 'confirmed', 'pending', 'sol_transfer', dayAgo) as { total: number }
       if (row.total + amountToRecord > 2) throw new Error('Agent wallet daily spend limit (2 SOL) exceeded')
     }
 

--- a/test/services/WalletService.swap.test.ts
+++ b/test/services/WalletService.swap.test.ts
@@ -109,14 +109,18 @@ vi.mock('@solana/spl-token', () => ({
 
 import { getDashboard, transferSOL, transferToken } from '../../electron/services/WalletService'
 
-function makeWalletDbChain(overrides: { walletRow?: object | null } = {}) {
+function makeWalletDbChain(overrides: { walletRow?: object | null; dailySpendTotal?: number } = {}) {
   const walletRow = overrides.walletRow !== undefined
     ? overrides.walletRow
     : { id: 'w1', name: 'Test', address: 'So11111111111111111111111111111111111111112', is_default: 1, wallet_type: 'user', keypair_path: null }
+  const dailySpendTotal = overrides.dailySpendTotal ?? 0
 
   return (sql: string) => {
     if (sql.includes('FROM wallets WHERE id') || sql.includes('wallet_type FROM wallets')) {
       return { get: vi.fn().mockReturnValue(walletRow) }
+    }
+    if (sql.includes('SELECT COALESCE(SUM(amount), 0) as total FROM transaction_history')) {
+      return { get: vi.fn().mockReturnValue({ total: dailySpendTotal }) }
     }
     if (sql.includes('INSERT INTO transaction_history') || sql.includes('UPDATE transaction_history')) {
       return { run: vi.fn() }
@@ -264,6 +268,30 @@ describe('transferSOL — insufficient balance', () => {
     await expect(
       transferSOL('w1', 'So11111111111111111111111111111111111111112', 1)
     ).rejects.toThrow(/insufficient/i)
+  })
+})
+
+describe('transferSOL — agent spend limit', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('counts pending transfers toward the daily spend limit', async () => {
+    mockPrepare.mockImplementation(makeWalletDbChain({
+      walletRow: { wallet_type: 'agent' },
+      dailySpendTotal: 1.75,
+    }))
+
+    const fakeKeypair = {
+      publicKey: { toBase58: () => 'FakeKey', toBuffer: () => Buffer.alloc(32) },
+      secretKey: new Uint8Array(64),
+      fill: vi.fn(),
+    }
+
+    mockGetBalance.mockResolvedValue(5_000_000_000)
+    mockWithKeypair.mockImplementation((_walletId: string, fn: Function) => fn(fakeKeypair))
+
+    await expect(
+      transferSOL('w1', 'So11111111111111111111111111111111111111112', 0.3)
+    ).rejects.toThrow(/daily spend limit/i)
   })
 })
 


### PR DESCRIPTION
## Summary\n- count both pending and confirmed SOL transfers toward the agent daily spend cap\n- close the race where concurrent sends could bypass the 2 SOL limit\n- add a regression test for pending transfers\n\n## Validation\n- pnpm run typecheck\n- pnpm test -- test/services/WalletService.swap.test.ts\n\nSupersedes #33 on top of current main.