### PR TITLE
fix: guard PumpFun trades and timeout metadata uploads

### DIFF
--- a/electron/services/PumpFunService.ts
+++ b/electron/services/PumpFunService.ts
@@ -126,9 +126,20 @@ export async function createToken(input: TokenCreateInput): Promise<TokenCreateR
     formData.append('file', blob, `token.${ext}`)
   }
 
-  const metaRes = await fetch('https://pump.fun/api/ipfs', { method: 'POST', body: formData })
-  if (!metaRes.ok) throw new Error('Failed to upload token metadata')
-  const metaJson = await metaRes.json() as { metadataUri: string }
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 30_000)
+  let metaJson: { metadataUri: string }
+  try {
+    const metaRes = await fetch('https://pump.fun/api/ipfs', { method: 'POST', body: formData, signal: controller.signal })
+    if (!metaRes.ok) throw new Error('Failed to upload token metadata')
+    metaJson = await metaRes.json() as { metadataUri: string }
+  } catch (e) {
+    throw e instanceof Error && e.name === 'AbortError'
+      ? new Error('Token metadata upload timed out after 30s')
+      : e
+  } finally {
+    clearTimeout(timeoutId)
+  }
 
   const mintKeypair = Keypair.generate()
   const bondingCurve = sdk.bondingCurvePda(mintKeypair.publicKey)
@@ -185,7 +196,8 @@ export async function buyToken(input: TradeInput): Promise<TxResult> {
 
   if (curve.complete) throw new Error('Bonding curve graduated. Use AMM trading.')
 
-  const solLamports = new BN(Math.floor((input.amountSol ?? 0) * 1e9))
+  if (!input.amountSol || input.amountSol <= 0) throw new Error('Buy amount must be greater than 0')
+  const solLamports = new BN(Math.floor(input.amountSol * 1e9))
   const tokenAmount = sdk.getBuyTokenAmountFromSolAmount({
     global,
     feeConfig,
@@ -236,7 +248,8 @@ export async function sellToken(input: TradeInput): Promise<TxResult> {
 
   if (curve.complete) throw new Error('Bonding curve graduated. Use AMM trading.')
 
-  const tokenAmount = new BN(Math.floor((input.amountTokens ?? 0) * 1e6))
+  if (!input.amountTokens || input.amountTokens <= 0) throw new Error('Sell amount must be greater than 0')
+  const tokenAmount = new BN(Math.floor(input.amountTokens * 1e6))
   const solAmount = sdk.getSellSolAmountFromTokenAmount({
     global,
     feeConfig,

--- a/scripts/smoke/visual-regression.mjs
+++ b/scripts/smoke/visual-regression.mjs
@@ -164,6 +164,23 @@ function attachPageDiagnostics(page) {
   })
 }
 
+async function cleanupUserDataDir(dir) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      rmSync(dir, { recursive: true, force: true })
+      return
+    } catch (error) {
+      const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined
+      if ((code === 'EBUSY' || code === 'EPERM') && attempt < 2) {
+        await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)))
+        continue
+      }
+      console.warn(`[visual-smoke] unable to remove temp dir ${dir}: ${error instanceof Error ? error.message : String(error)}`)
+      return
+    }
+  }
+}
+
 async function waitForAppReady(page) {
   await page.waitForFunction(() => !!window.daemon, { timeout: 30000 })
   await page.waitForSelector('.titlebar', { timeout: 30000 })
@@ -578,5 +595,5 @@ try {
       })
     })
   }
-  rmSync(userDataDir, { recursive: true, force: true })
+  await cleanupUserDataDir(userDataDir)
 }

--- a/test/services/PumpFunService.test.ts
+++ b/test/services/PumpFunService.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockWithKeypair,
+  mockGetConnectionStrict,
+  mockFetchGlobal,
+  mockFetchBondingCurve,
+  mockFetchFeeConfig,
+  mockFetch,
+} = vi.hoisted(() => ({
+  mockWithKeypair: vi.fn(),
+  mockGetConnectionStrict: vi.fn(),
+  mockFetchGlobal: vi.fn(),
+  mockFetchBondingCurve: vi.fn(),
+  mockFetchFeeConfig: vi.fn(),
+  mockFetch: vi.fn(),
+}))
+
+const mockSdkModule = vi.hoisted(() => ({
+  OnlinePumpSdk: vi.fn(() => ({
+    fetchGlobal: mockFetchGlobal,
+    fetchBondingCurve: mockFetchBondingCurve,
+    fetchFeeConfig: mockFetchFeeConfig,
+    buyInstructions: vi.fn(),
+    sellInstructions: vi.fn(),
+  })),
+  PumpSdk: vi.fn(() => ({})),
+  bondingCurvePda: vi.fn(() => ({ toBase58: () => 'curve-1' })),
+  getBuyTokenAmountFromSolAmount: vi.fn(),
+  getSellSolAmountFromTokenAmount: vi.fn(),
+}))
+
+vi.mock('node:module', () => ({
+  createRequire: () => () => mockSdkModule,
+}))
+
+vi.mock('../../electron/services/SolanaService', () => ({
+  withKeypair: mockWithKeypair,
+  getConnectionStrict: mockGetConnectionStrict,
+  executeInstructions: vi.fn(),
+  loadKeypair: vi.fn(),
+}))
+
+vi.mock('../../electron/db/db', () => ({
+  getDb: vi.fn(),
+}))
+
+vi.mock('../../electron/services/SecureKeyService', () => ({
+  getKey: vi.fn(),
+  storeKey: vi.fn(),
+  deleteKey: vi.fn(),
+  isEncryptionAvailable: vi.fn(() => true),
+}))
+
+vi.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+}))
+
+vi.mock('@solana/spl-token', () => ({
+  TOKEN_PROGRAM_ID: { toBase58: () => 'TokenProgram1111111111111111111111111111111' },
+}))
+
+vi.mock('@solana/web3.js', () => ({
+  PublicKey: vi.fn((value: string) => ({ toBase58: () => value })),
+  Keypair: {
+    generate: vi.fn(),
+  },
+}))
+
+vi.stubGlobal('fetch', mockFetch)
+
+import { buyToken, createToken, sellToken } from '../../electron/services/PumpFunService'
+
+describe('PumpFunService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetConnectionStrict.mockReturnValue({
+      getAccountInfo: vi.fn().mockResolvedValue({}),
+    })
+    mockWithKeypair.mockImplementation((_walletId: string, fn: Function) => fn({
+      publicKey: { toBase58: () => 'Wallet111111111111111111111111111111111111' },
+      secretKey: new Uint8Array(64),
+    }))
+    mockFetchGlobal.mockResolvedValue({ tokenTotalSupply: {} })
+    mockFetchBondingCurve.mockResolvedValue({ complete: false })
+    mockFetchFeeConfig.mockResolvedValue({})
+  })
+
+  it('rejects zero-value buys before building instructions', async () => {
+    await expect(buyToken({
+      walletId: 'wallet-1',
+      mint: 'Mint111111111111111111111111111111111111111',
+      action: 'buy',
+      amountSol: 0,
+      slippageBps: 100,
+    })).rejects.toThrow('Buy amount must be greater than 0')
+  })
+
+  it('rejects zero-value sells before building instructions', async () => {
+    await expect(sellToken({
+      walletId: 'wallet-1',
+      mint: 'Mint111111111111111111111111111111111111111',
+      action: 'sell',
+      amountTokens: 0,
+      slippageBps: 100,
+    })).rejects.toThrow('Sell amount must be greater than 0')
+  })
+
+  it('turns aborted metadata uploads into a clear timeout error', async () => {
+    const abortError = new Error('aborted')
+    abortError.name = 'AbortError'
+    mockFetch.mockRejectedValue(abortError)
+
+    await expect(createToken({
+      walletId: 'wallet-1',
+      name: 'Daemon',
+      symbol: 'DMN',
+      description: 'Daemon token',
+      imagePath: null,
+      initialBuyAmountSol: 0.1,
+      mayhemMode: false,
+    })).rejects.toThrow('Token metadata upload timed out after 30s')
+  })
+})


### PR DESCRIPTION
## Summary\n- reject zero or missing buy/sell amounts before any PumpFun SDK calls\n- add a 30s timeout and clear error for token metadata uploads\n- add focused PumpFun service tests for both behaviors\n\n## Validation\n- pnpm run typecheck\n- pnpm test -- test/services/PumpFunService.test.ts\n\nSupersedes #32 on top of current main.