### PR TITLE
feat: open launched pump token in browser mode

### DIFF
--- a/src/lib/launchHandoff.ts
+++ b/src/lib/launchHandoff.ts
@@ -1,0 +1,39 @@
+import { useBrowserStore } from '../store/browser'
+import { useUIStore } from '../store/ui'
+
+function buildPumpFunTokenUrl(mint: string): string {
+  return `https://pump.fun/coin/${mint}`
+}
+
+function buildPrintrTokenUrl(mint: string): string {
+  return `https://app.printr.money/v2/trade/${mint}`
+}
+
+export function openLaunchInBrowserMode(launchpad: LaunchpadId, mint: string) {
+  const trimmedMint = mint.trim()
+  if (!trimmedMint) return
+
+  let url: string | null = null
+
+  if (launchpad === 'pumpfun') {
+    url = buildPumpFunTokenUrl(trimmedMint)
+  } else if (launchpad === 'printr') {
+    url = buildPrintrTokenUrl(trimmedMint)
+  }
+
+  if (!url) return
+
+  const browserStore = useBrowserStore.getState()
+  const uiStore = useUIStore.getState()
+
+  browserStore.setUrl(url)
+  browserStore.setLoadStatus('loading')
+  uiStore.openBrowserTab()
+
+  window.daemon.browser.navigate(url).then((res) => {
+    if (res.ok && res.data) {
+      useBrowserStore.getState().setLastPageId(res.data.pageId)
+    }
+  }).catch(() => {})
+}
+

--- a/src/panels/LaunchWizard/LaunchWizard.tsx
+++ b/src/panels/LaunchWizard/LaunchWizard.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
+import { openLaunchInBrowserMode } from '../../lib/launchHandoff'
+import { useNotificationsStore } from '../../store/notifications'
 import { useUIStore } from '../../store/ui'
 import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useTokenLaunch } from './useTokenLaunch'
@@ -58,7 +60,9 @@ function phaseIndex(phase: string): number {
 export function LaunchWizard() {
   const closeLaunchWizard = useWorkflowShellStore((s) => s.closeLaunchWizard)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
+  const pushSuccess = useNotificationsStore((s) => s.pushSuccess)
   const overlayRef = useRef<HTMLDivElement>(null)
+  const hasAutoHandedOffRef = useRef(false)
 
   const [step, setStep] = useState<Step>(1)
   const [hasAttemptedNext, setHasAttemptedNext] = useState(false)
@@ -205,6 +209,21 @@ export function LaunchWizard() {
   const selectedLaunchpad = launchpads.find((pad) => pad.id === s2.launchpad) ?? null
 
   useEffect(() => {
+    if (launchState.phase !== 'done' || !launchState.result) {
+      hasAutoHandedOffRef.current = false
+      return
+    }
+    if (hasAutoHandedOffRef.current) return
+    if (s2.launchpad !== 'pumpfun' || !launchState.result.mint) return
+
+    hasAutoHandedOffRef.current = true
+    pushSuccess(`Opened ${s1.symbol.toUpperCase()} in Browser mode`, 'Token Launch')
+    window.setTimeout(() => {
+      closeLaunchWizard()
+    }, 120)
+  }, [launchState.phase, launchState.result, s2.launchpad, s1.symbol, pushSuccess, closeLaunchWizard])
+
+  useEffect(() => {
     if (step !== 3) return
     if (!s2.walletId) return
 
@@ -319,6 +338,7 @@ export function LaunchWizard() {
               result={launchState.result}
               error={launchState.error}
               activePhaseIdx={activePhaseIdx}
+              launchpad={s2.launchpad}
               onRetry={handleRetry}
               onClose={closeLaunchWizard}
             />
@@ -801,6 +821,7 @@ function StepExecuting({
   result,
   error,
   activePhaseIdx,
+  launchpad,
   onRetry,
   onClose,
 }: {
@@ -808,6 +829,7 @@ function StepExecuting({
   result: { mint: string; signature: string; success: boolean } | null
   error: string | null
   activePhaseIdx: number
+  launchpad: LaunchpadId
   onRetry: () => void
   onClose: () => void
 }) {
@@ -828,19 +850,27 @@ function StepExecuting({
             Signature: {result.signature}
           </div>
         )}
-        <button
-          className="lw-success-link"
-          onClick={() => {
-            if (result.signature) {
-              window.daemon.shell.openExternal(`https://solscan.io/tx/${result.signature}`)
-            }
-          }}
-        >
-          View on Solscan
-        </button>
-        <button className="lw-btn primary" style={{ marginTop: 4 }} onClick={onClose}>
-          Done
-        </button>
+        <div className="lw-btn-row" style={{ marginTop: 4 }}>
+          <button
+            className="lw-btn primary"
+            onClick={() => openLaunchInBrowserMode(launchpad, result.mint)}
+          >
+            Open in Browser
+          </button>
+          <button
+            className="lw-btn secondary"
+            onClick={() => {
+              if (result.signature) {
+                window.daemon.shell.openExternal(`https://solscan.io/tx/${result.signature}`)
+              }
+            }}
+          >
+            View on Solscan
+          </button>
+          <button className="lw-btn secondary" onClick={onClose}>
+            Done
+          </button>
+        </div>
       </div>
     )
   }

--- a/src/panels/LaunchWizard/useTokenLaunch.ts
+++ b/src/panels/LaunchWizard/useTokenLaunch.ts
@@ -1,6 +1,5 @@
 import { useState, useCallback } from 'react'
-import { useBrowserStore } from '../../store/browser'
-import { useUIStore } from '../../store/ui'
+import { openLaunchInBrowserMode } from '../../lib/launchHandoff'
 
 export interface LaunchParams {
   launchpad: LaunchpadId
@@ -71,13 +70,7 @@ export function useTokenLaunch() {
 
       const { signature, mint } = res.data
 
-      if (mint && (params.launchpad === 'pumpfun' || params.launchpad === 'printr')) {
-        const tokenUrl = params.launchpad === 'printr'
-          ? `https://app.printr.money/v2/trade/${mint}`
-          : `https://pump.fun/coin/${mint}`
-        useBrowserStore.getState().setUrl(tokenUrl)
-        useUIStore.getState().openBrowserTab()
-      }
+      openLaunchInBrowserMode(params.launchpad, mint)
 
       setState({
         phase: 'done',

--- a/src/panels/plugins/PumpFunTool/LaunchTab.tsx
+++ b/src/panels/plugins/PumpFunTool/LaunchTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { openLaunchInBrowserMode } from '../../../lib/launchHandoff'
 import { Toggle } from '../../../components/Toggle'
 
 interface Props { walletId: string | null }
@@ -40,6 +41,9 @@ export function LaunchTab({ walletId }: Props) {
     })
 
     if (res.ok && res.data) {
+      if (res.data.mint) {
+        openLaunchInBrowserMode('pumpfun', res.data.mint)
+      }
       setResult({ signature: res.data.signature, mint: res.data.mint })
     } else {
       setResult({ error: res.error ?? 'Launch failed' })


### PR DESCRIPTION
## Summary
Salvages the post-launch browser handoff onto current `main` after the runtime and launch workflow merge.

## Included
- opens successful Pump.fun launches directly in Browser mode
- extracts launch browser handoff into a shared helper
- keeps current Printr browser-open behavior intact
- wires the same handoff into the PumpFun plugin launch tab

## Validation
- `npm run typecheck`
- `pnpm exec vitest run test/panels/AppSurfaces.dom.test.tsx test/panels/ProjectStarter.runtime.test.ts`

## Notes
- This branch was rebuilt from `origin/main` and cherry-picked from the older `feat/post-launch-browser-handoff` work.
- The only conflict was in the launch flow hook, resolved by preserving the newer abstraction and existing `printr` support.
