### PR TITLE
fix: unblock project creation and terminal launch

### DIFF
--- a/electron/ipc/projects.ts
+++ b/electron/ipc/projects.ts
@@ -1,5 +1,6 @@
 import { ipcMain, dialog } from 'electron'
 import { getDb } from '../db/db'
+import { invalidatePathCache } from '../shared/pathValidation'
 import { ipcHandler } from '../services/IpcHandlerFactory'
 import type { ProjectCreateInput } from '../shared/types'
 
@@ -14,12 +15,14 @@ export function registerProjectHandlers() {
     const id = crypto.randomUUID()
     db.prepare('INSERT INTO projects (id, name, path, last_active) VALUES (?,?,?,?)')
       .run(id, project.name, project.path, Date.now())
+    invalidatePathCache()
     return db.prepare('SELECT * FROM projects WHERE id = ?').get(id)
   }))
 
   ipcMain.handle('projects:delete', ipcHandler(async (_event, id: string) => {
     const db = getDb()
     db.prepare('DELETE FROM projects WHERE id = ?').run(id)
+    invalidatePathCache()
   }))
 
   ipcMain.handle('projects:openDialog', ipcHandler(async () => {

--- a/src/panels/ProjectStarter/ProjectStarter.tsx
+++ b/src/panels/ProjectStarter/ProjectStarter.tsx
@@ -383,15 +383,8 @@ export function ProjectStarter() {
     setError(null)
 
     try {
-      // Create directory
-      const mkdirRes = await window.daemon.fs.createDir(projectPath)
-      if (!mkdirRes.ok) {
-        setError(mkdirRes.error ?? 'Failed to create directory')
-        setWizard((prev) => ({ ...prev, step: 'configure' }))
-        return
-      }
-
-      // Register project in DB
+      // Register the project before using sandboxed filesystem APIs so the
+      // target path is treated as a valid project root during scaffolding.
       const projRes = await window.daemon.projects.create({ name, path: projectPath })
       if (!projRes.ok || !projRes.data) {
         setError(projRes.error ?? 'Failed to register project')
@@ -400,6 +393,17 @@ export function ProjectStarter() {
       }
 
       const newProject = projRes.data as { id: string; name: string; path: string }
+      const cleanupProject = async () => {
+        await window.daemon.projects.delete(newProject.id)
+      }
+
+      const mkdirRes = await window.daemon.fs.createDir(projectPath)
+      if (!mkdirRes.ok) {
+        await cleanupProject()
+        setError(mkdirRes.error ?? 'Failed to create directory')
+        setWizard((prev) => ({ ...prev, step: 'configure' }))
+        return
+      }
 
       // Refresh project list and switch to new project
       const listRes = await window.daemon.projects.list()
@@ -415,11 +419,13 @@ export function ProjectStarter() {
           `${JSON.stringify(runtimePreset, null, 2)}\n`,
         )
         if (!runtimePresetRes.ok) {
+          await cleanupProject()
           setError(runtimePresetRes.error ?? 'Failed to write runtime preset')
           setWizard((prev) => ({ ...prev, step: 'configure' }))
           return
         }
       }
+
 
       // Spawn a terminal with Claude agent to scaffold the project
       const runtimePrompt = buildRuntimePrompt(walletInfrastructure)
@@ -449,6 +455,7 @@ export function ProjectStarter() {
         setCenterMode('canvas')
         closeDrawer()
       } else {
+        await cleanupProject()
         setError(termRes.error ?? 'Failed to start build agent')
         setWizard((prev) => ({ ...prev, step: 'configure' }))
       }

--- a/src/panels/Terminal/Terminal.css
+++ b/src/panels/Terminal/Terminal.css
@@ -320,6 +320,12 @@
   color: var(--t4);
 }
 
+.terminal-empty-error {
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--amber);
+}
+
 .terminal-split {
   position: absolute;
   inset: 0;

--- a/src/panels/Terminal/Terminal.tsx
+++ b/src/panels/Terminal/Terminal.tsx
@@ -19,11 +19,13 @@ export function TerminalPanel() {
   const addTerminal = useUIStore((s) => s.addTerminal)
   const removeTerminal = useUIStore((s) => s.removeTerminal)
   const setActiveTerminal = useUIStore((s) => s.setActiveTerminal)
+  const setActiveProject = useUIStore((s) => s.setActiveProject)
   const setDrawerTool = useWorkflowShellStore((s) => s.setDrawerTool)
   const centerMode = useUIStore((s) => s.centerMode)
   const setCenterMode = useUIStore((s) => s.setCenterMode)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
+  const projects = useUIStore((s) => s.projects)
   const activeTerminalId = useUIStore((s) =>
     s.activeProjectId ? s.activeTerminalIdByProject[s.activeProjectId] ?? null : null,
   )
@@ -34,6 +36,7 @@ export function TerminalPanel() {
   const [splitLayoutsByProject, setSplitLayoutsByProject] = useState<Record<string, SplitLayout | undefined>>({})
   const [launchRecents, setLaunchRecents] = useState<TerminalLaunchRecent[]>(() => readTerminalLaunchRecents())
   const [isDragOver, setIsDragOver] = useState(false)
+  const [launchError, setLaunchError] = useState<string | null>(null)
   const panelDragDepthRef = useRef(0)
   const creatingRef = useRef(false)
   const splitLayout = activeProjectId ? splitLayoutsByProject[activeProjectId] : undefined
@@ -42,15 +45,45 @@ export function TerminalPanel() {
     setLaunchRecents((prev) => addToRecents(prev, recent))
   }, [])
 
-  const handleNewTerminal = useCallback(async (label = 'Terminal', startupCommand?: string) => {
-    if (!activeProjectId) return null
-    const res = await window.daemon.terminal.create({ cwd: activeProjectPath ?? undefined, startupCommand })
-    if (res.ok && res.data) {
-      addTerminal(activeProjectId, res.data.id, label)
-      return res.data.id
+  const resolveProjectContext = useCallback(() => {
+    if (activeProjectId && activeProjectPath) {
+      return { projectId: activeProjectId, projectPath: activeProjectPath }
     }
-    return null
-  }, [activeProjectId, activeProjectPath, addTerminal])
+    if (projects.length === 0) {
+      setLaunchError('Open or create a project first to start a terminal.')
+      return null
+    }
+    const fallback = [...projects].sort((a, b) => (b.last_active ?? 0) - (a.last_active ?? 0))[0]
+    if (!fallback) {
+      setLaunchError('Open or create a project first to start a terminal.')
+      return null
+    }
+    setActiveProject(fallback.id, fallback.path)
+    setLaunchError(null)
+    return { projectId: fallback.id, projectPath: fallback.path }
+  }, [activeProjectId, activeProjectPath, projects, setActiveProject])
+
+  const handleNewTerminal = useCallback(async (label = 'Terminal', startupCommand?: string) => {
+    if (creatingRef.current) return null
+    creatingRef.current = true
+    const projectContext = resolveProjectContext()
+    if (!projectContext) {
+      creatingRef.current = false
+      return null
+    }
+    try {
+      setLaunchError(null)
+      const res = await window.daemon.terminal.create({ cwd: projectContext.projectPath, startupCommand })
+      if (res.ok && res.data) {
+        addTerminal(projectContext.projectId, res.data.id, label)
+        return res.data.id
+      }
+      setLaunchError(res.error ?? 'Failed to open terminal.')
+      return null
+    } finally {
+      creatingRef.current = false
+    }
+  }, [resolveProjectContext, addTerminal])
 
   const handleFolderDrop = useCallback(async (e: React.DragEvent) => {
     e.preventDefault()
@@ -83,25 +116,34 @@ export function TerminalPanel() {
   }, [addLaunchRecent, handleNewTerminal])
 
   const handleStartClaudeChat = useCallback(() => {
+    setLaunchError(null)
     setDrawerTool(null)
   }, [setDrawerTool])
 
   const handleStartSolanaAgent = useCallback(async () => {
-    if (!activeProjectId) return
-    const res = await window.daemon.terminal.spawnAgent({ agentId: SOLANA_AGENT_DB_ID, projectId: activeProjectId })
+    const projectContext = resolveProjectContext()
+    if (!projectContext) return
+    setLaunchError(null)
+    const res = await window.daemon.terminal.spawnAgent({ agentId: SOLANA_AGENT_DB_ID, projectId: projectContext.projectId })
     if (res.ok && res.data) {
-      addTerminal(activeProjectId, res.data.id, res.data.agentName ?? 'Solana Agent', res.data.agentId)
+      addTerminal(projectContext.projectId, res.data.id, res.data.agentName ?? 'Solana Agent', res.data.agentId)
+      return
     }
-  }, [activeProjectId, addTerminal])
+    setLaunchError(res.error ?? 'Failed to start Solana agent.')
+  }, [resolveProjectContext, addTerminal])
 
   const handleLaunchAgent = useCallback(async (agent: Agent) => {
-    if (!activeProjectId) return
-    const res = await window.daemon.terminal.spawnAgent({ agentId: agent.id, projectId: activeProjectId })
+    const projectContext = resolveProjectContext()
+    if (!projectContext) return
+    setLaunchError(null)
+    const res = await window.daemon.terminal.spawnAgent({ agentId: agent.id, projectId: projectContext.projectId })
     if (res.ok && res.data) {
-      addTerminal(activeProjectId, res.data.id, res.data.agentName ?? agent.name, res.data.agentId)
+      addTerminal(projectContext.projectId, res.data.id, res.data.agentName ?? agent.name, res.data.agentId)
       addLaunchRecent({ kind: 'agent', key: agent.id, label: agent.name })
+      return
     }
-  }, [activeProjectId, addLaunchRecent, addTerminal])
+    setLaunchError(res.error ?? `Failed to start ${agent.name}.`)
+  }, [resolveProjectContext, addLaunchRecent, addTerminal])
 
   const handleCloseTerminal = useCallback(async (id: string) => {
     if (!activeProjectId) return
@@ -115,19 +157,30 @@ export function TerminalPanel() {
   }, [activeProjectId, removeTerminal])
 
   const handleSplit = useCallback(async (direction: 'horizontal' | 'vertical') => {
-    if (!activeProjectId || !activeTerminalId) return
-    let secondaryId = splitLayoutsByProject[activeProjectId]?.secondaryId
+    const projectContext = resolveProjectContext()
+    if (!projectContext) return
+    const projectId = projectContext.projectId
+    let currentActiveTerminalId = activeTerminalId
+    if (!currentActiveTerminalId) {
+      currentActiveTerminalId = await handleNewTerminal('Terminal')
+      if (!currentActiveTerminalId) return
+    }
+    let secondaryId = splitLayoutsByProject[projectId]?.secondaryId
     const hasExistingSecondary = Boolean(secondaryId && visibleTerminals.some((tab) => tab.id === secondaryId))
     if (!hasExistingSecondary) {
-      const res = await window.daemon.terminal.create({ cwd: activeProjectPath ?? undefined })
-      if (!res.ok || !res.data) return
+      const res = await window.daemon.terminal.create({ cwd: projectContext.projectPath })
+      if (!res.ok || !res.data) {
+        setLaunchError(res.error ?? 'Failed to open split terminal.')
+        return
+      }
       secondaryId = res.data.id
-      addTerminal(activeProjectId, secondaryId, 'Split')
-      setActiveTerminal(activeProjectId, activeTerminalId)
+      addTerminal(projectId, secondaryId, 'Split')
+      setActiveTerminal(projectId, currentActiveTerminalId)
     }
     if (!secondaryId) return
-    setSplitLayoutsByProject((prev) => ({ ...prev, [activeProjectId]: { direction, secondaryId } }))
-  }, [activeProjectId, activeProjectPath, activeTerminalId, addTerminal, setActiveTerminal, splitLayoutsByProject, visibleTerminals])
+    setLaunchError(null)
+    setSplitLayoutsByProject((prev) => ({ ...prev, [projectId]: { direction, secondaryId } }))
+  }, [resolveProjectContext, activeTerminalId, handleNewTerminal, splitLayoutsByProject, visibleTerminals, addTerminal, setActiveTerminal])
 
   const handleUnsplit = useCallback(() => {
     if (!activeProjectId) return
@@ -139,11 +192,7 @@ export function TerminalPanel() {
   useEffect(() => {
     if (IS_SMOKE_TEST) return
     if (!activeProjectId || visibleTerminals.length !== 0 || creatingRef.current) return
-    creatingRef.current = true
-
-    handleNewTerminal('Terminal').finally(() => {
-      creatingRef.current = false
-    })
+    void handleNewTerminal('Terminal')
   }, [activeProjectId, visibleTerminals.length, handleNewTerminal])
 
   // Sync split layout when terminals change
@@ -208,6 +257,7 @@ export function TerminalPanel() {
         visibleTerminals={visibleTerminals}
         activeTerminalId={activeTerminalId}
         activeProjectId={activeProjectId}
+        canLaunchInProject={Boolean(activeProjectId) || projects.length > 0}
         centerMode={centerMode}
         splitLayout={splitLayout}
         launchRecents={launchRecents}
@@ -228,6 +278,7 @@ export function TerminalPanel() {
             <span className="terminal-empty-icon">&gt;_</span>
             <span className="terminal-empty-label">Click to start a terminal</span>
             <span className="terminal-empty-hint">or press Ctrl+`</span>
+            {launchError && <span className="terminal-empty-error">{launchError}</span>}
           </div>
         ) : paneIds.length <= 1 ? (
           /* Render ALL terminal instances to avoid unmount/remount on tab switch.

--- a/src/panels/Terminal/TerminalLauncher.tsx
+++ b/src/panels/Terminal/TerminalLauncher.tsx
@@ -3,6 +3,7 @@ import { type TerminalLaunchRecent } from './RecentsManager'
 
 interface TerminalLauncherProps {
   activeProjectId: string | null
+  canLaunchInProject: boolean
   launchRecents: TerminalLaunchRecent[]
   onStartShell: () => void
   onStartClaudeChat: () => void
@@ -13,6 +14,7 @@ interface TerminalLauncherProps {
 
 export function TerminalLauncher({
   activeProjectId,
+  canLaunchInProject,
   launchRecents,
   onStartShell,
   onStartClaudeChat,
@@ -118,7 +120,7 @@ export function TerminalLauncher({
           <button
             className="terminal-launcher-item"
             onClick={handleShell}
-            disabled={!activeProjectId}
+            disabled={!canLaunchInProject}
             aria-label="Standard Terminal"
           >
             <span className="terminal-launcher-item-title">Standard Terminal</span>
@@ -135,7 +137,7 @@ export function TerminalLauncher({
           <button
             className="terminal-launcher-item"
             onClick={handleSolana}
-            disabled={!activeProjectId}
+            disabled={!canLaunchInProject}
             aria-label="Solana Agent"
           >
             <span className="terminal-launcher-item-title">Solana Agent</span>
@@ -144,7 +146,7 @@ export function TerminalLauncher({
           <button
             className="terminal-launcher-item"
             onClick={() => handleCommand('surfpool', 'Surfpool')}
-            disabled={!activeProjectId}
+            disabled={!canLaunchInProject}
             aria-label="Surfpool"
           >
             <span className="terminal-launcher-item-title">Surfpool</span>
@@ -163,7 +165,7 @@ export function TerminalLauncher({
                   key={`recent-agent-${item.key}`}
                   className="terminal-launcher-item"
                   onClick={() => agent && handleAgent(agent)}
-                  disabled={!activeProjectId || !agent}
+                  disabled={!canLaunchInProject || !agent}
                   title={agent ? undefined : 'Agent no longer available'}
                 >
                   <span className="terminal-launcher-item-title">{item.label}</span>
@@ -182,7 +184,7 @@ export function TerminalLauncher({
                   key={`recent-command-${item.key}`}
                   className="terminal-launcher-item"
                   onClick={() => item.command && handleCommand(item.command, item.label)}
-                  disabled={!activeProjectId || !item.command}
+                  disabled={!canLaunchInProject || !item.command}
                 >
                   <span className="terminal-launcher-item-title">{item.label}</span>
                   <span className="terminal-launcher-item-desc">Recent command</span>

--- a/src/panels/Terminal/TerminalTabs.tsx
+++ b/src/panels/Terminal/TerminalTabs.tsx
@@ -18,6 +18,7 @@ interface TerminalTabsProps {
   visibleTerminals: TerminalTabEntry[]
   activeTerminalId: string | null
   activeProjectId: string | null
+  canLaunchInProject: boolean
   centerMode: CenterMode
   splitLayout: SplitLayout
   launchRecents: TerminalLaunchRecent[]
@@ -37,6 +38,7 @@ export function TerminalTabs({
   visibleTerminals,
   activeTerminalId,
   activeProjectId,
+  canLaunchInProject,
   centerMode,
   splitLayout,
   launchRecents,
@@ -77,6 +79,7 @@ export function TerminalTabs({
         ))}
         <TerminalLauncher
           activeProjectId={activeProjectId}
+          canLaunchInProject={canLaunchInProject}
           launchRecents={launchRecents}
           onStartShell={onStartShell}
           onStartClaudeChat={onStartClaudeChat}

--- a/test/panels/TerminalPanel.dom.test.tsx
+++ b/test/panels/TerminalPanel.dom.test.tsx
@@ -50,6 +50,7 @@ function resetStores() {
   useUIStore.setState({
     activeProjectId: 'project-1',
     activeProjectPath: 'C:/work/daemon-app',
+    projects: [{ id: 'project-1', name: 'daemon-app', path: 'C:/work/daemon-app', last_active: 10 } as Project],
     terminals: [],
     activeTerminalIdByProject: {},
     centerMode: 'canvas',
@@ -101,5 +102,24 @@ describe('TerminalPanel DOM behavior', () => {
     expect(screen.getByRole('button', { name: 'Claude Chat' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Solana Agent' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Surfpool' })).toBeInTheDocument()
+  })
+
+  it('falls back to the most recent project when the user starts a terminal without an active project', async () => {
+    const terminalCreate = installDaemonBridge()
+    useUIStore.setState({
+      activeProjectId: null,
+      activeProjectPath: null,
+      projects: [{ id: 'project-2', name: 'docs', path: 'C:/Users/offic/Documents/test', last_active: 42 } as Project],
+      terminals: [],
+      activeTerminalIdByProject: {},
+    })
+
+    render(<TerminalPanel />)
+
+    await userEvent.click(screen.getByText('Click to start a terminal'))
+
+    await waitFor(() => expect(terminalCreate).toHaveBeenCalledTimes(1))
+    expect(terminalCreate).toHaveBeenCalledWith({ cwd: 'C:/Users/offic/Documents/test', startupCommand: undefined })
+    expect(useUIStore.getState().activeProjectId).toBe('project-2')
   })
 })


### PR DESCRIPTION
## Summary
- fix project starter creating folders outside registered project boundaries by registering the project before sandboxed filesystem writes
- invalidate the project path cache on create/delete so newly added roots are immediately valid
- recover terminal launch and split actions when no active project is selected, and prevent duplicate terminal creation races
- add terminal DOM coverage for the recovered launch path

## Validation
- pnpm test
- 362 tests passing on top of main

## User impact
- fixes reported Path outside project boundaries errors when creating a project in custom folders such as Documents/test
- fixes terminal + / empty >_ interactions doing nothing in stale project-selection states
