### PR TITLE
chore: bump version to 2.0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- bump package version from 2.0.21 to 2.0.22
- prepare a coherent tagged patch release after the project-creation and terminal-launch hotfix landed on main

## Why
The latest shipped tag is still 2.0.21, while main now includes the hotfix merged in #110. The release workflow is tag-driven, so the app version needs to match the next tag before cutting the release.
