### PR TITLE
fix: allow multiple terminal launches

### DIFF
--- a/src/panels/Terminal/Terminal.tsx
+++ b/src/panels/Terminal/Terminal.tsx
@@ -38,8 +38,8 @@ export function TerminalPanel() {
   const [isDragOver, setIsDragOver] = useState(false)
   const [launchError, setLaunchError] = useState<string | null>(null)
   const panelDragDepthRef = useRef(0)
-  const autoCreatingRef = useRef(false)
-  const userCreatingRef = useRef(false)
+  const terminalCreateInFlightRef = useRef<Promise<string | null> | null>(null)
+  const splitCreatingRef = useRef(false)
   const splitLayout = activeProjectId ? splitLayoutsByProject[activeProjectId] : undefined
 
   const addLaunchRecent = useCallback((recent: Omit<TerminalLaunchRecent, 'timestamp'>) => {
@@ -67,21 +67,13 @@ export function TerminalPanel() {
   const handleNewTerminal = useCallback(async (
     label = 'Terminal',
     startupCommand?: string,
-    origin: 'user' | 'auto' = 'user',
   ) => {
-    if (origin === 'auto') {
-      if (autoCreatingRef.current || userCreatingRef.current) return null
-      autoCreatingRef.current = true
-    } else {
-      userCreatingRef.current = true
-    }
+    if (terminalCreateInFlightRef.current) return terminalCreateInFlightRef.current
+
     const projectContext = resolveProjectContext()
-    if (!projectContext) {
-      if (origin === 'auto') autoCreatingRef.current = false
-      else userCreatingRef.current = false
-      return null
-    }
-    try {
+    if (!projectContext) return null
+
+    const createTerminal = async () => {
       setLaunchError(null)
       const res = await window.daemon.terminal.create({ cwd: projectContext.projectPath, startupCommand })
       if (res.ok && res.data) {
@@ -90,10 +82,13 @@ export function TerminalPanel() {
       }
       setLaunchError(res.error ?? 'Failed to open terminal.')
       return null
-    } finally {
-      if (origin === 'auto') autoCreatingRef.current = false
-      else userCreatingRef.current = false
     }
+
+    const createPromise = createTerminal().finally(() => {
+      if (terminalCreateInFlightRef.current === createPromise) terminalCreateInFlightRef.current = null
+    })
+    terminalCreateInFlightRef.current = createPromise
+    return createPromise
   }, [resolveProjectContext, addTerminal])
 
   const handleFolderDrop = useCallback(async (e: React.DragEvent) => {
@@ -168,6 +163,7 @@ export function TerminalPanel() {
   }, [activeProjectId, removeTerminal])
 
   const handleSplit = useCallback(async (direction: 'horizontal' | 'vertical') => {
+    if (splitCreatingRef.current) return
     const projectContext = resolveProjectContext()
     if (!projectContext) return
     const projectId = projectContext.projectId
@@ -179,14 +175,19 @@ export function TerminalPanel() {
     let secondaryId = splitLayoutsByProject[projectId]?.secondaryId
     const hasExistingSecondary = Boolean(secondaryId && visibleTerminals.some((tab) => tab.id === secondaryId))
     if (!hasExistingSecondary) {
-      const res = await window.daemon.terminal.create({ cwd: projectContext.projectPath })
-      if (!res.ok || !res.data) {
-        setLaunchError(res.error ?? 'Failed to open split terminal.')
-        return
+      splitCreatingRef.current = true
+      try {
+        const res = await window.daemon.terminal.create({ cwd: projectContext.projectPath })
+        if (!res.ok || !res.data) {
+          setLaunchError(res.error ?? 'Failed to open split terminal.')
+          return
+        }
+        secondaryId = res.data.id
+        addTerminal(projectId, secondaryId, 'Split')
+        setActiveTerminal(projectId, currentActiveTerminalId)
+      } finally {
+        splitCreatingRef.current = false
       }
-      secondaryId = res.data.id
-      addTerminal(projectId, secondaryId, 'Split')
-      setActiveTerminal(projectId, currentActiveTerminalId)
     }
     if (!secondaryId) return
     setLaunchError(null)
@@ -202,8 +203,8 @@ export function TerminalPanel() {
   // start from explicit user actions, not from opening the bottom terminal.
   useEffect(() => {
     if (IS_SMOKE_TEST) return
-    if (!activeProjectId || visibleTerminals.length !== 0 || autoCreatingRef.current || userCreatingRef.current) return
-    void handleNewTerminal('Terminal', undefined, 'auto')
+    if (!activeProjectId || visibleTerminals.length !== 0 || terminalCreateInFlightRef.current) return
+    void handleNewTerminal('Terminal')
   }, [activeProjectId, visibleTerminals.length, handleNewTerminal])
 
   // Sync split layout when terminals change

--- a/src/panels/Terminal/Terminal.tsx
+++ b/src/panels/Terminal/Terminal.tsx
@@ -38,7 +38,8 @@ export function TerminalPanel() {
   const [isDragOver, setIsDragOver] = useState(false)
   const [launchError, setLaunchError] = useState<string | null>(null)
   const panelDragDepthRef = useRef(0)
-  const creatingRef = useRef(false)
+  const autoCreatingRef = useRef(false)
+  const userCreatingRef = useRef(false)
   const splitLayout = activeProjectId ? splitLayoutsByProject[activeProjectId] : undefined
 
   const addLaunchRecent = useCallback((recent: Omit<TerminalLaunchRecent, 'timestamp'>) => {
@@ -63,12 +64,21 @@ export function TerminalPanel() {
     return { projectId: fallback.id, projectPath: fallback.path }
   }, [activeProjectId, activeProjectPath, projects, setActiveProject])
 
-  const handleNewTerminal = useCallback(async (label = 'Terminal', startupCommand?: string) => {
-    if (creatingRef.current) return null
-    creatingRef.current = true
+  const handleNewTerminal = useCallback(async (
+    label = 'Terminal',
+    startupCommand?: string,
+    origin: 'user' | 'auto' = 'user',
+  ) => {
+    if (origin === 'auto') {
+      if (autoCreatingRef.current || userCreatingRef.current) return null
+      autoCreatingRef.current = true
+    } else {
+      userCreatingRef.current = true
+    }
     const projectContext = resolveProjectContext()
     if (!projectContext) {
-      creatingRef.current = false
+      if (origin === 'auto') autoCreatingRef.current = false
+      else userCreatingRef.current = false
       return null
     }
     try {
@@ -81,7 +91,8 @@ export function TerminalPanel() {
       setLaunchError(res.error ?? 'Failed to open terminal.')
       return null
     } finally {
-      creatingRef.current = false
+      if (origin === 'auto') autoCreatingRef.current = false
+      else userCreatingRef.current = false
     }
   }, [resolveProjectContext, addTerminal])
 
@@ -191,8 +202,8 @@ export function TerminalPanel() {
   // start from explicit user actions, not from opening the bottom terminal.
   useEffect(() => {
     if (IS_SMOKE_TEST) return
-    if (!activeProjectId || visibleTerminals.length !== 0 || creatingRef.current) return
-    void handleNewTerminal('Terminal')
+    if (!activeProjectId || visibleTerminals.length !== 0 || autoCreatingRef.current || userCreatingRef.current) return
+    void handleNewTerminal('Terminal', undefined, 'auto')
   }, [activeProjectId, visibleTerminals.length, handleNewTerminal])
 
   // Sync split layout when terminals change

--- a/test/panels/TerminalPanel.dom.test.tsx
+++ b/test/panels/TerminalPanel.dom.test.tsx
@@ -16,10 +16,13 @@ const { TerminalPanel } = await import('../../src/panels/Terminal/Terminal')
 
 function installDaemonBridge(createTerminal = vi.fn()) {
   let terminalId = 0
-  const terminalCreate = createTerminal.mockImplementation(async () => {
-    terminalId += 1
-    return { ok: true, data: { id: `term-${terminalId}` } }
-  })
+  const terminalCreate = createTerminal
+  if (!terminalCreate.getMockImplementation()) {
+    terminalCreate.mockImplementation(async () => {
+      terminalId += 1
+      return { ok: true, data: { id: `term-${terminalId}` } }
+    })
+  }
 
   Object.defineProperty(window, 'daemon', {
     configurable: true,
@@ -48,6 +51,14 @@ function installDaemonBridge(createTerminal = vi.fn()) {
   })
 
   return terminalCreate
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
 }
 
 function resetStores() {
@@ -120,6 +131,39 @@ describe('TerminalPanel DOM behavior', () => {
     expect(useUIStore.getState().terminals.map((terminal) => terminal.id)).toEqual(['term-1', 'term-2'])
     expect(useUIStore.getState().activeTerminalIdByProject['project-1']).toBe('term-2')
     expect(screen.getByTestId('terminal-instance-term-2')).toHaveAttribute('data-visible', 'true')
+  })
+
+  it('does not duplicate the first terminal when the empty state is clicked while auto-create is pending', async () => {
+    const pendingTerminal = deferred<{ ok: true; data: { id: string } }>()
+    const terminalCreate = installDaemonBridge(vi.fn().mockReturnValueOnce(pendingTerminal.promise))
+    render(<TerminalPanel />)
+
+    await waitFor(() => expect(terminalCreate).toHaveBeenCalledTimes(1))
+    await userEvent.click(screen.getByText('Click to start a terminal'))
+    expect(terminalCreate).toHaveBeenCalledTimes(1)
+
+    pendingTerminal.resolve({ ok: true, data: { id: 'term-1' } })
+    await waitFor(() => expect(useUIStore.getState().terminals.map((terminal) => terminal.id)).toEqual(['term-1']))
+  })
+
+  it('does not create duplicate split terminals from rapid split clicks', async () => {
+    const pendingSplit = deferred<{ ok: true; data: { id: string } }>()
+    let createCount = 0
+    const terminalCreate = installDaemonBridge(vi.fn().mockImplementation(() => {
+      createCount += 1
+      if (createCount === 1) return Promise.resolve({ ok: true, data: { id: 'term-1' } })
+      if (createCount === 2) return pendingSplit.promise
+      return Promise.resolve({ ok: true, data: { id: `term-${createCount}` } })
+    }))
+    render(<TerminalPanel />)
+
+    await waitFor(() => expect(terminalCreate).toHaveBeenCalledTimes(1))
+    await userEvent.click(screen.getByTitle('Split vertical'))
+    await userEvent.click(screen.getByTitle('Split vertical'))
+    expect(terminalCreate).toHaveBeenCalledTimes(2)
+
+    pendingSplit.resolve({ ok: true, data: { id: 'term-2' } })
+    await waitFor(() => expect(useUIStore.getState().terminals.map((terminal) => terminal.id)).toEqual(['term-1', 'term-2']))
   })
 
   it('falls back to the most recent project when the user starts a terminal without an active project', async () => {

--- a/test/panels/TerminalPanel.dom.test.tsx
+++ b/test/panels/TerminalPanel.dom.test.tsx
@@ -15,7 +15,11 @@ vi.mock('../../src/panels/Terminal/TerminalInstance', () => ({
 const { TerminalPanel } = await import('../../src/panels/Terminal/Terminal')
 
 function installDaemonBridge(createTerminal = vi.fn()) {
-  const terminalCreate = createTerminal.mockResolvedValue({ ok: true, data: { id: 'term-1' } })
+  let terminalId = 0
+  const terminalCreate = createTerminal.mockImplementation(async () => {
+    terminalId += 1
+    return { ok: true, data: { id: `term-${terminalId}` } }
+  })
 
   Object.defineProperty(window, 'daemon', {
     configurable: true,
@@ -102,6 +106,20 @@ describe('TerminalPanel DOM behavior', () => {
     expect(screen.getByRole('button', { name: 'Claude Chat' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Solana Agent' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Surfpool' })).toBeInTheDocument()
+  })
+
+  it('opens a second active terminal from the launcher while one is already running', async () => {
+    const terminalCreate = installDaemonBridge()
+    render(<TerminalPanel />)
+
+    await waitFor(() => expect(terminalCreate).toHaveBeenCalledTimes(1))
+    await userEvent.click(screen.getAllByTitle('New tab options')[0])
+    await userEvent.click(screen.getByRole('button', { name: 'Standard Terminal' }))
+
+    await waitFor(() => expect(terminalCreate).toHaveBeenCalledTimes(2))
+    expect(useUIStore.getState().terminals.map((terminal) => terminal.id)).toEqual(['term-1', 'term-2'])
+    expect(useUIStore.getState().activeTerminalIdByProject['project-1']).toBe('term-2')
+    expect(screen.getByTestId('terminal-instance-term-2')).toHaveAttribute('data-visible', 'true')
   })
 
   it('falls back to the most recent project when the user starts a terminal without an active project', async () => {


### PR DESCRIPTION
## Summary
- separate auto-created terminal guards from user-launched terminal creation
- allow the launcher to open a second active terminal while one is already running
- add a DOM regression test for multi-terminal launch behavior

## Tests
- pnpm vitest run test/panels/TerminalPanel.dom.test.tsx