### PR TITLE
chore: bump version to 2.0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- bump DAEMON to 2.0.23 for the terminal hotfix release

## Tests
- pnpm vitest run test/panels/TerminalPanel.dom.test.tsx