### PR TITLE
feat: add Solana activity timeline

### DIFF
--- a/src/components/CommandDrawer/CommandDrawer.tsx
+++ b/src/components/CommandDrawer/CommandDrawer.tsx
@@ -336,6 +336,24 @@ function ProIcon({ size = 18 }: { size?: number }) {
     </svg>
   )
 }
+function ActivityIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <defs>
+        <linearGradient id="activity-flow" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="#14f195" />
+          <stop offset="50%" stopColor="#38bdf8" />
+          <stop offset="100%" stopColor="#facc15" />
+        </linearGradient>
+      </defs>
+      <path d="M4 17.5h16" stroke="url(#activity-flow)" opacity="0.5" />
+      <path d="M6 15V8.5M12 15V5.5M18 15v-4" stroke="url(#activity-flow)" />
+      <circle cx="6" cy="8.5" r="2" stroke="url(#activity-flow)" />
+      <circle cx="12" cy="5.5" r="2" stroke="url(#activity-flow)" />
+      <circle cx="18" cy="11" r="2" stroke="url(#activity-flow)" />
+    </svg>
+  )
+}
 
 // Icon lookup for pinned sidebar tools
 export const TOOL_ICONS: Record<string, ComponentType<{ size?: number }>> = {
@@ -344,7 +362,7 @@ export const TOOL_ICONS: Record<string, ComponentType<{ size?: number }>> = {
   ports: PortsIcon, processes: ProcessIcon, settings: SettingsIcon,
   'image-editor': PaintIcon, 'solana-toolbox': SolanaIcon, 'block-scanner': ScannerIcon, docs: DocsIcon, starter: StarterIcon,
   'token-launch': TokenLaunchIcon, integrations: IntegrationsIcon, 'project-readiness': ReadinessIcon,
-  dashboard: DashboardIcon, sessions: SessionsIcon, hackathon: HackathonIcon, plugins: PluginsIcon, recovery: RecoveryIcon, pro: ProIcon,
+  dashboard: DashboardIcon, sessions: SessionsIcon, hackathon: HackathonIcon, plugins: PluginsIcon, recovery: RecoveryIcon, pro: ProIcon, activity: ActivityIcon,
 }
 
 // Tool name lookup
@@ -354,7 +372,7 @@ export const TOOL_NAMES: Record<string, string> = {
   ports: 'Ports', processes: 'Processes', settings: 'Settings',
   'image-editor': 'Image Editor', 'solana-toolbox': 'Solana', 'block-scanner': 'Block Scanner', docs: 'Docs', starter: 'New Project',
   'token-launch': 'Token Launch', integrations: 'Integrations', 'project-readiness': 'Project Readiness',
-  dashboard: 'Dashboard', sessions: 'Sessions', hackathon: 'Hackathon', plugins: 'Plugins', recovery: 'Recovery', pro: 'Daemon Pro',
+  dashboard: 'Dashboard', sessions: 'Sessions', hackathon: 'Hackathon', plugins: 'Plugins', recovery: 'Recovery', pro: 'Daemon Pro', activity: 'Activity',
 }
 
 // Lazy-load all tool components
@@ -380,6 +398,7 @@ const loadHackathonPanel = () => import('../../panels/Colosseum/HackathonPanel')
 const loadPluginManager = () => import('../../panels/PluginManager/PluginManager')
 const loadRecoveryPanel = () => import('../../panels/RecoveryPanel/RecoveryPanel')
 const loadProPanel = () => import('../../panels/ProPanel/ProPanel')
+const loadActivityTimeline = () => import('../../panels/ActivityTimeline/ActivityTimeline')
 
 const GitPanel = lazyNamedWithReload('git-panel', loadGitPanel, (m) => m.GitPanel)
 const EnvManager = lazyNamedWithReload('env-manager', loadEnvManager, (m) => m.EnvManager)
@@ -403,6 +422,7 @@ const HackathonPanel = lazyNamedWithReload('hackathon-panel', loadHackathonPanel
 const PluginManager = lazyNamedWithReload('plugin-manager', loadPluginManager, (m) => m.PluginManager)
 const RecoveryPanel = lazyNamedWithReload('recovery-panel', loadRecoveryPanel, (m) => m.RecoveryPanel)
 const ProPanel = lazyNamedWithReload('pro-panel', loadProPanel, (m) => m.ProPanel)
+const ActivityTimeline = lazyNamedWithReload('activity-timeline', loadActivityTimeline, (m) => m.ActivityTimeline)
 
 // Per-tool accent colors for the drawer grid and sidebar
 export const TOOL_COLORS: Record<string, string> = {
@@ -429,6 +449,7 @@ export const TOOL_COLORS: Record<string, string> = {
   plugins: '#cbd5e1',
   recovery: '#ec4899',
   pro: '#ffd700',
+  activity: '#14f195',
 }
 
 // Built-in tools registry — exported so other modules can enumerate all tool IDs
@@ -454,6 +475,7 @@ export const BUILTIN_TOOLS: DrawerTool[] = [
   { id: 'sessions', name: 'Sessions', description: 'Agent session history', icon: SessionsIcon, component: SessionHistory, preload: () => { void loadSessionHistory() }, category: 'dev' },
   { id: 'hackathon', name: 'Hackathon', description: 'Colosseum tracker', icon: HackathonIcon, component: HackathonPanel, preload: () => { void loadHackathonPanel() }, category: 'crypto' },
   { id: 'pro', name: 'Daemon Pro', description: 'Arena, Pro skills, MCP sync, and priority API', icon: ProIcon, component: ProPanel, preload: () => { void loadProPanel() }, category: 'crypto' },
+  { id: 'activity', name: 'Activity', description: 'Flight recorder for Solana development', icon: ActivityIcon, component: ActivityTimeline, preload: () => { void loadActivityTimeline() }, category: 'system' },
   { id: 'plugins', name: 'Plugins', description: 'Manage plugins', icon: PluginsIcon, component: PluginManager, preload: () => { void loadPluginManager() }, category: 'system' },
   { id: 'recovery', name: 'Recovery', description: 'Crash recovery and snapshots', icon: RecoveryIcon, component: RecoveryPanel, preload: () => { void loadRecoveryPanel() }, category: 'system' },
 ]

--- a/src/panels/ActivityTimeline/ActivityTimeline.css
+++ b/src/panels/ActivityTimeline/ActivityTimeline.css
@@ -1,0 +1,197 @@
+.activity-timeline {
+  min-height: 100%;
+  padding: 28px;
+  color: var(--text-primary);
+  background:
+    radial-gradient(circle at 15% 0%, rgba(20, 241, 149, 0.12), transparent 30%),
+    radial-gradient(circle at 85% 8%, rgba(56, 189, 248, 0.11), transparent 28%),
+    linear-gradient(145deg, rgba(8, 13, 18, 0.96), rgba(10, 17, 24, 0.98));
+}
+
+.activity-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.72), rgba(8, 47, 73, 0.32));
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.32);
+}
+
+.activity-kicker {
+  margin-bottom: 8px;
+  color: #14f195;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.activity-hero h2 {
+  margin: 0;
+  font-size: 30px;
+  letter-spacing: -0.04em;
+}
+
+.activity-hero p {
+  max-width: 760px;
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.activity-hero-actions,
+.activity-filter-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.activity-btn,
+.activity-filter {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: var(--text-primary);
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.activity-btn {
+  padding: 9px 13px;
+}
+
+.activity-btn:hover:not(:disabled),
+.activity-filter:hover {
+  border-color: rgba(20, 241, 149, 0.45);
+}
+
+.activity-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.activity-btn.danger {
+  color: #fca5a5;
+}
+
+.activity-filter-row {
+  margin: 20px 0;
+}
+
+.activity-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+}
+
+.activity-filter.active {
+  border-color: rgba(20, 241, 149, 0.7);
+  background: rgba(20, 241, 149, 0.11);
+}
+
+.activity-filter strong {
+  color: #14f195;
+  font-size: 11px;
+}
+
+.activity-stream {
+  display: grid;
+  gap: 10px;
+}
+
+.activity-entry {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.48);
+}
+
+.activity-entry.error {
+  border-color: rgba(248, 113, 113, 0.28);
+}
+
+.activity-entry.warning {
+  border-color: rgba(250, 204, 21, 0.28);
+}
+
+.activity-dot {
+  width: 10px;
+  height: 10px;
+  margin-top: 5px;
+  border-radius: 999px;
+  background: #38bdf8;
+  box-shadow: 0 0 18px rgba(56, 189, 248, 0.7);
+}
+
+.activity-dot.success {
+  background: #14f195;
+  box-shadow: 0 0 18px rgba(20, 241, 149, 0.7);
+}
+
+.activity-dot.warning {
+  background: #facc15;
+  box-shadow: 0 0 18px rgba(250, 204, 21, 0.7);
+}
+
+.activity-dot.error {
+  background: #f87171;
+  box-shadow: 0 0 18px rgba(248, 113, 113, 0.7);
+}
+
+.activity-entry-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-tertiary);
+  font-size: 11px;
+}
+
+.activity-entry-context {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.activity-entry-category {
+  padding: 2px 7px;
+  border-radius: 999px;
+  color: #67e8f9;
+  background: rgba(56, 189, 248, 0.1);
+  text-transform: capitalize;
+}
+
+.activity-entry-message {
+  margin-top: 6px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.activity-empty {
+  display: grid;
+  gap: 8px;
+  padding: 42px 22px;
+  border: 1px dashed rgba(148, 163, 184, 0.24);
+  border-radius: 20px;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.activity-empty-title {
+  color: var(--text-primary);
+  font-weight: 800;
+}
+
+@media (max-width: 760px) {
+  .activity-timeline {
+    padding: 18px;
+  }
+
+  .activity-hero {
+    display: grid;
+  }
+}

--- a/src/panels/ActivityTimeline/ActivityTimeline.tsx
+++ b/src/panels/ActivityTimeline/ActivityTimeline.tsx
@@ -1,0 +1,125 @@
+import { useMemo, useState } from 'react'
+import { useNotificationsStore, type ActivityEntry } from '../../store/notifications'
+import './ActivityTimeline.css'
+
+type ActivityFilter = 'all' | 'wallet' | 'runtime' | 'terminal' | 'scaffold' | 'errors'
+
+const FILTERS: Array<{ id: ActivityFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'wallet', label: 'Wallet' },
+  { id: 'runtime', label: 'Runtime' },
+  { id: 'terminal', label: 'Terminal' },
+  { id: 'scaffold', label: 'Scaffold' },
+  { id: 'errors', label: 'Errors' },
+]
+
+function classifyActivity(entry: ActivityEntry): Exclude<ActivityFilter, 'all' | 'errors'> | 'system' {
+  const haystack = `${entry.context ?? ''} ${entry.message}`.toLowerCase()
+  if (haystack.includes('wallet') || haystack.includes('swap') || haystack.includes('send') || haystack.includes('signature')) return 'wallet'
+  if (haystack.includes('runtime') || haystack.includes('validator') || haystack.includes('preflight') || haystack.includes('toolchain')) return 'runtime'
+  if (haystack.includes('terminal') || haystack.includes('shell') || haystack.includes('pty')) return 'terminal'
+  if (haystack.includes('scaffold') || haystack.includes('starter') || haystack.includes('project')) return 'scaffold'
+  return 'system'
+}
+
+function formatTime(createdAt: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(new Date(createdAt))
+}
+
+function matchesFilter(entry: ActivityEntry, filter: ActivityFilter): boolean {
+  if (filter === 'all') return true
+  if (filter === 'errors') return entry.kind === 'error' || entry.kind === 'warning'
+  return classifyActivity(entry) === filter
+}
+
+export function ActivityTimeline() {
+  const activity = useNotificationsStore((s) => s.activity)
+  const loadActivity = useNotificationsStore((s) => s.loadActivity)
+  const clearActivity = useNotificationsStore((s) => s.clearActivity)
+  const [filter, setFilter] = useState<ActivityFilter>('all')
+
+  const filtered = useMemo(
+    () => activity.filter((entry) => matchesFilter(entry, filter)),
+    [activity, filter],
+  )
+
+  const counts = useMemo(() => {
+    const next: Record<ActivityFilter, number> = {
+      all: activity.length,
+      wallet: 0,
+      runtime: 0,
+      terminal: 0,
+      scaffold: 0,
+      errors: 0,
+    }
+    for (const entry of activity) {
+      const category = classifyActivity(entry)
+      if (category in next) next[category as ActivityFilter] += 1
+      if (entry.kind === 'error' || entry.kind === 'warning') next.errors += 1
+    }
+    return next
+  }, [activity])
+
+  return (
+    <div className="activity-timeline">
+      <header className="activity-hero">
+        <div>
+          <div className="activity-kicker">DAEMON Flight Recorder</div>
+          <h2>Activity Timeline</h2>
+          <p>One durable trail for Solana scaffolds, terminal sessions, wallet execution, runtime checks, and failures.</p>
+        </div>
+        <div className="activity-hero-actions">
+          <button className="activity-btn" onClick={() => void loadActivity()}>Refresh</button>
+          <button className="activity-btn danger" onClick={() => void clearActivity()} disabled={activity.length === 0}>Clear</button>
+        </div>
+      </header>
+
+      <div className="activity-filter-row" role="tablist" aria-label="Activity filters">
+        {FILTERS.map((item) => (
+          <button
+            key={item.id}
+            role="tab"
+            aria-selected={filter === item.id}
+            className={`activity-filter ${filter === item.id ? 'active' : ''}`}
+            onClick={() => setFilter(item.id)}
+          >
+            <span>{item.label}</span>
+            <strong>{counts[item.id]}</strong>
+          </button>
+        ))}
+      </div>
+
+      <section className="activity-stream" aria-label="Activity stream">
+        {filtered.length === 0 ? (
+          <div className="activity-empty">
+            <span className="activity-empty-title">No matching activity yet</span>
+            <span>Run a scaffold, terminal, wallet action, validator, or runtime check and DAEMON will record it here.</span>
+          </div>
+        ) : (
+          filtered.map((entry) => {
+            const category = classifyActivity(entry)
+            return (
+              <article key={entry.id} className={`activity-entry ${entry.kind}`}>
+                <div className={`activity-dot ${entry.kind}`} />
+                <div className="activity-entry-main">
+                  <div className="activity-entry-top">
+                    <span className="activity-entry-context">{entry.context ?? category}</span>
+                    <span className="activity-entry-category">{category}</span>
+                    <time>{formatTime(entry.createdAt)}</time>
+                  </div>
+                  <div className="activity-entry-message">{entry.message}</div>
+                </div>
+              </article>
+            )
+          })
+        )}
+      </section>
+    </div>
+  )
+}
+
+export default ActivityTimeline

--- a/src/panels/LaunchWizard/LaunchWizard.tsx
+++ b/src/panels/LaunchWizard/LaunchWizard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useUIStore } from '../../store/ui'
 import { useWorkflowShellStore } from '../../store/workflowShell'
+import { useNotificationsStore } from '../../store/notifications'
 import { useTokenLaunch } from './useTokenLaunch'
 import type { LaunchParams } from './useTokenLaunch'
 import './LaunchWizard.css'
@@ -231,9 +232,19 @@ export function LaunchWizard() {
       if (!res.ok || !res.data) {
         setPreflight(null)
         setPreflightError(res.error ?? 'Launch preflight failed')
+        useNotificationsStore.getState().addActivity({
+          kind: 'error',
+          context: 'Runtime',
+          message: res.error ?? `Token launch preflight failed for ${s1.symbol.trim().toUpperCase() || s1.name.trim()}`,
+        })
       } else {
         setPreflight(res.data)
         setPreflightError(null)
+        useNotificationsStore.getState().addActivity({
+          kind: res.data.ready ? 'success' : 'warning',
+          context: 'Runtime',
+          message: `Token launch preflight ${res.data.ready ? 'passed' : 'needs attention'} for ${s1.symbol.trim().toUpperCase() || s1.name.trim()}`,
+        })
       }
       setPreflightLoading(false)
     }

--- a/src/panels/ProjectStarter/ProjectStarter.tsx
+++ b/src/panels/ProjectStarter/ProjectStarter.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { useUIStore } from '../../store/ui'
 import { useWorkflowShellStore } from '../../store/workflowShell'
+import { useNotificationsStore } from '../../store/notifications'
 import './ProjectStarter.css'
 
 // --- Template definitions ---
@@ -381,6 +382,11 @@ export function ProjectStarter() {
 
     setWizard((prev) => ({ ...prev, step: 'building' }))
     setError(null)
+    useNotificationsStore.getState().addActivity({
+      kind: 'info',
+      context: 'Scaffold',
+      message: `Started ${wizard.template.name} scaffold for ${name} at ${projectPath}`,
+    })
 
     try {
       // Register the project before using sandboxed filesystem APIs so the
@@ -419,6 +425,11 @@ export function ProjectStarter() {
           `${JSON.stringify(runtimePreset, null, 2)}\n`,
         )
         if (!runtimePresetRes.ok) {
+          useNotificationsStore.getState().addActivity({
+            kind: 'error',
+            context: 'Scaffold',
+            message: runtimePresetRes.error ?? `Failed to write runtime preset for ${name}`,
+          })
           await cleanupProject()
           setError(runtimePresetRes.error ?? 'Failed to write runtime preset')
           setWizard((prev) => ({ ...prev, step: 'configure' }))
@@ -452,14 +463,29 @@ export function ProjectStarter() {
 
       if (termRes.ok && termRes.data) {
         addTerminal(newProject.id, termRes.data.id, `Build: ${name}`, null)
+        useNotificationsStore.getState().addActivity({
+          kind: 'success',
+          context: 'Scaffold',
+          message: `Build agent started for ${name}; runtime preset ${runtimePreset ? 'written' : 'not available'}.`,
+        })
         setCenterMode('canvas')
         closeDrawer()
       } else {
+        useNotificationsStore.getState().addActivity({
+          kind: 'error',
+          context: 'Scaffold',
+          message: termRes.error ?? `Failed to start build agent for ${name}`,
+        })
         await cleanupProject()
         setError(termRes.error ?? 'Failed to start build agent')
         setWizard((prev) => ({ ...prev, step: 'configure' }))
       }
     } catch (err) {
+      useNotificationsStore.getState().addActivity({
+        kind: 'error',
+        context: 'Scaffold',
+        message: err instanceof Error ? err.message : String(err),
+      })
       setError(String(err))
       setWizard((prev) => ({ ...prev, step: 'configure' }))
     }

--- a/src/panels/Terminal/Terminal.tsx
+++ b/src/panels/Terminal/Terminal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback, useMemo, useState } from 'react'
 import { useUIStore } from '../../store/ui'
 import { useWorkflowShellStore } from '../../store/workflowShell'
+import { useNotificationsStore } from '../../store/notifications'
 import { TerminalTabs } from './TerminalTabs'
 import { TerminalInstance } from './TerminalInstance'
 import { readTerminalLaunchRecents, addToRecents, type TerminalLaunchRecent } from './RecentsManager'
@@ -78,8 +79,18 @@ export function TerminalPanel() {
       const res = await window.daemon.terminal.create({ cwd: projectContext.projectPath, startupCommand })
       if (res.ok && res.data) {
         addTerminal(projectContext.projectId, res.data.id, label)
+        useNotificationsStore.getState().addActivity({
+          kind: 'success',
+          context: 'Terminal',
+          message: `Opened ${label} in ${projectContext.projectPath}`,
+        })
         return res.data.id
       }
+      useNotificationsStore.getState().addActivity({
+        kind: 'error',
+        context: 'Terminal',
+        message: res.error ?? `Failed to open ${label}`,
+      })
       setLaunchError(res.error ?? 'Failed to open terminal.')
       return null
     }
@@ -155,6 +166,11 @@ export function TerminalPanel() {
     if (!activeProjectId) return
     await window.daemon.terminal.kill(id)
     removeTerminal(activeProjectId, id)
+    useNotificationsStore.getState().addActivity({
+      kind: 'info',
+      context: 'Terminal',
+      message: `Closed terminal ${id}`,
+    })
     setSplitLayoutsByProject((prev) => {
       const current = prev[activeProjectId]
       if (!current || current.secondaryId !== id) return prev
@@ -185,6 +201,11 @@ export function TerminalPanel() {
         secondaryId = res.data.id
         addTerminal(projectId, secondaryId, 'Split')
         setActiveTerminal(projectId, currentActiveTerminalId)
+        useNotificationsStore.getState().addActivity({
+          kind: 'success',
+          context: 'Terminal',
+          message: `Opened split terminal ${secondaryId}`,
+        })
       } finally {
         splitCreatingRef.current = false
       }

--- a/src/panels/WalletPanel/WalletSwapForm.tsx
+++ b/src/panels/WalletPanel/WalletSwapForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { useNotificationsStore } from '../../store/notifications'
 import './WalletPanel.css'
 import { TransactionPreviewCard } from './TransactionPreviewCard'
 
@@ -146,6 +147,12 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
     setSwapLoading(true)
     setSwapError(null)
     setSwapResult(null)
+    const activity = useNotificationsStore.getState()
+    activity.addActivity({
+      kind: 'info',
+      context: 'Wallet',
+      message: `Executing Jupiter swap for ${amount} from ${inputMint} to ${outputMint}`,
+    })
 
     try {
       const res = await window.daemon.wallet.swapExecute({
@@ -161,15 +168,30 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
 
       if (res.ok && res.data) {
         setSwapResult(res.data)
+        activity.addActivity({
+          kind: 'success',
+          context: 'Wallet',
+          message: `Swap confirmed via ${res.data.transport.toUpperCase()} with signature ${res.data.signature}`,
+        })
         setQuote(null)
         setPendingSwap(null)
         setAmount('')
         await onRefresh()
       } else {
+        activity.addActivity({
+          kind: 'error',
+          context: 'Wallet',
+          message: res.error ?? 'Swap failed',
+        })
         setSwapError(res.error ?? 'Swap failed')
         setPendingSwap(null)
       }
     } catch (err) {
+      activity.addActivity({
+        kind: 'error',
+        context: 'Wallet',
+        message: err instanceof Error ? err.message : 'Swap execution failed',
+      })
       setSwapError(err instanceof Error ? err.message : 'Swap execution failed')
       setPendingSwap(null)
     } finally {

--- a/src/panels/WalletPanel/tabs/WalletTab.tsx
+++ b/src/panels/WalletPanel/tabs/WalletTab.tsx
@@ -337,6 +337,12 @@ export function WalletTab({ onRefresh }: Props) {
   const handleExecuteSend = async () => {
     if (!pendingSend || sendLockRef.current) return
     sendLockRef.current = true
+    const activity = useNotificationsStore.getState()
+    activity.addActivity({
+      kind: 'info',
+      context: 'Wallet',
+      message: `Sending ${pendingSend.sendMax ? 'max' : pendingSend.amount} ${pendingSend.mode === 'sol' ? 'SOL' : 'token'} to ${pendingSend.dest}`,
+    })
     setSendLoading(true)
     setSendError(null)
     try {
@@ -345,9 +351,19 @@ export function WalletTab({ onRefresh }: Props) {
         setPendingSend(null)
         if (res.ok && res.data) {
           setSendResult(res.data)
+          activity.addActivity({
+            kind: 'success',
+            context: 'Wallet',
+            message: `SOL send confirmed via ${res.data.transport.toUpperCase()} with signature ${res.data.signature}`,
+          })
           resetSendState()
           await onRefresh()
         } else {
+          activity.addActivity({
+            kind: 'error',
+            context: 'Wallet',
+            message: res.error ?? 'SOL send failed',
+          })
           setSendError(res.error ?? 'Send failed')
         }
       } else {
@@ -355,9 +371,19 @@ export function WalletTab({ onRefresh }: Props) {
         setPendingSend(null)
         if (res.ok && res.data) {
           setSendResult(res.data)
+          activity.addActivity({
+            kind: 'success',
+            context: 'Wallet',
+            message: `Token send confirmed via ${res.data.transport.toUpperCase()} with signature ${res.data.signature}`,
+          })
           resetSendState()
           await onRefresh()
         } else {
+          activity.addActivity({
+            kind: 'error',
+            context: 'Wallet',
+            message: res.error ?? 'Token send failed',
+          })
           setSendError(res.error ?? 'Send failed')
         }
       }

--- a/src/store/notifications.ts
+++ b/src/store/notifications.ts
@@ -29,6 +29,7 @@ export interface ActivityEntry {
 interface NotificationsState {
   toasts: Toast[]
   activity: ActivityEntry[]
+  addActivity: (input: { kind: ToastKind; message: string; context?: string; createdAt?: number }) => string
   pushToast: (input: { kind: ToastKind; message: string; context?: string; ttlMs?: number; action?: ToastAction }) => string
   pushError: (err: unknown, context?: string) => string
   pushSuccess: (message: string, context?: string) => string
@@ -62,6 +63,18 @@ function persistEntry(entry: ActivityEntry): void {
 export const useNotificationsStore = create<NotificationsState>((set, get) => ({
   toasts: [],
   activity: [],
+
+  addActivity: ({ kind, message, context, createdAt }) => {
+    const id = crypto.randomUUID()
+    const entry: ActivityEntry = { id, kind, message, context: context ?? null, createdAt: createdAt ?? Date.now() }
+
+    set((state) => ({
+      activity: [entry, ...state.activity].slice(0, 500),
+    }))
+
+    persistEntry(entry)
+    return id
+  },
 
   pushToast: ({ kind, message, context, ttlMs, action }) => {
     const id = crypto.randomUUID()

--- a/src/store/solanaToolbox.ts
+++ b/src/store/solanaToolbox.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { daemon } from '../lib/daemonBridge'
+import { useNotificationsStore } from './notifications'
 import { SOLANA_MCP_CATALOG, type SolanaMcpCategory } from '../panels/SolanaToolbox/catalog'
 
 export interface SolanaMcpEntry {
@@ -104,15 +105,35 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
 
   startValidator: async (type) => {
     set({ validator: { type, status: 'starting', terminalId: null, port: null } })
+    useNotificationsStore.getState().addActivity({
+      kind: 'info',
+      context: 'Runtime',
+      message: `Starting ${type} validator`,
+    })
     try {
       const res = await daemon.validator.start(type)
       if (res.ok && res.data) {
         set({ validator: { type, status: 'running', terminalId: res.data.terminalId, port: res.data.port ?? 8899 } })
+        useNotificationsStore.getState().addActivity({
+          kind: 'success',
+          context: 'Runtime',
+          message: `${type} validator running on port ${res.data.port ?? 8899}`,
+        })
       } else {
         set({ validator: { type, status: 'error', terminalId: null, port: null } })
+        useNotificationsStore.getState().addActivity({
+          kind: 'error',
+          context: 'Runtime',
+          message: res.error ?? `${type} validator failed to start`,
+        })
       }
-    } catch {
+    } catch (err) {
       set({ validator: { type, status: 'error', terminalId: null, port: null } })
+      useNotificationsStore.getState().addActivity({
+        kind: 'error',
+        context: 'Runtime',
+        message: err instanceof Error ? err.message : `${type} validator failed to start`,
+      })
     }
   },
 
@@ -121,6 +142,11 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
     if (validator.terminalId) {
       try {
         await daemon.validator.stop()
+        useNotificationsStore.getState().addActivity({
+          kind: 'info',
+          context: 'Runtime',
+          message: `Stopped ${validator.type ?? 'local'} validator`,
+        })
       } catch { /* ignore */ }
     }
     set({ validator: { type: null, status: 'stopped', terminalId: null, port: null } })
@@ -147,6 +173,13 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
       const res = await daemon.validator.detectProject(projectPath)
       if (res.ok && res.data) {
         set({ projectInfo: res.data as SolanaProjectInfo })
+        if (res.data.isSolanaProject) {
+          useNotificationsStore.getState().addActivity({
+            kind: 'success',
+            context: 'Runtime',
+            message: `Detected Solana project${res.data.framework ? ` (${res.data.framework})` : ''} at ${projectPath}`,
+          })
+        }
       } else {
         set({ projectInfo: null })
       }
@@ -160,6 +193,18 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
       const res = await daemon.validator.toolchainStatus(projectPath)
       if (res.ok && res.data) {
         set({ toolchain: res.data as SolanaToolchainStatus })
+        const missing = [
+          res.data.solanaCli.installed ? null : 'Solana CLI',
+          res.data.anchor.installed ? null : 'Anchor',
+          res.data.surfpool.installed ? null : 'Surfpool',
+        ].filter(Boolean)
+        useNotificationsStore.getState().addActivity({
+          kind: missing.length === 0 ? 'success' : 'warning',
+          context: 'Runtime',
+          message: missing.length === 0
+            ? 'Runtime toolchain check passed'
+            : `Runtime toolchain check found missing tools: ${missing.join(', ')}`,
+        })
       } else {
         set({ toolchain: null })
       }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -152,7 +152,7 @@ export const useUIStore = create<UIState>((set) => ({
   launchWizardOpen: false,
   walletQuickViewOpen: false,
   emailQuickViewOpen: false,
-  pinnedTools: ['git', 'browser', 'project-readiness', 'solana-toolbox', 'integrations', 'token-launch', 'pro'],
+  pinnedTools: ['git', 'browser', 'activity', 'project-readiness', 'solana-toolbox', 'integrations', 'token-launch', 'pro'],
   drawerToolOrder: [],
 
   setActivePanel: (panel) => set({ activePanel: panel }),

--- a/test/panels/ActivityTimeline.dom.test.tsx
+++ b/test/panels/ActivityTimeline.dom.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ActivityTimeline } from '../../src/panels/ActivityTimeline/ActivityTimeline'
+import { useNotificationsStore } from '../../src/store/notifications'
+
+function installDaemonBridge() {
+  const append = vi.fn().mockResolvedValue({ ok: true })
+  const list = vi.fn().mockResolvedValue({
+    ok: true,
+    data: [
+      {
+        id: 'remote-1',
+        kind: 'success',
+        message: 'Runtime toolchain check passed',
+        context: 'Runtime',
+        createdAt: 1_700_000_000_000,
+      },
+    ],
+  })
+  const clear = vi.fn().mockResolvedValue({ ok: true })
+
+  Object.defineProperty(window, 'daemon', {
+    configurable: true,
+    value: {
+      activity: { append, list, clear },
+    },
+  })
+
+  return { append, clear, list }
+}
+
+describe('ActivityTimeline', () => {
+  beforeEach(() => {
+    installDaemonBridge()
+    useNotificationsStore.setState({
+      toasts: [],
+      activity: [
+        {
+          id: 'wallet-1',
+          kind: 'success',
+          message: 'Swap confirmed via RPC with signature abc123',
+          context: 'Wallet',
+          createdAt: 1_700_000_000_000,
+        },
+        {
+          id: 'terminal-1',
+          kind: 'info',
+          message: 'Opened Terminal in C:/work/daemon-app',
+          context: 'Terminal',
+          createdAt: 1_700_000_000_100,
+        },
+        {
+          id: 'scaffold-1',
+          kind: 'warning',
+          message: 'Token launch preflight needs attention for TEST',
+          context: 'Runtime',
+          createdAt: 1_700_000_000_200,
+        },
+      ],
+    })
+  })
+
+  it('filters activity by wallet, terminal, runtime, and errors', async () => {
+    render(<ActivityTimeline />)
+
+    expect(screen.getByText('Activity Timeline')).toBeInTheDocument()
+    expect(screen.getByText('Swap confirmed via RPC with signature abc123')).toBeInTheDocument()
+    expect(screen.getByText('Opened Terminal in C:/work/daemon-app')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('tab', { name: /Wallet/ }))
+    expect(screen.getByText('Swap confirmed via RPC with signature abc123')).toBeInTheDocument()
+    expect(screen.queryByText('Opened Terminal in C:/work/daemon-app')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('tab', { name: /Terminal/ }))
+    expect(screen.getByText('Opened Terminal in C:/work/daemon-app')).toBeInTheDocument()
+    expect(screen.queryByText('Swap confirmed via RPC with signature abc123')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('tab', { name: /Errors/ }))
+    expect(screen.getByText('Token launch preflight needs attention for TEST')).toBeInTheDocument()
+    expect(screen.queryByText('Opened Terminal in C:/work/daemon-app')).not.toBeInTheDocument()
+  })
+
+  it('records non-toast activity and can refresh or clear persisted history', async () => {
+    const { append, clear, list } = installDaemonBridge()
+    useNotificationsStore.setState({ toasts: [], activity: [] })
+
+    useNotificationsStore.getState().addActivity({
+      kind: 'success',
+      context: 'Scaffold',
+      message: 'Build agent started for demo',
+      createdAt: 1_700_000_000_000,
+    })
+
+    expect(useNotificationsStore.getState().toasts).toEqual([])
+    expect(append).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'success',
+      context: 'Scaffold',
+      message: 'Build agent started for demo',
+    }))
+
+    render(<ActivityTimeline />)
+    await userEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() => expect(list).toHaveBeenCalledWith(500))
+    expect(await screen.findByText('Runtime toolchain check passed')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear' }))
+    await waitFor(() => expect(clear).toHaveBeenCalled())
+    expect(useNotificationsStore.getState().activity).toEqual([])
+  })
+})

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -114,6 +114,11 @@ function installDaemonBridge() {
   Object.defineProperty(window, 'daemon', {
     configurable: true,
     value: {
+      activity: {
+        append: vi.fn().mockResolvedValue({ ok: true }),
+        list: vi.fn().mockResolvedValue({ ok: true, data: [] }),
+        clear: vi.fn().mockResolvedValue({ ok: true }),
+      },
       claude: {
         projectMcpAll: vi.fn().mockResolvedValue({
           ok: true,
@@ -291,6 +296,7 @@ describe('App surface DOM coverage', () => {
     expect(screen.getByText('Solana')).toBeInTheDocument()
     expect(screen.getByText('Integrations')).toBeInTheDocument()
     expect(screen.getByText('Project Readiness')).toBeInTheDocument()
+    expect(screen.getByText('Activity')).toBeInTheDocument()
 
     await userEvent.type(screen.getByPlaceholderText('Search tools...'), 'solana')
     await userEvent.click(screen.getByText('Solana').closest('button')!)

--- a/test/panels/TerminalPanel.dom.test.tsx
+++ b/test/panels/TerminalPanel.dom.test.tsx
@@ -27,6 +27,9 @@ function installDaemonBridge(createTerminal = vi.fn()) {
   Object.defineProperty(window, 'daemon', {
     configurable: true,
     value: {
+      activity: {
+        append: vi.fn().mockResolvedValue({ ok: true }),
+      },
       agents: {
         list: vi.fn().mockResolvedValue({ ok: true, data: [] }),
       },


### PR DESCRIPTION
## Summary
- add a pinned Activity tool that renders DAEMON's persisted activity log as a Solana development flight recorder
- add non-toast activity recording for durable background events
- record terminal, scaffold, runtime/validator, launch preflight, wallet send, and swap activity
- add timeline filtering for All, Wallet, Runtime, Terminal, Scaffold, and Errors

## Tests
- pnpm run typecheck
- pnpm test

Closes #115