### PR TITLE
feat: add v3 execution sessions

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3'
-import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25 } from './schema'
+import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25, SCHEMA_V26 } from './schema'
 
 export function runMigrations(db: Database.Database) {
   db.exec(`
@@ -276,6 +276,19 @@ export function runMigrations(db: Database.Database) {
         }
       }
       db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(25)
+    })()
+  }
+
+  if (currentVersion < 26) {
+    db.transaction(() => {
+      const stmts = SCHEMA_V26.split(';').map((s) => s.trim()).filter(Boolean)
+      for (const stmt of stmts) {
+        try { db.exec(stmt) } catch (err) {
+          const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
+          if (!msg.includes('duplicate column') && !msg.includes('already exists')) throw err
+        }
+      }
+      db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(26)
     })()
   }
 

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -552,3 +552,12 @@ CREATE TABLE IF NOT EXISTS pro_state (
   updated_at INTEGER NOT NULL
 );
 `
+
+export const SCHEMA_V26 = `
+ALTER TABLE activity_log ADD COLUMN session_id TEXT;
+ALTER TABLE activity_log ADD COLUMN session_status TEXT CHECK(session_status IN ('created','running','blocked','failed','complete') OR session_status IS NULL);
+ALTER TABLE activity_log ADD COLUMN project_id TEXT;
+ALTER TABLE activity_log ADD COLUMN project_name TEXT;
+CREATE INDEX IF NOT EXISTS idx_activity_log_session_id ON activity_log(session_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_log_project_id ON activity_log(project_id, created_at DESC);
+`

--- a/electron/ipc/activity.ts
+++ b/electron/ipc/activity.ts
@@ -8,6 +8,10 @@ interface ActivityEntryInput {
   message: string
   context: string | null
   createdAt: number
+  sessionId?: string | null
+  sessionStatus?: 'created' | 'running' | 'blocked' | 'failed' | 'complete' | null
+  projectId?: string | null
+  projectName?: string | null
 }
 
 interface ActivityRow {
@@ -16,11 +20,17 @@ interface ActivityRow {
   message: string
   context: string | null
   created_at: number
+  session_id: string | null
+  session_status: 'created' | 'running' | 'blocked' | 'failed' | 'complete' | null
+  project_id: string | null
+  project_name: string | null
 }
 
 const VALID_KINDS = new Set(['info', 'success', 'warning', 'error'])
+const VALID_SESSION_STATUSES = new Set(['created', 'running', 'blocked', 'failed', 'complete'])
 const MAX_MESSAGE_LEN = 2000
 const MAX_CONTEXT_LEN = 200
+const MAX_METADATA_LEN = 200
 const MAX_ROWS = 1000
 
 export function registerActivityHandlers() {
@@ -28,15 +38,24 @@ export function registerActivityHandlers() {
     if (!entry?.id || !entry.message || !VALID_KINDS.has(entry.kind)) {
       throw new Error('Invalid activity entry')
     }
+    const sessionStatus = entry.sessionStatus && VALID_SESSION_STATUSES.has(entry.sessionStatus)
+      ? entry.sessionStatus
+      : null
     const db = getDb()
     db.prepare(
-      'INSERT OR IGNORE INTO activity_log (id, kind, message, context, created_at) VALUES (?,?,?,?,?)'
+      `INSERT OR IGNORE INTO activity_log (
+        id, kind, message, context, created_at, session_id, session_status, project_id, project_name
+      ) VALUES (?,?,?,?,?,?,?,?,?)`
     ).run(
       entry.id,
       entry.kind,
       entry.message.slice(0, MAX_MESSAGE_LEN),
       entry.context ? entry.context.slice(0, MAX_CONTEXT_LEN) : null,
       entry.createdAt,
+      entry.sessionId ? entry.sessionId.slice(0, MAX_METADATA_LEN) : null,
+      sessionStatus,
+      entry.projectId ? entry.projectId.slice(0, MAX_METADATA_LEN) : null,
+      entry.projectName ? entry.projectName.slice(0, MAX_METADATA_LEN) : null,
     )
 
     // Trim oldest entries beyond MAX_ROWS to prevent unbounded growth
@@ -51,7 +70,8 @@ export function registerActivityHandlers() {
     const db = getDb()
     const safeLimit = Math.min(Math.max(1, limit ?? 500), MAX_ROWS)
     const rows = db.prepare(
-      'SELECT id, kind, message, context, created_at FROM activity_log ORDER BY created_at DESC LIMIT ?'
+      `SELECT id, kind, message, context, created_at, session_id, session_status, project_id, project_name
+       FROM activity_log ORDER BY created_at DESC LIMIT ?`
     ).all(safeLimit) as ActivityRow[]
     return rows.map((r) => ({
       id: r.id,
@@ -59,6 +79,10 @@ export function registerActivityHandlers() {
       message: r.message,
       context: r.context,
       createdAt: r.created_at,
+      sessionId: r.session_id,
+      sessionStatus: r.session_status,
+      projectId: r.project_id,
+      projectName: r.project_name,
     }))
   }))
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -143,7 +143,17 @@ contextBridge.exposeInMainWorld('daemon', {
   },
 
   activity: {
-    append: (entry: { id: string; kind: string; message: string; context: string | null; createdAt: number }) =>
+    append: (entry: {
+      id: string
+      kind: string
+      message: string
+      context: string | null
+      createdAt: number
+      sessionId?: string | null
+      sessionStatus?: string | null
+      projectId?: string | null
+      projectName?: string | null
+    }) =>
       ipcRenderer.invoke('activity:append', entry),
     list: (limit?: number) => ipcRenderer.invoke('activity:list', limit),
     clear: () => ipcRenderer.invoke('activity:clear'),

--- a/src/panels/ActivityTimeline/ActivityTimeline.css
+++ b/src/panels/ActivityTimeline/ActivityTimeline.css
@@ -102,6 +102,81 @@
   gap: 10px;
 }
 
+.activity-session {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(2, 6, 23, 0.62), rgba(15, 23, 42, 0.5));
+}
+
+.activity-session.problem {
+  border-color: rgba(250, 204, 21, 0.26);
+}
+
+.activity-session-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 2px 4px 8px;
+}
+
+.activity-session-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.activity-session-subtitle {
+  max-width: 920px;
+  margin-top: 4px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.activity-session-status {
+  padding: 4px 9px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+  color: var(--text-tertiary);
+  background: rgba(15, 23, 42, 0.78);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.activity-session-status.running,
+.activity-session-status.complete {
+  color: #14f195;
+  border-color: rgba(20, 241, 149, 0.35);
+  background: rgba(20, 241, 149, 0.09);
+}
+
+.activity-session-status.created {
+  color: #67e8f9;
+  border-color: rgba(103, 232, 249, 0.28);
+}
+
+.activity-session-status.blocked {
+  color: #facc15;
+  border-color: rgba(250, 204, 21, 0.35);
+}
+
+.activity-session-status.failed {
+  color: #fca5a5;
+  border-color: rgba(248, 113, 113, 0.38);
+  background: rgba(248, 113, 113, 0.08);
+}
+
+.activity-session-events {
+  display: grid;
+  gap: 8px;
+}
+
 .activity-entry {
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr);

--- a/src/panels/ActivityTimeline/ActivityTimeline.tsx
+++ b/src/panels/ActivityTimeline/ActivityTimeline.tsx
@@ -36,6 +36,69 @@ function matchesFilter(entry: ActivityEntry, filter: ActivityFilter): boolean {
   return classifyActivity(entry) === filter
 }
 
+type ActivitySessionGroup = {
+  id: string
+  title: string
+  status: NonNullable<ActivityEntry['sessionStatus']> | 'activity'
+  projectName: string | null
+  entries: ActivityEntry[]
+  latestAt: number
+  hasProblems: boolean
+}
+
+function deriveSessionStatus(entries: ActivityEntry[]): ActivitySessionGroup['status'] {
+  const statuses = entries.map((entry) => entry.sessionStatus).filter(Boolean)
+  if (statuses.includes('failed')) return 'failed'
+  if (statuses.includes('blocked')) return 'blocked'
+  if (statuses.includes('complete')) return 'complete'
+  if (statuses.includes('running')) return 'running'
+  if (statuses.includes('created')) return 'created'
+  return 'activity'
+}
+
+function groupActivity(entries: ActivityEntry[]): ActivitySessionGroup[] {
+  const bySession = new Map<string, ActivityEntry[]>()
+  const standalone: ActivityEntry[] = []
+
+  for (const entry of entries) {
+    if (entry.sessionId) {
+      bySession.set(entry.sessionId, [...(bySession.get(entry.sessionId) ?? []), entry])
+    } else {
+      standalone.push(entry)
+    }
+  }
+
+  const groups: ActivitySessionGroup[] = []
+  for (const [sessionId, sessionEntries] of bySession) {
+    const sorted = [...sessionEntries].sort((a, b) => b.createdAt - a.createdAt)
+    const first = sorted[sorted.length - 1]
+    const projectName = sorted.find((entry) => entry.projectName)?.projectName ?? null
+    groups.push({
+      id: sessionId,
+      title: first?.message ?? 'Execution session',
+      status: deriveSessionStatus(sorted),
+      projectName,
+      entries: sorted,
+      latestAt: sorted[0]?.createdAt ?? 0,
+      hasProblems: sorted.some((entry) => entry.kind === 'error' || entry.kind === 'warning'),
+    })
+  }
+
+  for (const entry of standalone) {
+    groups.push({
+      id: entry.id,
+      title: entry.message,
+      status: 'activity',
+      projectName: entry.projectName ?? null,
+      entries: [entry],
+      latestAt: entry.createdAt,
+      hasProblems: entry.kind === 'error' || entry.kind === 'warning',
+    })
+  }
+
+  return groups.sort((a, b) => b.latestAt - a.latestAt)
+}
+
 export function ActivityTimeline() {
   const activity = useNotificationsStore((s) => s.activity)
   const loadActivity = useNotificationsStore((s) => s.loadActivity)
@@ -46,6 +109,7 @@ export function ActivityTimeline() {
     () => activity.filter((entry) => matchesFilter(entry, filter)),
     [activity, filter],
   )
+  const grouped = useMemo(() => groupActivity(filtered), [filtered])
 
   const counts = useMemo(() => {
     const next: Record<ActivityFilter, number> = {
@@ -94,28 +158,41 @@ export function ActivityTimeline() {
       </div>
 
       <section className="activity-stream" aria-label="Activity stream">
-        {filtered.length === 0 ? (
+        {grouped.length === 0 ? (
           <div className="activity-empty">
             <span className="activity-empty-title">No matching activity yet</span>
             <span>Run a scaffold, terminal, wallet action, validator, or runtime check and DAEMON will record it here.</span>
           </div>
         ) : (
-          filtered.map((entry) => {
-            const category = classifyActivity(entry)
-            return (
-              <article key={entry.id} className={`activity-entry ${entry.kind}`}>
-                <div className={`activity-dot ${entry.kind}`} />
-                <div className="activity-entry-main">
-                  <div className="activity-entry-top">
-                    <span className="activity-entry-context">{entry.context ?? category}</span>
-                    <span className="activity-entry-category">{category}</span>
-                    <time>{formatTime(entry.createdAt)}</time>
-                  </div>
-                  <div className="activity-entry-message">{entry.message}</div>
+          grouped.map((group) => (
+            <article key={group.id} className={`activity-session ${group.hasProblems ? 'problem' : ''}`}>
+              <header className="activity-session-header">
+                <div>
+                  <div className="activity-session-title">{group.projectName ?? 'DAEMON execution'}</div>
+                  <div className="activity-session-subtitle">{group.title}</div>
                 </div>
-              </article>
-            )
-          })
+                <div className={`activity-session-status ${group.status}`}>{group.status}</div>
+              </header>
+              <div className="activity-session-events">
+                {group.entries.map((entry) => {
+                  const category = classifyActivity(entry)
+                  return (
+                    <div key={entry.id} className={`activity-entry ${entry.kind}`}>
+                      <div className={`activity-dot ${entry.kind}`} />
+                      <div className="activity-entry-main">
+                        <div className="activity-entry-top">
+                          <span className="activity-entry-context">{entry.context ?? category}</span>
+                          <span className="activity-entry-category">{category}</span>
+                          <time>{formatTime(entry.createdAt)}</time>
+                        </div>
+                        <div className="activity-entry-message">{entry.message}</div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </article>
+          ))
         )}
       </section>
     </div>

--- a/src/panels/LaunchWizard/LaunchWizard.tsx
+++ b/src/panels/LaunchWizard/LaunchWizard.tsx
@@ -59,6 +59,9 @@ function phaseIndex(phase: string): number {
 export function LaunchWizard() {
   const closeLaunchWizard = useWorkflowShellStore((s) => s.closeLaunchWizard)
   const activeProjectId = useUIStore((s) => s.activeProjectId)
+  const activeProjectName = useUIStore((s) => (
+    s.activeProjectId ? s.projects.find((project) => project.id === s.activeProjectId)?.name ?? null : null
+  ))
   const overlayRef = useRef<HTMLDivElement>(null)
 
   const [step, setStep] = useState<Step>(1)
@@ -236,6 +239,8 @@ export function LaunchWizard() {
           kind: 'error',
           context: 'Runtime',
           message: res.error ?? `Token launch preflight failed for ${s1.symbol.trim().toUpperCase() || s1.name.trim()}`,
+          projectId: activeProjectId,
+          projectName: activeProjectName,
         })
       } else {
         setPreflight(res.data)
@@ -244,6 +249,8 @@ export function LaunchWizard() {
           kind: res.data.ready ? 'success' : 'warning',
           context: 'Runtime',
           message: `Token launch preflight ${res.data.ready ? 'passed' : 'needs attention'} for ${s1.symbol.trim().toUpperCase() || s1.name.trim()}`,
+          projectId: activeProjectId,
+          projectName: activeProjectName,
         })
       }
       setPreflightLoading(false)
@@ -268,6 +275,7 @@ export function LaunchWizard() {
     s1.telegram,
     s1.website,
     activeProjectId,
+    activeProjectName,
     s2BuySol,
     s2Priority,
   ])

--- a/src/panels/ProjectStarter/ProjectStarter.tsx
+++ b/src/panels/ProjectStarter/ProjectStarter.tsx
@@ -379,6 +379,7 @@ export function ProjectStarter() {
 
     const name = wizard.projectName.trim()
     const projectPath = `${wizard.savePath}/${name}`
+    const sessionId = `scaffold-${crypto.randomUUID()}`
 
     setWizard((prev) => ({ ...prev, step: 'building' }))
     setError(null)
@@ -386,6 +387,9 @@ export function ProjectStarter() {
       kind: 'info',
       context: 'Scaffold',
       message: `Started ${wizard.template.name} scaffold for ${name} at ${projectPath}`,
+      sessionId,
+      sessionStatus: 'created',
+      projectName: name,
     })
 
     try {
@@ -393,6 +397,14 @@ export function ProjectStarter() {
       // target path is treated as a valid project root during scaffolding.
       const projRes = await window.daemon.projects.create({ name, path: projectPath })
       if (!projRes.ok || !projRes.data) {
+        useNotificationsStore.getState().addActivity({
+          kind: 'error',
+          context: 'Scaffold',
+          message: projRes.error ?? `Failed to register project ${name}`,
+          sessionId,
+          sessionStatus: 'failed',
+          projectName: name,
+        })
         setError(projRes.error ?? 'Failed to register project')
         setWizard((prev) => ({ ...prev, step: 'configure' }))
         return
@@ -405,6 +417,15 @@ export function ProjectStarter() {
 
       const mkdirRes = await window.daemon.fs.createDir(projectPath)
       if (!mkdirRes.ok) {
+        useNotificationsStore.getState().addActivity({
+          kind: 'error',
+          context: 'Scaffold',
+          message: mkdirRes.error ?? `Failed to create project directory for ${name}`,
+          sessionId,
+          sessionStatus: 'failed',
+          projectId: newProject.id,
+          projectName: name,
+        })
         await cleanupProject()
         setError(mkdirRes.error ?? 'Failed to create directory')
         setWizard((prev) => ({ ...prev, step: 'configure' }))
@@ -429,6 +450,10 @@ export function ProjectStarter() {
             kind: 'error',
             context: 'Scaffold',
             message: runtimePresetRes.error ?? `Failed to write runtime preset for ${name}`,
+            sessionId,
+            sessionStatus: 'failed',
+            projectId: newProject.id,
+            projectName: name,
           })
           await cleanupProject()
           setError(runtimePresetRes.error ?? 'Failed to write runtime preset')
@@ -467,6 +492,10 @@ export function ProjectStarter() {
           kind: 'success',
           context: 'Scaffold',
           message: `Build agent started for ${name}; runtime preset ${runtimePreset ? 'written' : 'not available'}.`,
+          sessionId,
+          sessionStatus: 'running',
+          projectId: newProject.id,
+          projectName: name,
         })
         setCenterMode('canvas')
         closeDrawer()
@@ -475,6 +504,10 @@ export function ProjectStarter() {
           kind: 'error',
           context: 'Scaffold',
           message: termRes.error ?? `Failed to start build agent for ${name}`,
+          sessionId,
+          sessionStatus: 'failed',
+          projectId: newProject.id,
+          projectName: name,
         })
         await cleanupProject()
         setError(termRes.error ?? 'Failed to start build agent')
@@ -485,6 +518,9 @@ export function ProjectStarter() {
         kind: 'error',
         context: 'Scaffold',
         message: err instanceof Error ? err.message : String(err),
+        sessionId,
+        sessionStatus: 'failed',
+        projectName: name,
       })
       setError(String(err))
       setWizard((prev) => ({ ...prev, step: 'configure' }))

--- a/src/panels/Terminal/Terminal.tsx
+++ b/src/panels/Terminal/Terminal.tsx
@@ -49,7 +49,11 @@ export function TerminalPanel() {
 
   const resolveProjectContext = useCallback(() => {
     if (activeProjectId && activeProjectPath) {
-      return { projectId: activeProjectId, projectPath: activeProjectPath }
+      return {
+        projectId: activeProjectId,
+        projectPath: activeProjectPath,
+        projectName: projects.find((project) => project.id === activeProjectId)?.name ?? null,
+      }
     }
     if (projects.length === 0) {
       setLaunchError('Open or create a project first to start a terminal.')
@@ -62,7 +66,7 @@ export function TerminalPanel() {
     }
     setActiveProject(fallback.id, fallback.path)
     setLaunchError(null)
-    return { projectId: fallback.id, projectPath: fallback.path }
+    return { projectId: fallback.id, projectPath: fallback.path, projectName: fallback.name ?? null }
   }, [activeProjectId, activeProjectPath, projects, setActiveProject])
 
   const handleNewTerminal = useCallback(async (
@@ -83,6 +87,8 @@ export function TerminalPanel() {
           kind: 'success',
           context: 'Terminal',
           message: `Opened ${label} in ${projectContext.projectPath}`,
+          projectId: projectContext.projectId,
+          projectName: projectContext.projectName,
         })
         return res.data.id
       }
@@ -90,6 +96,8 @@ export function TerminalPanel() {
         kind: 'error',
         context: 'Terminal',
         message: res.error ?? `Failed to open ${label}`,
+        projectId: projectContext.projectId,
+        projectName: projectContext.projectName,
       })
       setLaunchError(res.error ?? 'Failed to open terminal.')
       return null
@@ -170,13 +178,15 @@ export function TerminalPanel() {
       kind: 'info',
       context: 'Terminal',
       message: `Closed terminal ${id}`,
+      projectId: activeProjectId,
+      projectName: projects.find((project) => project.id === activeProjectId)?.name ?? null,
     })
     setSplitLayoutsByProject((prev) => {
       const current = prev[activeProjectId]
       if (!current || current.secondaryId !== id) return prev
       return { ...prev, [activeProjectId]: undefined }
     })
-  }, [activeProjectId, removeTerminal])
+  }, [activeProjectId, projects, removeTerminal])
 
   const handleSplit = useCallback(async (direction: 'horizontal' | 'vertical') => {
     if (splitCreatingRef.current) return
@@ -205,6 +215,8 @@ export function TerminalPanel() {
           kind: 'success',
           context: 'Terminal',
           message: `Opened split terminal ${secondaryId}`,
+          projectId,
+          projectName: projectContext.projectName,
         })
       } finally {
         splitCreatingRef.current = false

--- a/src/panels/WalletPanel/WalletSwapForm.tsx
+++ b/src/panels/WalletPanel/WalletSwapForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNotificationsStore } from '../../store/notifications'
+import { useUIStore } from '../../store/ui'
 import './WalletPanel.css'
 import { TransactionPreviewCard } from './TransactionPreviewCard'
 
@@ -50,6 +51,10 @@ interface PendingSwap {
 }
 
 export function WalletSwapForm({ walletId, walletName, holdings, executionMode, initialInputMint, initialOutputMint, onBack, onRefresh }: WalletSwapFormProps) {
+  const activeProjectId = useUIStore((s) => s.activeProjectId)
+  const activeProjectName = useUIStore((s) => (
+    s.activeProjectId ? s.projects.find((project) => project.id === s.activeProjectId)?.name ?? null : null
+  ))
   const [inputMint, setInputMint] = useState(initialInputMint ?? SOL_MINT)
   const [outputMint, setOutputMint] = useState(initialOutputMint ?? USDC_MINT)
   const [amount, setAmount] = useState('')
@@ -152,6 +157,8 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
       kind: 'info',
       context: 'Wallet',
       message: `Executing Jupiter swap for ${amount} from ${inputMint} to ${outputMint}`,
+      projectId: activeProjectId,
+      projectName: activeProjectName,
     })
 
     try {
@@ -172,6 +179,8 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
           kind: 'success',
           context: 'Wallet',
           message: `Swap confirmed via ${res.data.transport.toUpperCase()} with signature ${res.data.signature}`,
+          projectId: activeProjectId,
+          projectName: activeProjectName,
         })
         setQuote(null)
         setPendingSwap(null)
@@ -182,6 +191,8 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
           kind: 'error',
           context: 'Wallet',
           message: res.error ?? 'Swap failed',
+          projectId: activeProjectId,
+          projectName: activeProjectName,
         })
         setSwapError(res.error ?? 'Swap failed')
         setPendingSwap(null)
@@ -191,6 +202,8 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
         kind: 'error',
         context: 'Wallet',
         message: err instanceof Error ? err.message : 'Swap execution failed',
+        projectId: activeProjectId,
+        projectName: activeProjectName,
       })
       setSwapError(err instanceof Error ? err.message : 'Swap execution failed')
       setPendingSwap(null)

--- a/src/panels/WalletPanel/tabs/WalletTab.tsx
+++ b/src/panels/WalletPanel/tabs/WalletTab.tsx
@@ -20,6 +20,9 @@ type ManageCreateTab = 'import' | 'generate'
 
 export function WalletTab({ onRefresh }: Props) {
   const activeProjectId = useUIStore((s) => s.activeProjectId)
+  const activeProjectName = useUIStore((s) => (
+    s.activeProjectId ? s.projects.find((project) => project.id === s.activeProjectId)?.name ?? null : null
+  ))
   const dashboard = useWalletStore((s) => s.dashboard)!
   const showMarketTape = useWalletStore((s) => s.showMarketTape)
   const showTitlebarWallet = useWalletStore((s) => s.showTitlebarWallet)
@@ -342,6 +345,8 @@ export function WalletTab({ onRefresh }: Props) {
       kind: 'info',
       context: 'Wallet',
       message: `Sending ${pendingSend.sendMax ? 'max' : pendingSend.amount} ${pendingSend.mode === 'sol' ? 'SOL' : 'token'} to ${pendingSend.dest}`,
+      projectId: activeProjectId,
+      projectName: activeProjectName,
     })
     setSendLoading(true)
     setSendError(null)
@@ -355,6 +360,8 @@ export function WalletTab({ onRefresh }: Props) {
             kind: 'success',
             context: 'Wallet',
             message: `SOL send confirmed via ${res.data.transport.toUpperCase()} with signature ${res.data.signature}`,
+            projectId: activeProjectId,
+            projectName: activeProjectName,
           })
           resetSendState()
           await onRefresh()
@@ -363,6 +370,8 @@ export function WalletTab({ onRefresh }: Props) {
             kind: 'error',
             context: 'Wallet',
             message: res.error ?? 'SOL send failed',
+            projectId: activeProjectId,
+            projectName: activeProjectName,
           })
           setSendError(res.error ?? 'Send failed')
         }
@@ -375,6 +384,8 @@ export function WalletTab({ onRefresh }: Props) {
             kind: 'success',
             context: 'Wallet',
             message: `Token send confirmed via ${res.data.transport.toUpperCase()} with signature ${res.data.signature}`,
+            projectId: activeProjectId,
+            projectName: activeProjectName,
           })
           resetSendState()
           await onRefresh()
@@ -383,6 +394,8 @@ export function WalletTab({ onRefresh }: Props) {
             kind: 'error',
             context: 'Wallet',
             message: res.error ?? 'Token send failed',
+            projectId: activeProjectId,
+            projectName: activeProjectName,
           })
           setSendError(res.error ?? 'Send failed')
         }

--- a/src/store/notifications.ts
+++ b/src/store/notifications.ts
@@ -24,12 +24,25 @@ export interface ActivityEntry {
   message: string
   context: string | null
   createdAt: number
+  sessionId?: string | null
+  sessionStatus?: 'created' | 'running' | 'blocked' | 'failed' | 'complete' | null
+  projectId?: string | null
+  projectName?: string | null
 }
 
 interface NotificationsState {
   toasts: Toast[]
   activity: ActivityEntry[]
-  addActivity: (input: { kind: ToastKind; message: string; context?: string; createdAt?: number }) => string
+  addActivity: (input: {
+    kind: ToastKind
+    message: string
+    context?: string
+    createdAt?: number
+    sessionId?: string | null
+    sessionStatus?: ActivityEntry['sessionStatus']
+    projectId?: string | null
+    projectName?: string | null
+  }) => string
   pushToast: (input: { kind: ToastKind; message: string; context?: string; ttlMs?: number; action?: ToastAction }) => string
   pushError: (err: unknown, context?: string) => string
   pushSuccess: (message: string, context?: string) => string
@@ -57,6 +70,10 @@ function persistEntry(entry: ActivityEntry): void {
     message: entry.message,
     context: entry.context,
     createdAt: entry.createdAt,
+    sessionId: entry.sessionId ?? null,
+    sessionStatus: entry.sessionStatus ?? null,
+    projectId: entry.projectId ?? null,
+    projectName: entry.projectName ?? null,
   }).catch(() => { /* non-fatal */ })
 }
 
@@ -64,9 +81,19 @@ export const useNotificationsStore = create<NotificationsState>((set, get) => ({
   toasts: [],
   activity: [],
 
-  addActivity: ({ kind, message, context, createdAt }) => {
+  addActivity: ({ kind, message, context, createdAt, sessionId, sessionStatus, projectId, projectName }) => {
     const id = crypto.randomUUID()
-    const entry: ActivityEntry = { id, kind, message, context: context ?? null, createdAt: createdAt ?? Date.now() }
+    const entry: ActivityEntry = {
+      id,
+      kind,
+      message,
+      context: context ?? null,
+      createdAt: createdAt ?? Date.now(),
+      sessionId: sessionId ?? null,
+      sessionStatus: sessionStatus ?? null,
+      projectId: projectId ?? null,
+      projectName: projectName ?? null,
+    }
 
     set((state) => ({
       activity: [entry, ...state.activity].slice(0, 500),

--- a/src/store/solanaToolbox.ts
+++ b/src/store/solanaToolbox.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { daemon } from '../lib/daemonBridge'
 import { useNotificationsStore } from './notifications'
+import { useUIStore } from './ui'
 import { SOLANA_MCP_CATALOG, type SolanaMcpCategory } from '../panels/SolanaToolbox/catalog'
 
 export interface SolanaMcpEntry {
@@ -57,6 +58,14 @@ interface SolanaToolboxState {
 
 const SOLANA_MCP_NAMES = Object.keys(SOLANA_MCP_CATALOG)
 
+function getActiveProjectActivityContext() {
+  const { activeProjectId, projects } = useUIStore.getState()
+  return {
+    projectId: activeProjectId,
+    projectName: activeProjectId ? projects.find((project) => project.id === activeProjectId)?.name ?? null : null,
+  }
+}
+
 export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
   mcps: [],
   validator: { type: null, status: 'stopped', terminalId: null, port: null },
@@ -105,10 +114,12 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
 
   startValidator: async (type) => {
     set({ validator: { type, status: 'starting', terminalId: null, port: null } })
+    const projectContext = getActiveProjectActivityContext()
     useNotificationsStore.getState().addActivity({
       kind: 'info',
       context: 'Runtime',
       message: `Starting ${type} validator`,
+      ...projectContext,
     })
     try {
       const res = await daemon.validator.start(type)
@@ -118,6 +129,7 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
           kind: 'success',
           context: 'Runtime',
           message: `${type} validator running on port ${res.data.port ?? 8899}`,
+          ...projectContext,
         })
       } else {
         set({ validator: { type, status: 'error', terminalId: null, port: null } })
@@ -125,6 +137,7 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
           kind: 'error',
           context: 'Runtime',
           message: res.error ?? `${type} validator failed to start`,
+          ...projectContext,
         })
       }
     } catch (err) {
@@ -133,12 +146,14 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
         kind: 'error',
         context: 'Runtime',
         message: err instanceof Error ? err.message : `${type} validator failed to start`,
+        ...projectContext,
       })
     }
   },
 
   stopValidator: async () => {
     const { validator } = get()
+    const projectContext = getActiveProjectActivityContext()
     if (validator.terminalId) {
       try {
         await daemon.validator.stop()
@@ -146,6 +161,7 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
           kind: 'info',
           context: 'Runtime',
           message: `Stopped ${validator.type ?? 'local'} validator`,
+          ...projectContext,
         })
       } catch { /* ignore */ }
     }
@@ -178,6 +194,7 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
             kind: 'success',
             context: 'Runtime',
             message: `Detected Solana project${res.data.framework ? ` (${res.data.framework})` : ''} at ${projectPath}`,
+            ...getActiveProjectActivityContext(),
           })
         }
       } else {
@@ -204,6 +221,7 @@ export const useSolanaToolboxStore = create<SolanaToolboxState>((set, get) => ({
           message: missing.length === 0
             ? 'Runtime toolchain check passed'
             : `Runtime toolchain check found missing tools: ${missing.join(', ')}`,
+          ...getActiveProjectActivityContext(),
         })
       } else {
         set({ toolchain: null })

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -920,6 +920,10 @@ declare global {
     message: string
     context: string | null
     createdAt: number
+    sessionId?: string | null
+    sessionStatus?: 'created' | 'running' | 'blocked' | 'failed' | 'complete' | null
+    projectId?: string | null
+    projectName?: string | null
   }
 
   interface DaemonActivity {

--- a/test/panels/ActivityTimeline.dom.test.tsx
+++ b/test/panels/ActivityTimeline.dom.test.tsx
@@ -11,13 +11,17 @@ function installDaemonBridge() {
   const list = vi.fn().mockResolvedValue({
     ok: true,
     data: [
-      {
-        id: 'remote-1',
-        kind: 'success',
-        message: 'Runtime toolchain check passed',
-        context: 'Runtime',
-        createdAt: 1_700_000_000_000,
-      },
+        {
+          id: 'remote-1',
+          kind: 'success',
+          message: 'Runtime toolchain check passed',
+          context: 'Runtime',
+          createdAt: 1_700_000_000_000,
+          sessionId: null,
+          sessionStatus: null,
+          projectId: null,
+          projectName: null,
+        },
     ],
   })
   const clear = vi.fn().mockResolvedValue({ ok: true })
@@ -44,6 +48,10 @@ describe('ActivityTimeline', () => {
           message: 'Swap confirmed via RPC with signature abc123',
           context: 'Wallet',
           createdAt: 1_700_000_000_000,
+          sessionId: null,
+          sessionStatus: null,
+          projectId: null,
+          projectName: null,
         },
         {
           id: 'terminal-1',
@@ -51,6 +59,10 @@ describe('ActivityTimeline', () => {
           message: 'Opened Terminal in C:/work/daemon-app',
           context: 'Terminal',
           createdAt: 1_700_000_000_100,
+          sessionId: null,
+          sessionStatus: null,
+          projectId: 'project-1',
+          projectName: 'daemon-app',
         },
         {
           id: 'scaffold-1',
@@ -58,6 +70,10 @@ describe('ActivityTimeline', () => {
           message: 'Token launch preflight needs attention for TEST',
           context: 'Runtime',
           createdAt: 1_700_000_000_200,
+          sessionId: null,
+          sessionStatus: null,
+          projectId: null,
+          projectName: null,
         },
       ],
     })
@@ -67,19 +83,19 @@ describe('ActivityTimeline', () => {
     render(<ActivityTimeline />)
 
     expect(screen.getByText('Activity Timeline')).toBeInTheDocument()
-    expect(screen.getByText('Swap confirmed via RPC with signature abc123')).toBeInTheDocument()
-    expect(screen.getByText('Opened Terminal in C:/work/daemon-app')).toBeInTheDocument()
+    expect(screen.getAllByText('Swap confirmed via RPC with signature abc123').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Opened Terminal in C:/work/daemon-app').length).toBeGreaterThan(0)
 
     await userEvent.click(screen.getByRole('tab', { name: /Wallet/ }))
-    expect(screen.getByText('Swap confirmed via RPC with signature abc123')).toBeInTheDocument()
+    expect(screen.getAllByText('Swap confirmed via RPC with signature abc123').length).toBeGreaterThan(0)
     expect(screen.queryByText('Opened Terminal in C:/work/daemon-app')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('tab', { name: /Terminal/ }))
-    expect(screen.getByText('Opened Terminal in C:/work/daemon-app')).toBeInTheDocument()
+    expect(screen.getAllByText('Opened Terminal in C:/work/daemon-app').length).toBeGreaterThan(0)
     expect(screen.queryByText('Swap confirmed via RPC with signature abc123')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('tab', { name: /Errors/ }))
-    expect(screen.getByText('Token launch preflight needs attention for TEST')).toBeInTheDocument()
+    expect(screen.getAllByText('Token launch preflight needs attention for TEST').length).toBeGreaterThan(0)
     expect(screen.queryByText('Opened Terminal in C:/work/daemon-app')).not.toBeInTheDocument()
   })
 
@@ -92,6 +108,10 @@ describe('ActivityTimeline', () => {
       context: 'Scaffold',
       message: 'Build agent started for demo',
       createdAt: 1_700_000_000_000,
+      sessionId: 'scaffold-demo',
+      sessionStatus: 'running',
+      projectId: 'project-demo',
+      projectName: 'demo',
     })
 
     expect(useNotificationsStore.getState().toasts).toEqual([])
@@ -99,15 +119,69 @@ describe('ActivityTimeline', () => {
       kind: 'success',
       context: 'Scaffold',
       message: 'Build agent started for demo',
+      sessionId: 'scaffold-demo',
+      sessionStatus: 'running',
+      projectId: 'project-demo',
+      projectName: 'demo',
     }))
 
     render(<ActivityTimeline />)
     await userEvent.click(screen.getByRole('button', { name: 'Refresh' }))
     await waitFor(() => expect(list).toHaveBeenCalledWith(500))
-    expect(await screen.findByText('Runtime toolchain check passed')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getAllByText('Runtime toolchain check passed').length).toBeGreaterThan(0))
 
     await userEvent.click(screen.getByRole('button', { name: 'Clear' }))
     await waitFor(() => expect(clear).toHaveBeenCalled())
     expect(useNotificationsStore.getState().activity).toEqual([])
+  })
+
+  it('groups execution-session events and preserves standalone legacy entries', () => {
+    useNotificationsStore.setState({
+      toasts: [],
+      activity: [
+        {
+          id: 'session-running',
+          kind: 'success',
+          message: 'Build agent started for demo; runtime preset written.',
+          context: 'Scaffold',
+          createdAt: 1_700_000_000_200,
+          sessionId: 'scaffold-demo',
+          sessionStatus: 'running',
+          projectId: 'project-demo',
+          projectName: 'demo',
+        },
+        {
+          id: 'session-created',
+          kind: 'info',
+          message: 'Started dApp scaffold for demo at C:/work/demo',
+          context: 'Scaffold',
+          createdAt: 1_700_000_000_100,
+          sessionId: 'scaffold-demo',
+          sessionStatus: 'created',
+          projectId: 'project-demo',
+          projectName: 'demo',
+        },
+        {
+          id: 'legacy-terminal',
+          kind: 'info',
+          message: 'Opened Terminal in C:/work/daemon-app',
+          context: 'Terminal',
+          createdAt: 1_700_000_000_000,
+          sessionId: null,
+          sessionStatus: null,
+          projectId: null,
+          projectName: null,
+        },
+      ],
+    })
+
+    render(<ActivityTimeline />)
+
+    expect(screen.getByText('demo')).toBeInTheDocument()
+    expect(screen.getByText('running')).toBeInTheDocument()
+    expect(screen.getAllByText('Started dApp scaffold for demo at C:/work/demo').length).toBeGreaterThan(0)
+    expect(screen.getByText('Build agent started for demo; runtime preset written.')).toBeInTheDocument()
+    expect(screen.getAllByText('DAEMON execution').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Opened Terminal in C:/work/daemon-app').length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary

Closes #118.

- extend persisted activity records with execution-session and project metadata
- create scaffold execution sessions from Project Starter and attach failure/running states
- attach project context to terminal, validator/runtime, launch preflight, wallet send, and swap activity
- group Activity Timeline entries into execution-session cards while preserving legacy standalone activity

## Verification

- pnpm run typecheck
- pnpm vitest run test/panels/ActivityTimeline.dom.test.tsx test/panels/TerminalPanel.dom.test.tsx test/panels/AppSurfaces.dom.test.tsx test/panels/WalletTab.dom.test.tsx
- pnpm test