### PR TITLE
chore: bump version to 2.0.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary

- bump app version to 2.0.25 for the v3 execution sessions release

## Verification

- covered by #119 validation and full local test suite