### PR TITLE
feat: add execution session reports

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3'
-import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25, SCHEMA_V26 } from './schema'
+import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25, SCHEMA_V26, SCHEMA_V27 } from './schema'
 
 export function runMigrations(db: Database.Database) {
   db.exec(`
@@ -289,6 +289,19 @@ export function runMigrations(db: Database.Database) {
         }
       }
       db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(26)
+    })()
+  }
+
+  if (currentVersion < 27) {
+    db.transaction(() => {
+      const stmts = SCHEMA_V27.split(';').map((s) => s.trim()).filter(Boolean)
+      for (const stmt of stmts) {
+        try { db.exec(stmt) } catch (err) {
+          const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
+          if (!msg.includes('duplicate column') && !msg.includes('already exists')) throw err
+        }
+      }
+      db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(27)
     })()
   }
 

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -561,3 +561,7 @@ ALTER TABLE activity_log ADD COLUMN project_name TEXT;
 CREATE INDEX IF NOT EXISTS idx_activity_log_session_id ON activity_log(session_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_activity_log_project_id ON activity_log(project_id, created_at DESC);
 `
+
+export const SCHEMA_V27 = `
+ALTER TABLE activity_log ADD COLUMN session_summary TEXT;
+`

--- a/electron/ipc/activity.ts
+++ b/electron/ipc/activity.ts
@@ -24,6 +24,7 @@ interface ActivityRow {
   session_status: 'created' | 'running' | 'blocked' | 'failed' | 'complete' | null
   project_id: string | null
   project_name: string | null
+  session_summary: string | null
 }
 
 const VALID_KINDS = new Set(['info', 'success', 'warning', 'error'])
@@ -31,6 +32,7 @@ const VALID_SESSION_STATUSES = new Set(['created', 'running', 'blocked', 'failed
 const MAX_MESSAGE_LEN = 2000
 const MAX_CONTEXT_LEN = 200
 const MAX_METADATA_LEN = 200
+const MAX_SUMMARY_LEN = 5000
 const MAX_ROWS = 1000
 
 export function registerActivityHandlers() {
@@ -70,7 +72,7 @@ export function registerActivityHandlers() {
     const db = getDb()
     const safeLimit = Math.min(Math.max(1, limit ?? 500), MAX_ROWS)
     const rows = db.prepare(
-      `SELECT id, kind, message, context, created_at, session_id, session_status, project_id, project_name
+      `SELECT id, kind, message, context, created_at, session_id, session_status, project_id, project_name, session_summary
        FROM activity_log ORDER BY created_at DESC LIMIT ?`
     ).all(safeLimit) as ActivityRow[]
     return rows.map((r) => ({
@@ -83,7 +85,20 @@ export function registerActivityHandlers() {
       sessionStatus: r.session_status,
       projectId: r.project_id,
       projectName: r.project_name,
+      sessionSummary: r.session_summary,
     }))
+  }))
+
+  ipcMain.handle('activity:save-summary', ipcHandler(async (_event, input: { targetId: string; summary: string }) => {
+    if (!input?.targetId || !input.summary) {
+      throw new Error('Invalid activity summary')
+    }
+    const db = getDb()
+    const summary = input.summary.slice(0, MAX_SUMMARY_LEN)
+    const bySession = db.prepare('UPDATE activity_log SET session_summary = ? WHERE session_id = ?').run(summary, input.targetId)
+    if (bySession.changes === 0) {
+      db.prepare('UPDATE activity_log SET session_summary = ? WHERE id = ?').run(summary, input.targetId)
+    }
   }))
 
   ipcMain.handle('activity:clear', ipcHandler(async () => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -156,6 +156,7 @@ contextBridge.exposeInMainWorld('daemon', {
     }) =>
       ipcRenderer.invoke('activity:append', entry),
     list: (limit?: number) => ipcRenderer.invoke('activity:list', limit),
+    saveSummary: (targetId: string, summary: string) => ipcRenderer.invoke('activity:save-summary', { targetId, summary }),
     clear: () => ipcRenderer.invoke('activity:clear'),
   },
 

--- a/src/panels/ActivityTimeline/ActivityTimeline.css
+++ b/src/panels/ActivityTimeline/ActivityTimeline.css
@@ -123,6 +123,14 @@
   padding: 2px 4px 8px;
 }
 
+.activity-session-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .activity-session-title {
   color: var(--text-primary);
   font-size: 13px;
@@ -175,6 +183,43 @@
 .activity-session-events {
   display: grid;
   gap: 8px;
+}
+
+.activity-mini-btn {
+  padding: 5px 9px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: rgba(2, 6, 23, 0.5);
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.activity-mini-btn:hover:not(:disabled) {
+  color: #14f195;
+  border-color: rgba(20, 241, 149, 0.4);
+}
+
+.activity-mini-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.activity-session-report {
+  margin: 0;
+  padding: 14px;
+  overflow: auto;
+  border: 1px solid rgba(20, 241, 149, 0.16);
+  border-radius: 14px;
+  color: #d1fae5;
+  background:
+    linear-gradient(135deg, rgba(20, 241, 149, 0.07), rgba(56, 189, 248, 0.04)),
+    rgba(2, 6, 23, 0.58);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  line-height: 1.55;
+  white-space: pre-wrap;
 }
 
 .activity-entry {

--- a/src/panels/ActivityTimeline/ActivityTimeline.tsx
+++ b/src/panels/ActivityTimeline/ActivityTimeline.tsx
@@ -102,8 +102,10 @@ function groupActivity(entries: ActivityEntry[]): ActivitySessionGroup[] {
 export function ActivityTimeline() {
   const activity = useNotificationsStore((s) => s.activity)
   const loadActivity = useNotificationsStore((s) => s.loadActivity)
+  const saveActivitySummary = useNotificationsStore((s) => s.saveActivitySummary)
   const clearActivity = useNotificationsStore((s) => s.clearActivity)
   const [filter, setFilter] = useState<ActivityFilter>('all')
+  const [busySummaryId, setBusySummaryId] = useState<string | null>(null)
 
   const filtered = useMemo(
     () => activity.filter((entry) => matchesFilter(entry, filter)),
@@ -127,6 +129,21 @@ export function ActivityTimeline() {
     }
     return next
   }, [activity])
+
+  const handleSummarize = async (group: ActivitySessionGroup) => {
+    const summary = buildSessionReport(group)
+    setBusySummaryId(group.id)
+    try {
+      await saveActivitySummary(group.id, summary)
+    } finally {
+      setBusySummaryId(null)
+    }
+  }
+
+  const handleCopy = async (group: ActivitySessionGroup) => {
+    const summary = group.entries.find((entry) => entry.sessionSummary)?.sessionSummary ?? buildSessionReport(group)
+    await navigator.clipboard?.writeText(summary)
+  }
 
   return (
     <div className="activity-timeline">
@@ -171,8 +188,23 @@ export function ActivityTimeline() {
                   <div className="activity-session-title">{group.projectName ?? 'DAEMON execution'}</div>
                   <div className="activity-session-subtitle">{group.title}</div>
                 </div>
-                <div className={`activity-session-status ${group.status}`}>{group.status}</div>
+                <div className="activity-session-controls">
+                  <div className={`activity-session-status ${group.status}`}>{group.status}</div>
+                  <button
+                    className="activity-mini-btn"
+                    onClick={() => void handleSummarize(group)}
+                    disabled={busySummaryId === group.id}
+                  >
+                    {group.entries.some((entry) => entry.sessionSummary) ? 'Refresh report' : 'Summarize'}
+                  </button>
+                  <button className="activity-mini-btn" onClick={() => void handleCopy(group)}>Copy</button>
+                </div>
               </header>
+              {group.entries.find((entry) => entry.sessionSummary)?.sessionSummary && (
+                <pre className="activity-session-report">
+                  {group.entries.find((entry) => entry.sessionSummary)?.sessionSummary}
+                </pre>
+              )}
               <div className="activity-session-events">
                 {group.entries.map((entry) => {
                   const category = classifyActivity(entry)
@@ -200,3 +232,46 @@ export function ActivityTimeline() {
 }
 
 export default ActivityTimeline
+
+function buildSessionReport(group: ActivitySessionGroup): string {
+  const ordered = [...group.entries].sort((a, b) => a.createdAt - b.createdAt)
+  const categories = new Set(ordered.map(classifyActivity))
+  const problems = ordered.filter((entry) => entry.kind === 'error' || entry.kind === 'warning')
+  const txEvents = ordered.filter((entry) => classifyActivity(entry) === 'wallet')
+  const runtimeEvents = ordered.filter((entry) => classifyActivity(entry) === 'runtime')
+  const terminalEvents = ordered.filter((entry) => classifyActivity(entry) === 'terminal')
+  const scaffoldEvents = ordered.filter((entry) => classifyActivity(entry) === 'scaffold')
+  const last = ordered[ordered.length - 1]
+
+  const lines = [
+    `DAEMON Session Report: ${group.projectName ?? 'workspace execution'}`,
+    `Status: ${group.status}`,
+    `Objective: ${group.title}`,
+    `Scope: ${[...categories].join(', ') || 'activity'}`,
+    '',
+    'What happened:',
+    ...ordered.slice(0, 6).map((entry) => `- ${entry.context ?? classifyActivity(entry)}: ${entry.message}`),
+  ]
+
+  if (ordered.length > 6) lines.push(`- ${ordered.length - 6} additional event${ordered.length - 6 === 1 ? '' : 's'} recorded.`)
+  if (scaffoldEvents.length > 0) lines.push('', `Scaffold: ${scaffoldEvents[scaffoldEvents.length - 1].message}`)
+  if (terminalEvents.length > 0) lines.push(`Terminal: ${terminalEvents.length} terminal event${terminalEvents.length === 1 ? '' : 's'} recorded.`)
+  if (runtimeEvents.length > 0) lines.push(`Runtime/deploy: ${runtimeEvents[runtimeEvents.length - 1].message}`)
+  if (txEvents.length > 0) lines.push(`Wallet/tx: ${txEvents[txEvents.length - 1].message}`)
+  if (problems.length > 0) {
+    lines.push('', 'Needs attention:')
+    lines.push(...problems.slice(-3).map((entry) => `- ${entry.message}`))
+  }
+  lines.push('', `Next action: ${deriveNextAction(group, problems, last)}`)
+
+  return lines.join('\n')
+}
+
+function deriveNextAction(group: ActivitySessionGroup, problems: ActivityEntry[], last?: ActivityEntry): string {
+  if (group.status === 'failed') return 'Open the failed event, fix the blocker, then rerun the session from the same project context.'
+  if (group.status === 'blocked' || problems.length > 0) return 'Resolve the warnings/errors above, then rerun preflight before executing wallet or deploy steps.'
+  if (group.status === 'running') return 'Continue monitoring the terminal/runtime output and mark the session complete once build/deploy verification passes.'
+  if (group.status === 'complete') return 'Share this report as the handoff artifact and archive the session.'
+  if (last && classifyActivity(last) === 'scaffold') return 'Open the generated project, run install/build checks, then attach terminal output to this session.'
+  return 'Continue from the latest recorded event and capture the next terminal, wallet, or deploy action in DAEMON.'
+}

--- a/src/store/notifications.ts
+++ b/src/store/notifications.ts
@@ -28,6 +28,7 @@ export interface ActivityEntry {
   sessionStatus?: 'created' | 'running' | 'blocked' | 'failed' | 'complete' | null
   projectId?: string | null
   projectName?: string | null
+  sessionSummary?: string | null
 }
 
 interface NotificationsState {
@@ -50,6 +51,7 @@ interface NotificationsState {
   dismiss: (id: string) => void
   clearAll: () => void
   loadActivity: () => Promise<void>
+  saveActivitySummary: (targetId: string, summary: string) => Promise<void>
   clearActivity: () => Promise<void>
 }
 
@@ -93,6 +95,7 @@ export const useNotificationsStore = create<NotificationsState>((set, get) => ({
       sessionStatus: sessionStatus ?? null,
       projectId: projectId ?? null,
       projectName: projectName ?? null,
+      sessionSummary: null,
     }
 
     set((state) => ({
@@ -149,6 +152,16 @@ export const useNotificationsStore = create<NotificationsState>((set, get) => ({
   loadActivity: async () => {
     const res = await daemon.activity.list(500)
     if (res.ok && res.data) set({ activity: res.data })
+  },
+
+  saveActivitySummary: async (targetId, summary) => {
+    set((state) => ({
+      activity: state.activity.map((entry) => (
+        entry.sessionId === targetId || entry.id === targetId ? { ...entry, sessionSummary: summary } : entry
+      )),
+    }))
+    const res = await daemon.activity.saveSummary(targetId, summary)
+    if (!res.ok) throw new Error(res.error ?? 'Failed to save activity summary')
   },
 
   clearActivity: async () => {

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -924,11 +924,13 @@ declare global {
     sessionStatus?: 'created' | 'running' | 'blocked' | 'failed' | 'complete' | null
     projectId?: string | null
     projectName?: string | null
+    sessionSummary?: string | null
   }
 
   interface DaemonActivity {
     append: (entry: DaemonActivityEntry) => Promise<IpcResponse<void>>
     list: (limit?: number) => Promise<IpcResponse<DaemonActivityEntry[]>>
+    saveSummary: (targetId: string, summary: string) => Promise<IpcResponse<void>>
     clear: () => Promise<IpcResponse<void>>
   }
 

--- a/test/panels/ActivityTimeline.dom.test.tsx
+++ b/test/panels/ActivityTimeline.dom.test.tsx
@@ -21,19 +21,21 @@ function installDaemonBridge() {
           sessionStatus: null,
           projectId: null,
           projectName: null,
+          sessionSummary: null,
         },
     ],
   })
   const clear = vi.fn().mockResolvedValue({ ok: true })
+  const saveSummary = vi.fn().mockResolvedValue({ ok: true })
 
   Object.defineProperty(window, 'daemon', {
     configurable: true,
     value: {
-      activity: { append, list, clear },
+      activity: { append, list, saveSummary, clear },
     },
   })
 
-  return { append, clear, list }
+  return { append, clear, list, saveSummary }
 }
 
 describe('ActivityTimeline', () => {
@@ -52,6 +54,7 @@ describe('ActivityTimeline', () => {
           sessionStatus: null,
           projectId: null,
           projectName: null,
+          sessionSummary: null,
         },
         {
           id: 'terminal-1',
@@ -63,6 +66,7 @@ describe('ActivityTimeline', () => {
           sessionStatus: null,
           projectId: 'project-1',
           projectName: 'daemon-app',
+          sessionSummary: null,
         },
         {
           id: 'scaffold-1',
@@ -74,6 +78,7 @@ describe('ActivityTimeline', () => {
           sessionStatus: null,
           projectId: null,
           projectName: null,
+          sessionSummary: null,
         },
       ],
     })
@@ -112,6 +117,7 @@ describe('ActivityTimeline', () => {
       sessionStatus: 'running',
       projectId: 'project-demo',
       projectName: 'demo',
+      sessionSummary: null,
     })
 
     expect(useNotificationsStore.getState().toasts).toEqual([])
@@ -149,6 +155,7 @@ describe('ActivityTimeline', () => {
           sessionStatus: 'running',
           projectId: 'project-demo',
           projectName: 'demo',
+          sessionSummary: null,
         },
         {
           id: 'session-created',
@@ -160,6 +167,7 @@ describe('ActivityTimeline', () => {
           sessionStatus: 'created',
           projectId: 'project-demo',
           projectName: 'demo',
+          sessionSummary: null,
         },
         {
           id: 'legacy-terminal',
@@ -171,6 +179,7 @@ describe('ActivityTimeline', () => {
           sessionStatus: null,
           projectId: null,
           projectName: null,
+          sessionSummary: null,
         },
       ],
     })
@@ -183,5 +192,65 @@ describe('ActivityTimeline', () => {
     expect(screen.getByText('Build agent started for demo; runtime preset written.')).toBeInTheDocument()
     expect(screen.getAllByText('DAEMON execution').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Opened Terminal in C:/work/daemon-app').length).toBeGreaterThan(0)
+  })
+
+  it('generates, persists, and copies a session handoff report', async () => {
+    const { saveSummary } = installDaemonBridge()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    useNotificationsStore.setState({
+      toasts: [],
+      activity: [
+        {
+          id: 'session-wallet',
+          kind: 'success',
+          message: 'Swap confirmed via RPC with signature abc123',
+          context: 'Wallet',
+          createdAt: 1_700_000_000_300,
+          sessionId: 'scaffold-demo',
+          sessionStatus: 'running',
+          projectId: 'project-demo',
+          projectName: 'demo',
+          sessionSummary: null,
+        },
+        {
+          id: 'session-warning',
+          kind: 'warning',
+          message: 'Runtime toolchain check found missing tools: Anchor',
+          context: 'Runtime',
+          createdAt: 1_700_000_000_200,
+          sessionId: 'scaffold-demo',
+          sessionStatus: 'blocked',
+          projectId: 'project-demo',
+          projectName: 'demo',
+          sessionSummary: null,
+        },
+        {
+          id: 'session-created',
+          kind: 'info',
+          message: 'Started dApp scaffold for demo at C:/work/demo',
+          context: 'Scaffold',
+          createdAt: 1_700_000_000_100,
+          sessionId: 'scaffold-demo',
+          sessionStatus: 'created',
+          projectId: 'project-demo',
+          projectName: 'demo',
+          sessionSummary: null,
+        },
+      ],
+    })
+
+    render(<ActivityTimeline />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Summarize' }))
+    await waitFor(() => expect(saveSummary).toHaveBeenCalledWith('scaffold-demo', expect.stringContaining('DAEMON Session Report: demo')))
+    expect(screen.getByText(/Needs attention:/)).toBeInTheDocument()
+    expect(screen.getByText(/Wallet\/tx: Swap confirmed via RPC/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy' }))
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Next action: Resolve the warnings/errors above'))
   })
 })


### PR DESCRIPTION
## Summary

Closes #121.

- add persisted activity session summaries via SQLite migration and IPC/preload bridge
- generate deterministic DAEMON Session Reports from grouped activity timeline events
- add Summarize, Refresh report, and Copy actions to Activity Timeline session cards
- cover summary generation, persistence, and clipboard handoff behavior in DOM tests

## Verification

- pnpm run typecheck
- pnpm vitest run test/panels/ActivityTimeline.dom.test.tsx test/panels/AppSurfaces.dom.test.tsx
- pnpm test