### PR TITLE
chore: bump version to 2.0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary

- bump app version to 2.0.26 for the execution session reports release

## Verification

- covered by #122 validation and full local test suite