### PR TITLE
feat: attach launch artifacts to sessions

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3'
-import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25, SCHEMA_V26, SCHEMA_V27 } from './schema'
+import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25, SCHEMA_V26, SCHEMA_V27, SCHEMA_V28 } from './schema'
 
 export function runMigrations(db: Database.Database) {
   db.exec(`
@@ -302,6 +302,19 @@ export function runMigrations(db: Database.Database) {
         }
       }
       db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(27)
+    })()
+  }
+
+  if (currentVersion < 28) {
+    db.transaction(() => {
+      const stmts = SCHEMA_V28.split(';').map((s) => s.trim()).filter(Boolean)
+      for (const stmt of stmts) {
+        try { db.exec(stmt) } catch (err) {
+          const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
+          if (!msg.includes('duplicate column') && !msg.includes('already exists')) throw err
+        }
+      }
+      db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(28)
     })()
   }
 

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -565,3 +565,7 @@ CREATE INDEX IF NOT EXISTS idx_activity_log_project_id ON activity_log(project_i
 export const SCHEMA_V27 = `
 ALTER TABLE activity_log ADD COLUMN session_summary TEXT;
 `
+
+export const SCHEMA_V28 = `
+ALTER TABLE activity_log ADD COLUMN artifacts_json TEXT DEFAULT '[]';
+`

--- a/electron/ipc/activity.ts
+++ b/electron/ipc/activity.ts
@@ -12,6 +12,14 @@ interface ActivityEntryInput {
   sessionStatus?: 'created' | 'running' | 'blocked' | 'failed' | 'complete' | null
   projectId?: string | null
   projectName?: string | null
+  artifacts?: ActivityArtifactInput[] | null
+}
+
+interface ActivityArtifactInput {
+  type: 'transaction' | 'program' | 'explorer' | 'project' | 'deploy' | 'wallet' | 'other'
+  label: string
+  value: string
+  href?: string | null
 }
 
 interface ActivityRow {
@@ -25,6 +33,7 @@ interface ActivityRow {
   project_id: string | null
   project_name: string | null
   session_summary: string | null
+  artifacts_json: string | null
 }
 
 const VALID_KINDS = new Set(['info', 'success', 'warning', 'error'])
@@ -33,7 +42,19 @@ const MAX_MESSAGE_LEN = 2000
 const MAX_CONTEXT_LEN = 200
 const MAX_METADATA_LEN = 200
 const MAX_SUMMARY_LEN = 5000
+const MAX_ARTIFACTS_LEN = 6000
 const MAX_ROWS = 1000
+
+function normalizeArtifacts(input: ActivityEntryInput['artifacts']): string {
+  if (!Array.isArray(input)) return '[]'
+  const artifacts = input.slice(0, 12).map((artifact) => ({
+    type: typeof artifact.type === 'string' ? artifact.type.slice(0, 40) : 'other',
+    label: typeof artifact.label === 'string' ? artifact.label.slice(0, 80) : 'Artifact',
+    value: typeof artifact.value === 'string' ? artifact.value.slice(0, 400) : '',
+    href: typeof artifact.href === 'string' ? artifact.href.slice(0, 600) : null,
+  })).filter((artifact) => artifact.value)
+  return JSON.stringify(artifacts).slice(0, MAX_ARTIFACTS_LEN)
+}
 
 export function registerActivityHandlers() {
   ipcMain.handle('activity:append', ipcHandler(async (_event, entry: ActivityEntryInput) => {
@@ -46,8 +67,8 @@ export function registerActivityHandlers() {
     const db = getDb()
     db.prepare(
       `INSERT OR IGNORE INTO activity_log (
-        id, kind, message, context, created_at, session_id, session_status, project_id, project_name
-      ) VALUES (?,?,?,?,?,?,?,?,?)`
+        id, kind, message, context, created_at, session_id, session_status, project_id, project_name, artifacts_json
+      ) VALUES (?,?,?,?,?,?,?,?,?,?)`
     ).run(
       entry.id,
       entry.kind,
@@ -58,6 +79,7 @@ export function registerActivityHandlers() {
       sessionStatus,
       entry.projectId ? entry.projectId.slice(0, MAX_METADATA_LEN) : null,
       entry.projectName ? entry.projectName.slice(0, MAX_METADATA_LEN) : null,
+      normalizeArtifacts(entry.artifacts),
     )
 
     // Trim oldest entries beyond MAX_ROWS to prevent unbounded growth
@@ -72,7 +94,7 @@ export function registerActivityHandlers() {
     const db = getDb()
     const safeLimit = Math.min(Math.max(1, limit ?? 500), MAX_ROWS)
     const rows = db.prepare(
-      `SELECT id, kind, message, context, created_at, session_id, session_status, project_id, project_name, session_summary
+      `SELECT id, kind, message, context, created_at, session_id, session_status, project_id, project_name, session_summary, artifacts_json
        FROM activity_log ORDER BY created_at DESC LIMIT ?`
     ).all(safeLimit) as ActivityRow[]
     return rows.map((r) => ({
@@ -86,6 +108,7 @@ export function registerActivityHandlers() {
       projectId: r.project_id,
       projectName: r.project_name,
       sessionSummary: r.session_summary,
+      artifacts: parseArtifacts(r.artifacts_json),
     }))
   }))
 
@@ -105,4 +128,14 @@ export function registerActivityHandlers() {
     const db = getDb()
     db.prepare('DELETE FROM activity_log').run()
   }))
+}
+
+function parseArtifacts(raw: string | null) {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
 }

--- a/src/panels/ActivityTimeline/ActivityTimeline.css
+++ b/src/panels/ActivityTimeline/ActivityTimeline.css
@@ -222,6 +222,58 @@
   white-space: pre-wrap;
 }
 
+.activity-artifacts {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.activity-artifact {
+  display: inline-grid;
+  gap: 3px;
+  min-width: 136px;
+  padding: 9px 11px;
+  border: 1px solid rgba(20, 241, 149, 0.18);
+  border-radius: 13px;
+  color: var(--text-secondary);
+  background:
+    linear-gradient(135deg, rgba(20, 241, 149, 0.08), rgba(56, 189, 248, 0.05)),
+    rgba(2, 6, 23, 0.5);
+  text-decoration: none;
+}
+
+.activity-artifact:hover {
+  border-color: rgba(20, 241, 149, 0.42);
+  color: #d1fae5;
+}
+
+.activity-artifact span {
+  color: #14f195;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.activity-artifact strong {
+  overflow: hidden;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-artifact.transaction,
+.activity-artifact.explorer {
+  border-color: rgba(103, 232, 249, 0.24);
+}
+
+.activity-artifact.program,
+.activity-artifact.deploy {
+  border-color: rgba(20, 241, 149, 0.3);
+}
+
 .activity-entry {
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr);

--- a/src/panels/ActivityTimeline/ActivityTimeline.tsx
+++ b/src/panels/ActivityTimeline/ActivityTimeline.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { useNotificationsStore, type ActivityEntry } from '../../store/notifications'
+import { useNotificationsStore, type ActivityArtifact, type ActivityEntry } from '../../store/notifications'
 import './ActivityTimeline.css'
 
 type ActivityFilter = 'all' | 'wallet' | 'runtime' | 'terminal' | 'scaffold' | 'errors'
@@ -44,6 +44,7 @@ type ActivitySessionGroup = {
   entries: ActivityEntry[]
   latestAt: number
   hasProblems: boolean
+  artifacts: ActivityArtifact[]
 }
 
 function deriveSessionStatus(entries: ActivityEntry[]): ActivitySessionGroup['status'] {
@@ -81,6 +82,7 @@ function groupActivity(entries: ActivityEntry[]): ActivitySessionGroup[] {
       entries: sorted,
       latestAt: sorted[0]?.createdAt ?? 0,
       hasProblems: sorted.some((entry) => entry.kind === 'error' || entry.kind === 'warning'),
+      artifacts: collectArtifacts(sorted),
     })
   }
 
@@ -93,6 +95,7 @@ function groupActivity(entries: ActivityEntry[]): ActivitySessionGroup[] {
       entries: [entry],
       latestAt: entry.createdAt,
       hasProblems: entry.kind === 'error' || entry.kind === 'warning',
+      artifacts: collectArtifacts([entry]),
     })
   }
 
@@ -205,6 +208,22 @@ export function ActivityTimeline() {
                   {group.entries.find((entry) => entry.sessionSummary)?.sessionSummary}
                 </pre>
               )}
+              {group.artifacts.length > 0 && (
+                <div className="activity-artifacts" aria-label="Session artifacts">
+                  {group.artifacts.map((artifact) => (
+                    <a
+                      key={`${artifact.type}-${artifact.value}`}
+                      className={`activity-artifact ${artifact.type}`}
+                      href={artifact.href ?? undefined}
+                      target={artifact.href ? '_blank' : undefined}
+                      rel={artifact.href ? 'noreferrer' : undefined}
+                    >
+                      <span>{artifact.label}</span>
+                      <strong>{compactArtifactValue(artifact.value)}</strong>
+                    </a>
+                  ))}
+                </div>
+              )}
               <div className="activity-session-events">
                 {group.entries.map((entry) => {
                   const category = classifyActivity(entry)
@@ -258,6 +277,10 @@ function buildSessionReport(group: ActivitySessionGroup): string {
   if (terminalEvents.length > 0) lines.push(`Terminal: ${terminalEvents.length} terminal event${terminalEvents.length === 1 ? '' : 's'} recorded.`)
   if (runtimeEvents.length > 0) lines.push(`Runtime/deploy: ${runtimeEvents[runtimeEvents.length - 1].message}`)
   if (txEvents.length > 0) lines.push(`Wallet/tx: ${txEvents[txEvents.length - 1].message}`)
+  if (group.artifacts.length > 0) {
+    lines.push('', 'Launch artifacts:')
+    lines.push(...group.artifacts.map((artifact) => `- ${artifact.label}: ${artifact.value}${artifact.href ? ` (${artifact.href})` : ''}`))
+  }
   if (problems.length > 0) {
     lines.push('', 'Needs attention:')
     lines.push(...problems.slice(-3).map((entry) => `- ${entry.message}`))
@@ -265,6 +288,83 @@ function buildSessionReport(group: ActivitySessionGroup): string {
   lines.push('', `Next action: ${deriveNextAction(group, problems, last)}`)
 
   return lines.join('\n')
+}
+
+function collectArtifacts(entries: ActivityEntry[]): ActivityArtifact[] {
+  const artifacts: ActivityArtifact[] = []
+  const seen = new Set<string>()
+
+  for (const entry of entries) {
+    for (const artifact of [...(entry.artifacts ?? []), ...extractArtifacts(entry)]) {
+      const key = `${artifact.type}:${artifact.value}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      artifacts.push(artifact)
+    }
+  }
+
+  return artifacts.slice(0, 12)
+}
+
+function extractArtifacts(entry: ActivityEntry): ActivityArtifact[] {
+  const haystack = `${entry.context ?? ''} ${entry.message}`
+  const artifacts: ActivityArtifact[] = []
+  const signatures = haystack.match(/\b[1-9A-HJ-NP-Za-km-z]{64,88}\b/g) ?? []
+  const urls = haystack.match(/https?:\/\/[^\s)]+/g) ?? []
+  const windowsPaths = haystack.match(/[A-Za-z]:[\\/][^\s,;]+/g) ?? []
+  const programIds = haystack.match(/program(?: id)?[:\s]+([1-9A-HJ-NP-Za-km-z]{32,44})/i)
+  const wallet = haystack.match(/wallet[:\s]+([1-9A-HJ-NP-Za-km-z]{32,44})/i)
+
+  for (const signature of signatures.slice(0, 4)) {
+    artifacts.push({
+      type: 'transaction',
+      label: 'Tx signature',
+      value: signature,
+      href: `https://solscan.io/tx/${signature}`,
+    })
+  }
+
+  for (const url of urls.slice(0, 4)) {
+    artifacts.push({
+      type: url.includes('explorer.solana.com') || url.includes('solscan.io') ? 'explorer' : 'other',
+      label: url.includes('explorer.solana.com') || url.includes('solscan.io') ? 'Explorer' : 'Link',
+      value: url,
+      href: url,
+    })
+  }
+
+  for (const path of windowsPaths.slice(0, 2)) {
+    artifacts.push({ type: 'project', label: 'Project path', value: path })
+  }
+
+  if (programIds?.[1]) {
+    artifacts.push({
+      type: 'program',
+      label: 'Program ID',
+      value: programIds[1],
+      href: `https://explorer.solana.com/address/${programIds[1]}`,
+    })
+  }
+
+  if (wallet?.[1]) {
+    artifacts.push({
+      type: 'wallet',
+      label: 'Wallet',
+      value: wallet[1],
+      href: `https://explorer.solana.com/address/${wallet[1]}`,
+    })
+  }
+
+  if (classifyActivity(entry) === 'runtime' && /deploy|launched|confirmed/i.test(entry.message)) {
+    artifacts.push({ type: 'deploy', label: 'Deploy event', value: entry.message })
+  }
+
+  return artifacts
+}
+
+function compactArtifactValue(value: string): string {
+  if (value.length <= 34) return value
+  return `${value.slice(0, 16)}...${value.slice(-10)}`
 }
 
 function deriveNextAction(group: ActivitySessionGroup, problems: ActivityEntry[], last?: ActivityEntry): string {

--- a/src/panels/ActivityTimeline/ActivityTimeline.tsx
+++ b/src/panels/ActivityTimeline/ActivityTimeline.tsx
@@ -325,9 +325,10 @@ function extractArtifacts(entry: ActivityEntry): ActivityArtifact[] {
   }
 
   for (const url of urls.slice(0, 4)) {
+    const isExplorer = isSolanaExplorerUrl(url)
     artifacts.push({
-      type: url.includes('explorer.solana.com') || url.includes('solscan.io') ? 'explorer' : 'other',
-      label: url.includes('explorer.solana.com') || url.includes('solscan.io') ? 'Explorer' : 'Link',
+      type: isExplorer ? 'explorer' : 'other',
+      label: isExplorer ? 'Explorer' : 'Link',
       value: url,
       href: url,
     })
@@ -365,6 +366,15 @@ function extractArtifacts(entry: ActivityEntry): ActivityArtifact[] {
 function compactArtifactValue(value: string): string {
   if (value.length <= 34) return value
   return `${value.slice(0, 16)}...${value.slice(-10)}`
+}
+
+function isSolanaExplorerUrl(value: string): boolean {
+  try {
+    const host = new URL(value).hostname.toLowerCase()
+    return host === 'explorer.solana.com' || host === 'solscan.io' || host.endsWith('.solscan.io')
+  } catch {
+    return false
+  }
 }
 
 function deriveNextAction(group: ActivitySessionGroup, problems: ActivityEntry[], last?: ActivityEntry): string {

--- a/src/store/notifications.ts
+++ b/src/store/notifications.ts
@@ -29,6 +29,14 @@ export interface ActivityEntry {
   projectId?: string | null
   projectName?: string | null
   sessionSummary?: string | null
+  artifacts?: ActivityArtifact[] | null
+}
+
+export interface ActivityArtifact {
+  type: 'transaction' | 'program' | 'explorer' | 'project' | 'deploy' | 'wallet' | 'other'
+  label: string
+  value: string
+  href?: string | null
 }
 
 interface NotificationsState {
@@ -43,6 +51,7 @@ interface NotificationsState {
     sessionStatus?: ActivityEntry['sessionStatus']
     projectId?: string | null
     projectName?: string | null
+    artifacts?: ActivityArtifact[] | null
   }) => string
   pushToast: (input: { kind: ToastKind; message: string; context?: string; ttlMs?: number; action?: ToastAction }) => string
   pushError: (err: unknown, context?: string) => string
@@ -76,6 +85,7 @@ function persistEntry(entry: ActivityEntry): void {
     sessionStatus: entry.sessionStatus ?? null,
     projectId: entry.projectId ?? null,
     projectName: entry.projectName ?? null,
+    artifacts: entry.artifacts ?? null,
   }).catch(() => { /* non-fatal */ })
 }
 
@@ -83,7 +93,7 @@ export const useNotificationsStore = create<NotificationsState>((set, get) => ({
   toasts: [],
   activity: [],
 
-  addActivity: ({ kind, message, context, createdAt, sessionId, sessionStatus, projectId, projectName }) => {
+  addActivity: ({ kind, message, context, createdAt, sessionId, sessionStatus, projectId, projectName, artifacts }) => {
     const id = crypto.randomUUID()
     const entry: ActivityEntry = {
       id,
@@ -96,6 +106,7 @@ export const useNotificationsStore = create<NotificationsState>((set, get) => ({
       projectId: projectId ?? null,
       projectName: projectName ?? null,
       sessionSummary: null,
+      artifacts: artifacts ?? null,
     }
 
     set((state) => ({
@@ -118,7 +129,7 @@ export const useNotificationsStore = create<NotificationsState>((set, get) => ({
       ttlMs: ttlMs ?? DEFAULT_TTL[kind],
       action,
     }
-    const entry: ActivityEntry = { id, kind, message, context: context ?? null, createdAt }
+    const entry: ActivityEntry = { id, kind, message, context: context ?? null, createdAt, artifacts: null }
 
     set((state) => ({
       toasts: [...state.toasts, toast],

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -925,6 +925,14 @@ declare global {
     projectId?: string | null
     projectName?: string | null
     sessionSummary?: string | null
+    artifacts?: DaemonActivityArtifact[] | null
+  }
+
+  interface DaemonActivityArtifact {
+    type: 'transaction' | 'program' | 'explorer' | 'project' | 'deploy' | 'wallet' | 'other'
+    label: string
+    value: string
+    href?: string | null
   }
 
   interface DaemonActivity {

--- a/test/panels/ActivityTimeline.dom.test.tsx
+++ b/test/panels/ActivityTimeline.dom.test.tsx
@@ -22,6 +22,7 @@ function installDaemonBridge() {
           projectId: null,
           projectName: null,
           sessionSummary: null,
+          artifacts: null,
         },
     ],
   })
@@ -55,6 +56,7 @@ describe('ActivityTimeline', () => {
           projectId: null,
           projectName: null,
           sessionSummary: null,
+          artifacts: null,
         },
         {
           id: 'terminal-1',
@@ -67,6 +69,7 @@ describe('ActivityTimeline', () => {
           projectId: 'project-1',
           projectName: 'daemon-app',
           sessionSummary: null,
+          artifacts: null,
         },
         {
           id: 'scaffold-1',
@@ -79,6 +82,7 @@ describe('ActivityTimeline', () => {
           projectId: null,
           projectName: null,
           sessionSummary: null,
+          artifacts: null,
         },
       ],
     })
@@ -118,6 +122,13 @@ describe('ActivityTimeline', () => {
       projectId: 'project-demo',
       projectName: 'demo',
       sessionSummary: null,
+      artifacts: [
+        {
+          type: 'project',
+          label: 'Project path',
+          value: 'C:/work/demo',
+        },
+      ],
     })
 
     expect(useNotificationsStore.getState().toasts).toEqual([])
@@ -129,6 +140,13 @@ describe('ActivityTimeline', () => {
       sessionStatus: 'running',
       projectId: 'project-demo',
       projectName: 'demo',
+      artifacts: [
+        {
+          type: 'project',
+          label: 'Project path',
+          value: 'C:/work/demo',
+        },
+      ],
     }))
 
     render(<ActivityTimeline />)
@@ -156,6 +174,7 @@ describe('ActivityTimeline', () => {
           projectId: 'project-demo',
           projectName: 'demo',
           sessionSummary: null,
+          artifacts: null,
         },
         {
           id: 'session-created',
@@ -168,6 +187,7 @@ describe('ActivityTimeline', () => {
           projectId: 'project-demo',
           projectName: 'demo',
           sessionSummary: null,
+          artifacts: null,
         },
         {
           id: 'legacy-terminal',
@@ -180,6 +200,7 @@ describe('ActivityTimeline', () => {
           projectId: null,
           projectName: null,
           sessionSummary: null,
+          artifacts: null,
         },
       ],
     })
@@ -215,6 +236,14 @@ describe('ActivityTimeline', () => {
           projectId: 'project-demo',
           projectName: 'demo',
           sessionSummary: null,
+          artifacts: [
+            {
+              type: 'transaction',
+              label: 'Tx signature',
+              value: '5rR5jzJwP5xHhNTRNLpR8XUqz4fRqV7VQqLD3fkGRhY2N1Vy8uKFN6rDc4B7bEBZV1Jr3jbyKQnAorxyuQ9Z7Z6G',
+              href: 'https://solscan.io/tx/5rR5jzJwP5xHhNTRNLpR8XUqz4fRqV7VQqLD3fkGRhY2N1Vy8uKFN6rDc4B7bEBZV1Jr3jbyKQnAorxyuQ9Z7Z6G',
+            },
+          ],
         },
         {
           id: 'session-warning',
@@ -227,6 +256,7 @@ describe('ActivityTimeline', () => {
           projectId: 'project-demo',
           projectName: 'demo',
           sessionSummary: null,
+          artifacts: null,
         },
         {
           id: 'session-created',
@@ -239,6 +269,13 @@ describe('ActivityTimeline', () => {
           projectId: 'project-demo',
           projectName: 'demo',
           sessionSummary: null,
+          artifacts: [
+            {
+              type: 'project',
+              label: 'Project path',
+              value: 'C:/work/demo',
+            },
+          ],
         },
       ],
     })
@@ -249,6 +286,9 @@ describe('ActivityTimeline', () => {
     await waitFor(() => expect(saveSummary).toHaveBeenCalledWith('scaffold-demo', expect.stringContaining('DAEMON Session Report: demo')))
     expect(screen.getByText(/Needs attention:/)).toBeInTheDocument()
     expect(screen.getByText(/Wallet\/tx: Swap confirmed via RPC/)).toBeInTheDocument()
+    expect(screen.getByText('Tx signature')).toBeInTheDocument()
+    expect(screen.getByText('Project path')).toBeInTheDocument()
+    expect(screen.getByText(/Launch artifacts:/)).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: 'Copy' }))
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Next action: Resolve the warnings/errors above'))


### PR DESCRIPTION
## Summary
- Persist structured activity artifacts for execution sessions
- Render tx/program/explorer/project/deploy artifact chips in Activity Timeline
- Include launch artifacts in generated DAEMON Session Reports
- Add coverage for persisted artifact handoff reports

Closes #124

## Validation
- pnpm run typecheck
- pnpm vitest run test/panels/ActivityTimeline.dom.test.tsx
- pnpm test