### PR TITLE
chore: bump version to 2.0.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- Bump DAEMON version to 2.0.27 for the launch artifact session release.

## Validation
- Release PR only; feature validation completed in #125.