### PR TITLE
feat: record deploy handoff activity

### DIFF
--- a/src/panels/plugins/Deploy/Deploy.tsx
+++ b/src/panels/plugins/Deploy/Deploy.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useUIStore } from '../../../store/ui'
+import { useNotificationsStore, type ActivityArtifact } from '../../../store/notifications'
 import { DeployConnect } from './DeployConnect'
 import './Deploy.css'
 
@@ -38,9 +39,20 @@ function relativeTime(ts: number): string {
   return `${days}d ago`
 }
 
+function platformLabel(platform: DeployPlatform): string {
+  return platform === 'vercel' ? 'Vercel' : 'Railway'
+}
+
+function projectNameFromPath(projectPath: string | null): string | null {
+  if (!projectPath) return null
+  const clean = projectPath.replace(/[\\/]+$/, '')
+  return clean.split(/[\\/]/).pop() || clean
+}
+
 export default function DeployPanel() {
   const activeProjectId = useUIStore((s) => s.activeProjectId)
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
+  const addActivity = useNotificationsStore((s) => s.addActivity)
 
   const [authStatus, setAuthStatus] = useState<DeployAuthStatus>({
     vercel: { authenticated: false, user: null },
@@ -102,6 +114,29 @@ export default function DeployPanel() {
   const loadDeploymentsRef = useRef(loadDeployments)
   loadDeploymentsRef.current = loadDeployments
 
+  const recordDeployActivity = useCallback((
+    platform: DeployPlatform,
+    kind: 'info' | 'success' | 'warning' | 'error',
+    message: string,
+    sessionStatus: 'created' | 'running' | 'blocked' | 'failed' | 'complete',
+    artifacts: ActivityArtifact[] = [],
+  ) => {
+    if (!activeProjectId) return
+    addActivity({
+      kind,
+      context: 'Deploy',
+      message,
+      sessionId: `deploy-${activeProjectId}-${platform}`,
+      sessionStatus,
+      projectId: activeProjectId,
+      projectName: projectNameFromPath(activeProjectPath),
+      artifacts: [
+        { type: 'deploy', label: 'Platform', value: platformLabel(platform) },
+        ...artifacts,
+      ],
+    })
+  }, [activeProjectId, activeProjectPath, addActivity])
+
   useEffect(() => {
     hasActiveRef.current = deployments.some((d) => d.status === 'BUILDING' || d.status === 'QUEUED')
   }, [deployments])
@@ -118,11 +153,26 @@ export default function DeployPanel() {
     if (!activeProjectId) return
     setDeploying(true)
     setError(null)
+    recordDeployActivity(platform, 'info', `${platformLabel(platform)} deploy started for ${projectNameFromPath(activeProjectPath) ?? activeProjectId}.`, 'running')
     const res = await window.daemon.deploy.redeploy(activeProjectId, platform)
     if (res.ok) {
+      const data = res.data as { id?: string; url?: string | null } | boolean | undefined
+      const deployUrl = typeof data === 'object' && data?.url ? data.url : null
+      const deployId = typeof data === 'object' && data?.id ? data.id : null
+      recordDeployActivity(
+        platform,
+        'success',
+        `${platformLabel(platform)} deploy triggered${deployUrl ? `: ${deployUrl}` : '.'}`,
+        'complete',
+        [
+          ...(deployId ? [{ type: 'deploy' as const, label: 'Deployment ID', value: deployId }] : []),
+          ...(deployUrl ? [{ type: 'explorer' as const, label: 'Deploy URL', value: deployUrl, href: deployUrl }] : []),
+        ],
+      )
       await loadDeployments()
     } else {
       setError(res.error ?? 'Deploy failed')
+      recordDeployActivity(platform, 'error', `${platformLabel(platform)} deploy failed: ${res.error ?? 'Deploy failed'}`, 'failed')
     }
     setDeploying(false)
   }
@@ -137,6 +187,7 @@ export default function DeployPanel() {
   const handleDisconnect = async (platform: DeployPlatform) => {
     const res = await window.daemon.deploy.disconnect(platform)
     if (res.ok) {
+      recordDeployActivity(platform, 'warning', `${platformLabel(platform)} credentials disconnected.`, 'blocked')
       loadAuthStatus()
       loadStatuses()
     }
@@ -166,6 +217,16 @@ export default function DeployPanel() {
 
     const res = await window.daemon.deploy.link(activeProjectId, linkingPlatform, linkData)
     if (res.ok) {
+      recordDeployActivity(
+        linkingPlatform,
+        'success',
+        `${platformLabel(linkingPlatform)} project linked: ${selected.name}.`,
+        'created',
+        [
+          { type: 'project', label: 'Deploy project', value: selected.name },
+          { type: 'deploy', label: 'Provider project ID', value: selectedProjectId },
+        ],
+      )
       setLinkingPlatform(null)
       setSelectedProjectId('')
       setPlatformProjects([])
@@ -178,7 +239,10 @@ export default function DeployPanel() {
     const confirmed = window.confirm(`Unlink ${platform === 'vercel' ? 'Vercel' : 'Railway'} from this project?`)
     if (!confirmed) return
     const res = await window.daemon.deploy.unlink(activeProjectId, platform)
-    if (res.ok) { loadStatuses() }
+    if (res.ok) {
+      recordDeployActivity(platform, 'warning', `${platformLabel(platform)} project unlinked.`, 'blocked')
+      loadStatuses()
+    }
   }
 
   const handleOpenUrl = (url: string) => {

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -570,8 +570,7 @@ describe('App surface DOM coverage', () => {
     expect(useNotificationsStore.getState().activity.some((entry) => (
       entry.context === 'Deploy' &&
       entry.sessionStatus === 'complete' &&
-      entry.message.includes('https://daemon-app.vercel.app') &&
-      entry.artifacts?.some((artifact) => artifact.label === 'Deploy URL')
+      entry.artifacts?.some((artifact) => artifact.label === 'Deploy URL' && artifact.href === artifact.value)
     ))).toBe(true)
   })
 

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -8,11 +8,13 @@ import { usePluginStore } from '../../src/store/plugins'
 import { useSolanaToolboxStore } from '../../src/store/solanaToolbox'
 import { useWorkflowShellStore } from '../../src/store/workflowShell'
 import { useWorkspaceProfileStore } from '../../src/store/workspaceProfile'
+import { useNotificationsStore } from '../../src/store/notifications'
 import { WalletSendForm } from '../../src/panels/WalletPanel/WalletSendForm'
 import { SolanaToolbox } from '../../src/panels/SolanaToolbox/SolanaToolbox'
 import { TokenLaunchTool } from '../../src/panels/TokenLaunchTool/TokenLaunchTool'
 import { IntegrationCommandCenter } from '../../src/panels/IntegrationCommandCenter/IntegrationCommandCenter'
 import { ProjectReadiness } from '../../src/panels/ProjectReadiness/ProjectReadiness'
+import DeployPanel from '../../src/panels/plugins/Deploy/Deploy'
 
 vi.mock('../../src/utils/lazyWithReload', () => ({
   lazyWithReload: () => () => null,
@@ -50,6 +52,9 @@ function installDaemonBridge() {
   })
   const writeFile = vi.fn().mockResolvedValue({ ok: true })
   const createDir = vi.fn().mockResolvedValue({ ok: true })
+  const appendActivity = vi.fn().mockResolvedValue({ ok: true })
+  const redeploy = vi.fn().mockResolvedValue({ ok: true, data: { id: 'dep-123', url: 'https://daemon-app.vercel.app' } })
+  const linkDeploy = vi.fn().mockResolvedValue({ ok: true })
   const createTerminal = vi.fn().mockImplementation(async ({ startupCommand }: { startupCommand?: string }) => ({
     ok: true,
     data: {
@@ -114,11 +119,6 @@ function installDaemonBridge() {
   Object.defineProperty(window, 'daemon', {
     configurable: true,
     value: {
-      activity: {
-        append: vi.fn().mockResolvedValue({ ok: true }),
-        list: vi.fn().mockResolvedValue({ ok: true, data: [] }),
-        clear: vi.fn().mockResolvedValue({ ok: true }),
-      },
       claude: {
         projectMcpAll: vi.fn().mockResolvedValue({
           ok: true,
@@ -149,6 +149,38 @@ function installDaemonBridge() {
         readFile,
         writeFile,
         createDir,
+      },
+      activity: {
+        append: appendActivity,
+        list: vi.fn().mockResolvedValue({ ok: true, data: [] }),
+        saveSummary: vi.fn().mockResolvedValue({ ok: true }),
+        clear: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      deploy: {
+        authStatus: vi.fn().mockResolvedValue({
+          ok: true,
+          data: {
+            vercel: { authenticated: true, user: 'builder@daemon.test' },
+            railway: { authenticated: false, user: null },
+          },
+        }),
+        connectVercel: vi.fn().mockResolvedValue({ ok: true, data: { name: 'Builder', email: 'builder@daemon.test' } }),
+        connectRailway: vi.fn().mockResolvedValue({ ok: true, data: { name: 'Builder', email: 'builder@daemon.test' } }),
+        disconnect: vi.fn().mockResolvedValue({ ok: true }),
+        vercelProjects: vi.fn().mockResolvedValue({ ok: true, data: [{ id: 'vercel-project-1', name: 'daemon-app' }] }),
+        railwayProjects: vi.fn().mockResolvedValue({ ok: true, data: [] }),
+        link: linkDeploy,
+        unlink: vi.fn().mockResolvedValue({ ok: true }),
+        status: vi.fn()
+          .mockResolvedValueOnce({ ok: true, data: [] })
+          .mockResolvedValue({ ok: true, data: [{ platform: 'vercel', linked: true, projectName: 'daemon-app', productionUrl: 'https://daemon-app.vercel.app', latestStatus: null, latestUrl: null, latestBranch: null, latestCreatedAt: null }] }),
+        deployments: vi.fn().mockResolvedValue({
+          ok: true,
+          data: [{ id: 'dep-123', platform: 'vercel', status: 'READY', url: 'https://daemon-app.vercel.app', branch: 'main', commitSha: 'abcdef123', commitMessage: 'ship deploy', createdAt: Date.now() }],
+        }),
+        redeploy,
+        envVars: vi.fn().mockResolvedValue({ ok: true, data: [] }),
+        autoDetect: vi.fn().mockResolvedValue({ ok: true, data: {} }),
       },
       terminal: {
         create: createTerminal,
@@ -245,7 +277,7 @@ function installDaemonBridge() {
     },
   })
 
-  return { createDir, createTerminal, holdings, readFile, swapQuote, transactionPreview, writeFile }
+  return { appendActivity, createDir, createTerminal, holdings, linkDeploy, readFile, redeploy, swapQuote, transactionPreview, writeFile }
 }
 
 function resetStores() {
@@ -257,6 +289,7 @@ function resetStores() {
     launchWizardOpen: false,
   })
   useWorkspaceProfileStore.setState({ profileName: 'custom', toolVisibility: {}, loaded: true })
+  useNotificationsStore.setState({ toasts: [], activity: [] })
   useUIStore.setState({
     activeProjectId: 'project-1',
     activeProjectPath: 'C:/work/daemon-app',
@@ -507,6 +540,39 @@ describe('App surface DOM coverage', () => {
 
     await userEvent.click(screen.getByRole('tab', { name: /Debug/ }))
     expect(screen.getByRole('tab', { name: /Debug/ })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('records deploy link and launch handoff activity', async () => {
+    const { linkDeploy, redeploy } = installDaemonBridge()
+
+    render(<DeployPanel />)
+
+    expect(await screen.findByRole('heading', { name: 'Deploy' })).toBeInTheDocument()
+    await userEvent.click(await screen.findByRole('button', { name: 'Link Project' }))
+    await userEvent.selectOptions(await screen.findByRole('combobox'), 'vercel-project-1')
+    await userEvent.click(screen.getByRole('button', { name: 'Link' }))
+
+    await waitFor(() => expect(linkDeploy).toHaveBeenCalledWith(
+      'project-1',
+      'vercel',
+      expect.objectContaining({ projectId: 'vercel-project-1', projectName: 'daemon-app' }),
+    ))
+    expect(useNotificationsStore.getState().activity.some((entry) => (
+      entry.context === 'Deploy' &&
+      entry.sessionId === 'deploy-project-1-vercel' &&
+      entry.message.includes('Vercel project linked') &&
+      entry.artifacts?.some((artifact) => artifact.label === 'Provider project ID')
+    ))).toBe(true)
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Deploy' }))
+
+    await waitFor(() => expect(redeploy).toHaveBeenCalledWith('project-1', 'vercel'))
+    expect(useNotificationsStore.getState().activity.some((entry) => (
+      entry.context === 'Deploy' &&
+      entry.sessionStatus === 'complete' &&
+      entry.message.includes('https://daemon-app.vercel.app') &&
+      entry.artifacts?.some((artifact) => artifact.label === 'Deploy URL')
+    ))).toBe(true)
   })
 
   it('keeps Token Launch actions and config obvious', async () => {


### PR DESCRIPTION
## Summary
- Record deploy link/start/success/failure/unlink events into Activity Timeline
- Attach platform, deploy project, deployment ID, and deploy URL artifacts
- Add DOM coverage proving deploy handoff activity is emitted

Closes #127

## Validation
- pnpm run typecheck
- pnpm vitest run test/panels/AppSurfaces.dom.test.tsx test/panels/ActivityTimeline.dom.test.tsx
- pnpm test