### PR TITLE
fix: keep token launch out of project starter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",

--- a/src/panels/Editor/EditorWelcome.tsx
+++ b/src/panels/Editor/EditorWelcome.tsx
@@ -9,7 +9,6 @@ interface EditorWelcomeProps {
 }
 
 const QUICK_TEMPLATES = [
-  { id: 'token-launch', name: 'Token Launch', icon: 'M12 4a8 8 0 1 0 8 8 8 8 0 0 0-8-8Zm-2 10 5-5M11 9h4v4', color: '#3ecf8e' },
   { id: 'anchor-program', name: 'Anchor Program', icon: 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4', color: '#60a5fa' },
   { id: 'trading-bot', name: 'Trading Bot', icon: 'M13 7h8m0 0v8m0-8l-8 8-4-4-6 6', color: '#f0b429' },
   { id: 'dapp-nextjs', name: 'dApp', icon: 'M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9', color: '#c084fc' },
@@ -156,8 +155,8 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
                     width="14"
                     height="14"
                     viewBox="0 0 24 24"
-                    fill={t.id === 'token-launch' ? t.color : 'none'}
-                    stroke={t.id === 'token-launch' ? 'none' : t.color}
+                    fill="none"
+                    stroke={t.color}
                     strokeWidth="1.5"
                     strokeLinecap="round"
                     strokeLinejoin="round"

--- a/src/panels/ProjectStarter/ProjectStarter.tsx
+++ b/src/panels/ProjectStarter/ProjectStarter.tsx
@@ -17,20 +17,6 @@ interface Template {
 
 const TEMPLATES: Template[] = [
   {
-    id: 'token-launch',
-    name: 'Token Launch',
-    description: 'SPL token with metadata, mint authority, and launch script',
-    tags: ['Token', 'SPL'],
-    icon: 'M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5',
-    prompt: `Scaffold a Solana SPL token launch project. Include:
-- Anchor program with mint, metadata (Metaplex), and freeze authority setup
-- TypeScript client scripts: create-token, mint-supply, transfer, burn
-- Deployment scripts for devnet and mainnet
-- .env.example with RPC_URL, WALLET_PATH, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS, INITIAL_SUPPLY
-- README with setup instructions
-Use Anchor 0.32+, AVM-managed toolchains, and @solana/kit (or @solana/web3-compat only when required by third-party SDKs). Initialize git repo.`,
-  },
-  {
     id: 'nft-collection',
     name: 'NFT Collection',
     description: 'Metaplex collection with minting, metadata, and candy machine',
@@ -102,24 +88,6 @@ Initialize git repo. Prefer @solana/client, @solana/react-hooks, and @solana/web
 - .env.example with RPC_URL, WALLET_PATH, PROGRAM_ID
 - README with build, test, and deploy instructions
 Use Anchor 0.32+ with AVM. Initialize git repo.`,
-  },
-  {
-    id: 'pump-token',
-    name: 'Pump.fun Token',
-    description: 'Token launch via Pump.fun with bonding curve and migration',
-    tags: ['PumpFun', 'Launch'],
-    icon: 'M13 10V3L4 14h7v7l9-11h-7z',
-    prompt: `Scaffold a Pump.fun token launch project. Include:
-- Token creation script using Pump.fun API
-- Bonding curve buy/sell scripts
-- Migration monitoring (bonding curve → Raydium)
-- Metadata preparation (name, symbol, description, image URL)
-- Bundle buying strategy scripts (multi-wallet)
-- Jito bundle integration for MEV protection
-- Wallet generation and fund distribution utilities
-- .env.example with RPC_URL, MASTER_WALLET_PATH, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DESCRIPTION, IMAGE_URL
-- README with full workflow guide
-Use @solana/kit plus web3 compatibility only where Pump tooling requires it. Initialize git repo.`,
   },
   {
     id: 'telegram-bot',
@@ -286,7 +254,7 @@ function buildTemplateSpecificPrompt(templateId: string, settings: WalletInfrast
     ].join('\n')
   }
 
-  if (templateId === 'trading-bot' || templateId === 'pump-token' || templateId === 'telegram-bot') {
+  if (templateId === 'trading-bot' || templateId === 'telegram-bot') {
     return [
       'Execution architecture requirements:',
       providerFlow,

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -14,6 +14,7 @@ import { SolanaToolbox } from '../../src/panels/SolanaToolbox/SolanaToolbox'
 import { TokenLaunchTool } from '../../src/panels/TokenLaunchTool/TokenLaunchTool'
 import { IntegrationCommandCenter } from '../../src/panels/IntegrationCommandCenter/IntegrationCommandCenter'
 import { ProjectReadiness } from '../../src/panels/ProjectReadiness/ProjectReadiness'
+import { ProjectStarter } from '../../src/panels/ProjectStarter/ProjectStarter'
 import DeployPanel from '../../src/panels/plugins/Deploy/Deploy'
 
 vi.mock('../../src/utils/lazyWithReload', () => ({
@@ -336,6 +337,20 @@ describe('App surface DOM coverage', () => {
 
     expect(useUIStore.getState().activeWorkspaceToolId).toBe('solana-toolbox')
     expect(useWorkflowShellStore.getState().drawerOpen).toBe(false)
+  })
+
+  it('keeps token launch out of New Project templates', async () => {
+    render(<ProjectStarter />)
+
+    expect(await screen.findByText('What do you want to build?')).toBeInTheDocument()
+    expect(screen.getByText('Anchor Program')).toBeInTheDocument()
+    expect(screen.getByText('Trading Bot')).toBeInTheDocument()
+    expect(screen.queryByText('Token Launch')).not.toBeInTheDocument()
+    expect(screen.queryByText('Pump.fun Token')).not.toBeInTheDocument()
+
+    await userEvent.type(screen.getByPlaceholderText('Filter templates...'), 'launch')
+
+    expect(screen.getByText('No templates match "launch"')).toBeInTheDocument()
   })
 
   it('renders Integration Command Center setup status and safe checks', async () => {


### PR DESCRIPTION
## Summary
- remove Token Launch and Pump.fun Token from New Project scaffolding templates
- remove Token Launch from the editor quick-start starter row
- keep Token Launch available as the standalone addon/tool surface
- bump version to 3.0.2

## Validation
- pnpm run typecheck
- pnpm exec vitest run test/panels/AppSurfaces.dom.test.tsx test/panels/ProjectStarter.runtime.test.ts
- pnpm test