### PR TITLE
feat: add staking utility surface

### DIFF
--- a/electron/ipc/launch.ts
+++ b/electron/ipc/launch.ts
@@ -12,6 +12,10 @@ export function registerLaunchHandlers() {
     return TokenLaunch.listLaunchWallets(projectId)
   }))
 
+  ipcMain.handle('launch:ensure-daemon-deployer-wallet', ipcHandler(async (_event, projectId?: string | null) => {
+    return TokenLaunch.ensureDaemonDeployerWallet(projectId)
+  }))
+
   ipcMain.handle('launch:pick-image', ipcHandler(async () => {
     return TokenLaunch.pickImage()
   }))

--- a/electron/ipc/terminal.ts
+++ b/electron/ipc/terminal.ts
@@ -1,11 +1,12 @@
 import { ipcMain, BrowserWindow, clipboard } from 'electron'
-import os from 'node:os'
 import * as pty from 'node-pty'
 import { getDb } from '../db/db'
 import { buildCommand, cleanupContextFile } from '../services/ClaudeRouter'
 import { registerPort } from '../services/PortService'
 import { ipcHandler } from '../services/IpcHandlerFactory'
 import { LogService } from '../services/LogService'
+import { getEmbeddedProviderStartupCommand, type ProviderShellId } from '../shared/providerLaunch'
+import { validateCwd } from '../shared/pathValidation'
 import type { Agent, Project, ActiveSession, TerminalSession, TerminalCreateInput, TerminalSpawnAgentInput, TerminalCreateOutput } from '../shared/types'
 
 // Regex patterns to auto-detect "listening on port X" from terminal output
@@ -39,6 +40,8 @@ function createPtySession(
   cwd: string,
   agentId: string | null,
   contextFilePath: string | null,
+  providerId: string | null = null,
+  isAgentShell = false,
 ): TerminalSession {
   let shell: string
   let shellArgs: string[]
@@ -74,11 +77,26 @@ function createPtySession(
     },
   })
 
-  const session: TerminalSession = { pty: ptyProcess, agentId, contextFilePath }
+  const session: TerminalSession = {
+    pty: ptyProcess,
+    agentId,
+    contextFilePath,
+    providerId,
+    isAgentShell,
+    dataBuffer: [],
+    rendererReady: false,
+  }
   sessions.set(id, session)
 
   ptyProcess.onData((data) => {
-    getWin()?.webContents.send('terminal:data', { id, data })
+    if (session.rendererReady) {
+      getWin()?.webContents.send('terminal:data', { id, data })
+    } else {
+      session.dataBuffer?.push(data)
+      if ((session.dataBuffer?.length ?? 0) > 200) {
+        session.dataBuffer = session.dataBuffer?.slice(-200)
+      }
+    }
 
     // Auto-detect port announcements and register them
     for (const pattern of PORT_PATTERNS) {
@@ -91,7 +109,7 @@ function createPtySession(
             const row = getDb().prepare('SELECT project_id FROM active_sessions WHERE id = ?').get(id) as ActiveSession | undefined
             if (row?.project_id) {
               registerPort(port, row.project_id, 'auto-detected')
-              getWin()?.webContents.send('ports:auto-registered', { port, projectId: row.project_id })
+              getWin()?.webContents.send('port:changed', { port, projectId: row.project_id, action: 'auto-registered' })
             }
           } catch (err) {
             LogService.warn('Terminal', `Failed to register auto-detected port ${port}`, { error: (err as Error).message })
@@ -117,14 +135,52 @@ function createPtySession(
 export function registerTerminalHandlers() {
   ipcMain.handle('terminal:create', ipcHandler(async (_event, opts: TerminalCreateInput) => {
     const id = crypto.randomUUID()
-    const cwd = opts?.cwd || os.homedir()
-    const session = createPtySession(id, '', [], cwd, null, null)
+    const cwd = opts?.cwd
+    if (!cwd) throw new Error('Terminal cwd is required')
+    validateCwd(cwd)
+    const session = createPtySession(id, '', [], cwd, null, null, null, opts?.isAgent ?? false)
 
     if (opts?.startupCommand?.trim()) {
       session.pty.write(`${opts.startupCommand.trim()}\r`)
     }
 
     const response: TerminalCreateOutput = { id, pid: session.pty.pid, agentId: null }
+    return response
+  }))
+
+  ipcMain.handle('terminal:spawnProvider', ipcHandler(async (_event, opts: {
+    providerId: ProviderShellId
+    projectId?: string
+    cwd?: string
+  }) => {
+    if (opts.providerId !== 'claude' && opts.providerId !== 'codex') {
+      throw new Error('Unsupported provider')
+    }
+
+    let cwd = opts.cwd
+    if (!cwd && opts.projectId) {
+      const project = getDb().prepare('SELECT path FROM projects WHERE id = ?').get(opts.projectId) as { path: string } | undefined
+      cwd = project?.path
+    }
+    if (!cwd) throw new Error('Project path is required to launch provider terminal')
+    validateCwd(cwd)
+
+    const id = crypto.randomUUID()
+    const session = createPtySession(id, '', [], cwd, null, null, opts.providerId, true)
+    session.pty.write(`${getEmbeddedProviderStartupCommand(opts.providerId)}\r`)
+
+    if (opts.projectId) {
+      getDb().prepare(
+        'INSERT INTO active_sessions (id, project_id, agent_id, terminal_id, pid, started_at) VALUES (?,?,?,?,?,?)'
+      ).run(id, opts.projectId, null, id, session.pty.pid, Date.now())
+    }
+
+    const response: TerminalCreateOutput = {
+      id,
+      pid: session.pty.pid,
+      agentId: null,
+      agentName: opts.providerId === 'claude' ? 'Claude' : 'Codex',
+    }
     return response
   }))
 
@@ -155,6 +211,17 @@ export function registerTerminalHandlers() {
   ipcMain.on('terminal:resize', (_event, id: string, cols: number, rows: number) => {
     try { sessions.get(id)?.pty.resize(cols, rows) } catch (err) {
       LogService.warn('Terminal', `Failed to resize terminal ${id}`, { error: (err as Error).message })
+    }
+  })
+
+  ipcMain.on('terminal:ready', (_event, id: string) => {
+    const session = sessions.get(id)
+    if (!session) return
+    session.rendererReady = true
+    const buffered = session.dataBuffer ?? []
+    session.dataBuffer = []
+    for (const data of buffered) {
+      getWin()?.webContents.send('terminal:data', { id, data })
     }
   })
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -387,6 +387,7 @@ contextBridge.exposeInMainWorld('daemon', {
   launch: {
     listLaunchpads: () => ipcRenderer.invoke('launch:list-launchpads'),
     listWalletOptions: (projectId?: string | null) => ipcRenderer.invoke('launch:list-wallet-options', projectId),
+    ensureDaemonDeployerWallet: (projectId?: string | null) => ipcRenderer.invoke('launch:ensure-daemon-deployer-wallet', projectId),
     listPulseTokens: (input?: { category?: PulseTokenCategory; pageNumber?: number; pageSize?: number }) => ipcRenderer.invoke('launch:list-pulse-tokens', input),
     pickImage: () => ipcRenderer.invoke('launch:pick-image'),
     preflightToken: (input: object) => ipcRenderer.invoke('launch:preflight-token', input),

--- a/electron/services/SettingsService.ts
+++ b/electron/services/SettingsService.ts
@@ -101,7 +101,7 @@ export function setOnboardingProgress(progress: OnboardingProgress): void {
   setJsonSetting('onboarding_progress', progress)
 }
 
-const DEFAULT_PINNED_TOOLS = ['git', 'browser', 'token-launch', 'solana-toolbox', 'pro']
+const DEFAULT_PINNED_TOOLS = ['git', 'browser', 'solana-toolbox', 'pro']
 const PRO_PIN_MIGRATION_KEY = 'pinned_tools_pro_default_added'
 const UI_RECOVERY_KEYS = [
   'layout_center_mode',

--- a/electron/services/TokenLaunchService.ts
+++ b/electron/services/TokenLaunchService.ts
@@ -25,6 +25,8 @@ export interface LaunchWalletOption {
   name: string
   address: string
   isDefault: boolean
+  walletType: string
+  ecosystemRole: 'daemon-deployer' | null
   hasKeypair: boolean
   isAssignedToActiveProject: boolean
   assignedProjectIds: string[]
@@ -91,6 +93,10 @@ export interface TokenLaunchPreflight {
   checks: TokenLaunchCheck[]
 }
 
+const DAEMON_DEPLOYER_NAME = 'DAEMON Deployer'
+const DAEMON_DEPLOYER_ADDRESS = 'yk8R9ivCGdtQeyo71JYyB6CjfSsMnWcYthisPwT'
+const DAEMON_DEPLOYER_WALLET_TYPE = 'daemon-deployer'
+
 const bonkDefinition: LaunchpadDefinition = {
   id: 'bonk',
   name: 'Bonk',
@@ -139,10 +145,23 @@ export function listLaunchWallets(projectId?: string | null): LaunchWalletOption
     name: wallet.name,
     address: wallet.address,
     isDefault: wallet.is_default === 1,
+    walletType: wallet.wallet_type ?? 'user',
+    ecosystemRole: wallet.address === DAEMON_DEPLOYER_ADDRESS ? 'daemon-deployer' : null,
     hasKeypair: WalletService.hasKeypair(wallet.id),
     isAssignedToActiveProject: wallet.id === projectWalletId,
     assignedProjectIds: wallet.assigned_project_ids ?? [],
   }))
+}
+
+export function ensureDaemonDeployerWallet(projectId?: string | null): LaunchWalletOption {
+  const wallet = WalletService.ensureWatchWallet(
+    DAEMON_DEPLOYER_NAME,
+    DAEMON_DEPLOYER_ADDRESS,
+    DAEMON_DEPLOYER_WALLET_TYPE,
+  )
+  const option = listLaunchWallets(projectId).find((entry) => entry.id === wallet.id)
+  if (!option) throw new Error('Could not resolve DAEMON deployer wallet')
+  return option
 }
 
 export async function pickImage(): Promise<string | null> {
@@ -179,14 +198,28 @@ export async function preflightLaunch(input: TokenLaunchInput): Promise<TokenLau
   }
 
   const hasKeypair = WalletService.hasKeypair(input.walletId)
+  const selectedWallet = listLaunchWallets(input.projectId ?? null).find((wallet) => wallet.id === input.walletId)
   checks.push({
     id: 'wallet-keypair',
     label: 'Signing Wallet',
     status: hasKeypair ? 'pass' : 'fail',
     detail: hasKeypair
-      ? 'Selected wallet has an imported keypair.'
+      ? selectedWallet?.ecosystemRole === 'daemon-deployer'
+        ? `DAEMON Deployer is selected. Launch creator/deployer will be ${DAEMON_DEPLOYER_ADDRESS}.`
+        : 'Selected wallet has an imported keypair.'
       : 'Selected wallet is watch-only. Import or generate a signing wallet first.',
   })
+
+  if (selectedWallet?.ecosystemRole === 'daemon-deployer') {
+    checks.push({
+      id: 'daemon-deployer',
+      label: 'DAEMON Deployer',
+      status: hasKeypair ? 'pass' : 'fail',
+      detail: hasKeypair
+        ? 'The matching DAEMON Deployer keypair is available locally for signing.'
+        : `Import the keypair for ${DAEMON_DEPLOYER_ADDRESS} before launching if you want this address to appear as deployer.`,
+    })
+  }
 
   const projectWalletId = WalletService.getProjectWalletId(input.projectId ?? null)
   if (projectWalletId && projectWalletId !== input.walletId) {

--- a/electron/services/TokenLaunchService.ts
+++ b/electron/services/TokenLaunchService.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { PublicKey } from '@solana/web3.js'
 import { getDb } from '../db/db'
 import * as PumpFun from './PumpFunService'
 import * as Settings from './SettingsService'
@@ -154,6 +155,14 @@ export function listLaunchWallets(projectId?: string | null): LaunchWalletOption
 }
 
 export function ensureDaemonDeployerWallet(projectId?: string | null): LaunchWalletOption {
+  try {
+    // Validate here so the UI reports that the configured deployer address is invalid,
+    // instead of failing deeper in generic wallet creation.
+    new PublicKey(DAEMON_DEPLOYER_ADDRESS)
+  } catch {
+    throw new Error(`Configured DAEMON deployer address is not a valid Solana wallet: ${DAEMON_DEPLOYER_ADDRESS}`)
+  }
+
   const wallet = WalletService.ensureWatchWallet(
     DAEMON_DEPLOYER_NAME,
     DAEMON_DEPLOYER_ADDRESS,

--- a/electron/services/WalletService.ts
+++ b/electron/services/WalletService.ts
@@ -249,6 +249,7 @@ export function listWallets() {
     name: wallet.name,
     address: wallet.address,
     is_default: wallet.is_default,
+    wallet_type: wallet.wallet_type ?? 'user',
     created_at: wallet.created_at,
     assigned_project_ids: projectAssignments.get(wallet.id) ?? [],
   }))
@@ -267,6 +268,28 @@ export function createWallet(name: string, address: string) {
     'INSERT INTO wallets (id, name, address, is_default, created_at) VALUES (?,?,?,?,?)'
   ).run(id, trimmedName, trimmedAddress, existingDefault ? 0 : 1, Date.now())
   return db.prepare('SELECT id, name, address, is_default, created_at FROM wallets WHERE id = ?').get(id)
+}
+
+export function ensureWatchWallet(name: string, address: string, walletType = 'user') {
+  const trimmedName = name.trim()
+  const trimmedAddress = address.trim()
+  if (!trimmedName) throw new Error('Wallet name is required')
+  if (!isValidSolanaAddress(trimmedAddress)) throw new Error('Invalid Solana wallet address')
+
+  const db = getDb()
+  const existing = db.prepare('SELECT id FROM wallets WHERE address = ? LIMIT 1').get(trimmedAddress) as { id: string } | undefined
+  if (existing) {
+    db.prepare('UPDATE wallets SET wallet_type = ? WHERE id = ?').run(walletType, existing.id)
+    const wallet = listWallets().find((entry) => entry.id === existing.id)
+    if (!wallet) throw new Error('Could not resolve existing wallet')
+    return wallet
+  }
+
+  const created = createWallet(trimmedName, trimmedAddress) as { id: string }
+  db.prepare('UPDATE wallets SET wallet_type = ? WHERE id = ?').run(walletType, created.id)
+  const wallet = listWallets().find((entry) => entry.id === created.id)
+  if (!wallet) throw new Error('Could not resolve created wallet')
+  return wallet
 }
 
 export function deleteWallet(id: string) {

--- a/electron/services/WalletService.ts
+++ b/electron/services/WalletService.ts
@@ -267,7 +267,7 @@ export function createWallet(name: string, address: string) {
   db.prepare(
     'INSERT INTO wallets (id, name, address, is_default, created_at) VALUES (?,?,?,?,?)'
   ).run(id, trimmedName, trimmedAddress, existingDefault ? 0 : 1, Date.now())
-  return db.prepare('SELECT id, name, address, is_default, created_at FROM wallets WHERE id = ?').get(id)
+  return db.prepare('SELECT id, name, address, is_default, wallet_type, created_at FROM wallets WHERE id = ?').get(id)
 }
 
 export function ensureWatchWallet(name: string, address: string, walletType = 'user') {
@@ -279,7 +279,6 @@ export function ensureWatchWallet(name: string, address: string, walletType = 'u
   const db = getDb()
   const existing = db.prepare('SELECT id FROM wallets WHERE address = ? LIMIT 1').get(trimmedAddress) as { id: string } | undefined
   if (existing) {
-    db.prepare('UPDATE wallets SET wallet_type = ? WHERE id = ?').run(walletType, existing.id)
     const wallet = listWallets().find((entry) => entry.id === existing.id)
     if (!wallet) throw new Error('Could not resolve existing wallet')
     return wallet

--- a/electron/shared/types.ts
+++ b/electron/shared/types.ts
@@ -350,6 +350,7 @@ export interface WalletListEntry {
   name: string
   address: string
   is_default: number
+  wallet_type: string
   created_at: number
   assigned_project_ids: string[]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ function App() {
 
   const { loadProjects, addProject, removeProject } = useProjects()
   const { paletteMode, setPaletteMode, paletteFiles, handleFileSelect, closePalette } = useCommandPalette()
+  const isToolVisible = useWorkspaceProfileStore((s) => s.isToolVisible)
   const closeAgentLauncher = useCallback(() => setShowAgentLauncher(false), [])
 
   useAppShortcuts({ setPaletteMode, setShowAgentLauncher, setShowExplorer: setShowExplorer, setShowRightPanel, setShowTerminal })
@@ -262,7 +263,7 @@ function App() {
   useEffect(() => {
     if (!appReady) return
     const pinnedTools = useUIStore.getState().pinnedTools
-    const likelyNext = ['wallet', 'git', 'token-launch']
+    const likelyNext = ['wallet', 'git', 'project-readiness']
     const warmSet = [...new Set([...pinnedTools, ...likelyNext])]
       .filter((toolId) => toolId !== 'browser')
       .slice(0, 6)
@@ -331,8 +332,9 @@ function App() {
         closeDrawer: () => useWorkflowShellStore.getState().closeDrawer(),
         toggleBrowserTab: () => useUIStore.getState().toggleBrowserTab(),
         toggleDashboardTab: () => useUIStore.getState().toggleDashboardTab(),
+        isToolVisible,
       }),
-    [],
+    [isToolVisible],
   )
 
   return (

--- a/src/components/CommandDrawer/CommandDrawer.tsx
+++ b/src/components/CommandDrawer/CommandDrawer.tsx
@@ -4,6 +4,7 @@ import { usePluginStore } from '../../store/plugins'
 import { useWorkspaceProfileStore } from '../../store/workspaceProfile'
 import { useWorkflowShellStore } from '../../store/workflowShell'
 import { PLUGIN_REGISTRY } from '../../plugins/registry'
+import { TOOL_DISPLAY_NAMES } from '../../constants/toolRegistry'
 import { lazyNamedWithReload, lazyWithReload } from '../../utils/lazyWithReload'
 import './CommandDrawer.css'
 
@@ -366,14 +367,7 @@ export const TOOL_ICONS: Record<string, ComponentType<{ size?: number }>> = {
 }
 
 // Tool name lookup
-export const TOOL_NAMES: Record<string, string> = {
-  git: 'Git', deploy: 'Deploy', env: 'Env',
-  wallet: 'Wallet', email: 'Email', browser: 'Browser',
-  ports: 'Ports', processes: 'Processes', settings: 'Settings',
-  'image-editor': 'Image Editor', 'solana-toolbox': 'Solana', 'block-scanner': 'Block Scanner', docs: 'Docs', starter: 'New Project',
-  'token-launch': 'Token Launch', integrations: 'Integrations', 'project-readiness': 'Project Readiness',
-  dashboard: 'Dashboard', sessions: 'Sessions', hackathon: 'Hackathon', plugins: 'Plugins', recovery: 'Recovery', pro: 'Daemon Pro', activity: 'Activity',
-}
+export const TOOL_NAMES: Record<string, string> = { ...TOOL_DISPLAY_NAMES }
 
 // Lazy-load all tool components
 const loadGitPanel = () => import('../../panels/GitPanel/GitPanel')

--- a/src/components/CommandPalette/commands.ts
+++ b/src/components/CommandPalette/commands.ts
@@ -6,6 +6,13 @@ export interface Command {
   action: () => void
 }
 
+interface ToolCommandDefinition {
+  commandId: string
+  label: string
+  toolId: string
+  shortcut?: string
+}
+
 type CenterModeSetter = (mode: string) => void
 type CenterModeGetter = () => string
 type VoidCallback = () => void
@@ -21,6 +28,7 @@ interface CommandDeps {
   closeDrawer: VoidCallback
   toggleBrowserTab?: VoidCallback
   toggleDashboardTab?: VoidCallback
+  isToolVisible?: (toolId: string) => boolean
 }
 
 export function buildCommands(deps: CommandDeps): Command[] {
@@ -35,7 +43,33 @@ export function buildCommands(deps: CommandDeps): Command[] {
     closeDrawer,
     toggleBrowserTab,
     toggleDashboardTab,
+    isToolVisible,
   } = deps
+
+  const toolCommands: ToolCommandDefinition[] = [
+    { commandId: 'nav:git', label: 'Open Git Panel', toolId: 'git' },
+    { commandId: 'nav:deploy', label: 'Open Deploy Panel', toolId: 'deploy' },
+    { commandId: 'nav:email', label: 'Open Email', toolId: 'email' },
+    { commandId: 'nav:env', label: 'Open Env Manager', toolId: 'env' },
+    { commandId: 'nav:wallet', label: 'Open Wallet Panel', toolId: 'wallet' },
+    { commandId: 'nav:project-readiness', label: 'Open Solana Project Readiness', toolId: 'project-readiness' },
+    { commandId: 'nav:starter', label: 'New Project from Template', toolId: 'starter' },
+    { commandId: 'nav:settings', label: 'Open Settings', toolId: 'settings', shortcut: 'Ctrl+,' },
+    { commandId: 'nav:ports', label: 'Open Ports', toolId: 'ports' },
+    { commandId: 'nav:process', label: 'Open Processes', toolId: 'processes' },
+    { commandId: 'nav:plugins', label: 'Open Plugins', toolId: 'plugins' },
+    { commandId: 'nav:recovery', label: 'Open Recovery', toolId: 'recovery' },
+  ]
+
+  const visibleToolCommands = toolCommands
+    .filter((command) => (isToolVisible ? isToolVisible(command.toolId) : true))
+    .map((command) => ({
+      id: command.commandId,
+      label: command.label,
+      shortcut: command.shortcut,
+      category: 'Navigation',
+      action: () => openWorkspaceTool(command.toolId),
+    }))
 
   return [
     // Navigation
@@ -52,79 +86,7 @@ export function buildCommands(deps: CommandDeps): Command[] {
       category: 'Navigation',
       action: () => openAgentLauncher(),
     },
-    {
-      id: 'nav:git',
-      label: 'Open Git Panel',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('git'),
-    },
-    {
-      id: 'nav:deploy',
-      label: 'Open Deploy Panel',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('deploy'),
-    },
-    {
-      id: 'nav:email',
-      label: 'Open Email',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('email'),
-    },
-    {
-      id: 'nav:env',
-      label: 'Open Env Manager',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('env'),
-    },
-    {
-      id: 'nav:wallet',
-      label: 'Open Wallet Panel',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('wallet'),
-    },
-    {
-      id: 'nav:project-readiness',
-      label: 'Open Solana Project Readiness',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('project-readiness'),
-    },
-    {
-      id: 'nav:starter',
-      label: 'New Project from Template',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('starter'),
-    },
-    {
-      id: 'nav:settings',
-      label: 'Open Settings',
-      shortcut: 'Ctrl+,',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('settings'),
-    },
-    {
-      id: 'nav:ports',
-      label: 'Open Ports',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('ports'),
-    },
-    {
-      id: 'nav:process',
-      label: 'Open Processes',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('processes'),
-    },
-    {
-      id: 'nav:plugins',
-      label: 'Open Plugins',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('plugins'),
-    },
-    {
-      id: 'nav:recovery',
-      label: 'Open Recovery',
-      category: 'Navigation',
-      action: () => openWorkspaceTool('recovery'),
-    },
+    ...visibleToolCommands,
     {
       id: 'nav:main-view',
       label: 'Return to Editor',
@@ -139,12 +101,6 @@ export function buildCommands(deps: CommandDeps): Command[] {
       shortcut: 'Ctrl+B',
       category: 'View',
       action: () => toggleRightPanel(),
-    },
-    {
-      id: 'view:canvas-mode',
-      label: 'Switch to Canvas Mode',
-      category: 'View',
-      action: () => setCenterMode('canvas'),
     },
     {
       id: 'view:grind-mode',

--- a/src/constants/toolIds.ts
+++ b/src/constants/toolIds.ts
@@ -1,9 +1,5 @@
-// Canonical list of all built-in drawer tool IDs.
-// Keep in sync with BUILTIN_TOOLS in CommandDrawer.tsx.
-// This list covers drawer-managed tools only. Browser mode is not a drawer tool.
-export const BUILTIN_TOOL_IDS: string[] = [
-  'starter', 'git', 'deploy', 'env', 'wallet', 'email',
-  'ports', 'processes', 'settings', 'image-editor',
-  'token-launch', 'project-readiness', 'solana-toolbox', 'integrations', 'block-scanner', 'docs', 'dashboard',
-  'sessions', 'hackathon', 'pro', 'plugins', 'recovery',
-]
+import { DRAWER_TOOL_IDS } from './toolRegistry'
+
+// Canonical list of drawer-managed built-in tools.
+// Derived from the shared registry so visibility, profiles, and drawer behavior stay aligned.
+export const BUILTIN_TOOL_IDS: string[] = [...DRAWER_TOOL_IDS]

--- a/src/constants/toolRegistry.ts
+++ b/src/constants/toolRegistry.ts
@@ -1,0 +1,72 @@
+export type ToolModuleClass = 'core' | 'addon'
+export type ToolSurface = 'drawer' | 'tab'
+
+export interface ToolRegistryEntry {
+  id: string
+  name: string
+  moduleClass: ToolModuleClass
+  surface: ToolSurface
+}
+
+export const TOOL_REGISTRY: ToolRegistryEntry[] = [
+  { id: 'starter', name: 'New Project', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'git', name: 'Git', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'deploy', name: 'Deploy', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'env', name: 'Env', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'wallet', name: 'Wallet', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'email', name: 'Email', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'ports', name: 'Ports', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'processes', name: 'Processes', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'settings', name: 'Settings', moduleClass: 'core', surface: 'drawer' },
+  { id: 'image-editor', name: 'Image Editor', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'token-launch', name: 'Token Launch', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'project-readiness', name: 'Project Readiness', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'solana-toolbox', name: 'Solana', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'integrations', name: 'Integrations', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'block-scanner', name: 'Block Scanner', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'docs', name: 'Docs', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'dashboard', name: 'Dashboard', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'sessions', name: 'Sessions', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'hackathon', name: 'Hackathon', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'pro', name: 'Daemon Pro', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'plugins', name: 'Plugins', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'recovery', name: 'Recovery', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'activity', name: 'Activity', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'browser', name: 'Browser', moduleClass: 'addon', surface: 'tab' },
+] as const
+
+export const TOOL_REGISTRY_BY_ID = Object.fromEntries(
+  TOOL_REGISTRY.map((tool) => [tool.id, tool]),
+) as Record<string, ToolRegistryEntry>
+
+export const TOOL_DISPLAY_NAMES = Object.fromEntries(
+  TOOL_REGISTRY.map((tool) => [tool.id, tool.name]),
+) as Record<string, string>
+
+export const CORE_TOOL_IDS = TOOL_REGISTRY
+  .filter((tool) => tool.moduleClass === 'core')
+  .map((tool) => tool.id)
+
+export const ADDON_TOOL_IDS = TOOL_REGISTRY
+  .filter((tool) => tool.moduleClass === 'addon')
+  .map((tool) => tool.id)
+
+export const DRAWER_TOOL_IDS = TOOL_REGISTRY
+  .filter((tool) => tool.surface === 'drawer')
+  .map((tool) => tool.id)
+
+export function getToolRegistryEntry(toolId: string): ToolRegistryEntry | null {
+  return TOOL_REGISTRY_BY_ID[toolId] ?? null
+}
+
+export function isCoreTool(toolId: string): boolean {
+  return getToolRegistryEntry(toolId)?.moduleClass === 'core'
+}
+
+export function isAddonTool(toolId: string): boolean {
+  return getToolRegistryEntry(toolId)?.moduleClass === 'addon'
+}
+
+export function isToolDisableable(toolId: string): boolean {
+  return !isCoreTool(toolId)
+}

--- a/src/constants/workspaceProfiles.ts
+++ b/src/constants/workspaceProfiles.ts
@@ -1,3 +1,5 @@
+import { CORE_TOOL_IDS } from './toolRegistry'
+
 export type WorkspaceProfileName = 'web' | 'solana' | 'custom'
 
 export interface WorkspaceProfile {
@@ -8,7 +10,7 @@ export interface WorkspaceProfile {
 const WEB_TOOLS = [
   'starter', 'git', 'deploy', 'env', 'email', 'ports',
   'processes', 'settings', 'image-editor', 'docs',
-  'sessions', 'plugins', 'recovery',
+  'sessions', 'plugins', 'recovery', 'activity',
 ]
 
 const SOLANA_TOOLS = [
@@ -34,6 +36,6 @@ export function getDefaultVisibility(
   }
 
   return Object.fromEntries(
-    allToolIds.map((id) => [id, allowedTools.includes(id)]),
+    allToolIds.map((id) => [id, CORE_TOOL_IDS.includes(id) || allowedTools.includes(id)]),
   )
 }

--- a/src/panels/IconSidebar/IconSidebar.css
+++ b/src/panels/IconSidebar/IconSidebar.css
@@ -14,13 +14,13 @@
 }
 
 .sidebar-icon {
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--t3);
-  border-radius: 10px;
+  border-radius: 8px;
   position: relative;
   border: 1px solid transparent;
   background: transparent;
@@ -36,11 +36,10 @@
   color: var(--t1);
   background: rgba(255, 255, 255, 0.03);
   border-color: rgba(255, 255, 255, 0.05);
-  transform: translateY(-1px);
 }
 
 .sidebar-icon:hover svg {
-  transform: scale(1.04);
+  opacity: 0.92;
 }
 
 .sidebar-icon.active {
@@ -89,7 +88,7 @@
 .sidebar-drop-zone {
   width: 32px;
   height: 32px;
-  border-radius: 10px;
+  border-radius: 8px;
   margin: 4px auto;
   transition: height 0.15s, background 0.15s, border-color 0.15s, opacity 0.15s;
   border: 1px dashed var(--s5);
@@ -220,9 +219,9 @@
 .colosseum-icon-wrap {
   position: relative;
   overflow: hidden;
-  border-radius: 10px;
-  width: 36px;
-  height: 36px;
+  border-radius: 8px;
+  width: 34px;
+  height: 34px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -237,7 +236,6 @@
   color: #ffe270;
   border-color: rgba(255, 216, 77, 0.14);
   background: rgba(255, 216, 77, 0.05);
-  transform: translateY(-1px);
 }
 
 .colosseum-icon-wrap.active {

--- a/src/panels/LaunchWizard/LaunchWizard.css
+++ b/src/panels/LaunchWizard/LaunchWizard.css
@@ -198,6 +198,51 @@
   line-height: 1.5;
 }
 
+.lw-daemon-deployer-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px 14px;
+  margin-bottom: 10px;
+  background: linear-gradient(135deg, rgba(62, 207, 142, 0.08), rgba(255, 216, 77, 0.04));
+  border: 1px solid rgba(62, 207, 142, 0.16);
+  border-radius: 8px;
+}
+
+.lw-daemon-deployer-card.active {
+  border-color: rgba(62, 207, 142, 0.42);
+  box-shadow: 0 0 0 1px rgba(62, 207, 142, 0.08) inset;
+}
+
+.lw-daemon-deployer-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--t1);
+  margin-bottom: 3px;
+}
+
+.lw-daemon-deployer-copy {
+  font-size: 10px;
+  color: var(--t3);
+  line-height: 1.45;
+  word-break: break-all;
+}
+
+.lw-daemon-deployer-status {
+  margin-top: 6px;
+  font-size: 10px;
+  color: var(--green);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.lw-daemon-deployer-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
 /* ── Image upload ── */
 .lw-image-row {
   display: flex;

--- a/src/panels/LaunchWizard/LaunchWizard.tsx
+++ b/src/panels/LaunchWizard/LaunchWizard.tsx
@@ -199,6 +199,77 @@ export function LaunchWizard() {
     launch(params)
   }
 
+  const upsertWallet = (wallet: LaunchWalletOption) => {
+    setWallets((current) => {
+      const exists = current.some((entry) => entry.id === wallet.id)
+      return exists
+        ? current.map((entry) => entry.id === wallet.id ? wallet : entry)
+        : [wallet, ...current]
+    })
+  }
+
+  const handleUseDaemonDeployer = async () => {
+    const res = await window.daemon.launch.ensureDaemonDeployerWallet(activeProjectId)
+    if (!res.ok || !res.data) {
+      useNotificationsStore.getState().addActivity({
+        kind: 'error',
+        context: 'Runtime',
+        message: res.error ?? 'Could not prepare DAEMON Deployer wallet',
+        projectId: activeProjectId,
+        projectName: activeProjectName,
+      })
+      return
+    }
+
+    upsertWallet(res.data)
+    setS2((prev) => ({ ...prev, walletId: res.data!.id }))
+    setPreflight(null)
+    setConfirmed(false)
+    useNotificationsStore.getState().addActivity({
+      kind: res.data.hasKeypair ? 'success' : 'warning',
+      context: 'Runtime',
+      message: res.data.hasKeypair
+        ? 'DAEMON Deployer selected for token launch'
+        : 'DAEMON Deployer selected. Import the matching keypair before launch.',
+      projectId: activeProjectId,
+      projectName: activeProjectName,
+    })
+  }
+
+  const handleImportSelectedWalletKeypair = async () => {
+    if (!s2.walletId) return
+    const res = await window.daemon.pumpfun.importKeypair(s2.walletId)
+    if (!res.ok) {
+      useNotificationsStore.getState().addActivity({
+        kind: 'error',
+        context: 'Runtime',
+        message: res.error ?? 'Could not import wallet keypair',
+        projectId: activeProjectId,
+        projectName: activeProjectName,
+      })
+      return
+    }
+    if (!res.data) return
+
+    const walletsRes = await window.daemon.launch.listWalletOptions(activeProjectId)
+    if (walletsRes.ok && walletsRes.data) {
+      setWallets(walletsRes.data)
+    } else {
+      setWallets((current) => current.map((wallet) => (
+        wallet.id === s2.walletId ? { ...wallet, hasKeypair: true } : wallet
+      )))
+    }
+    setPreflight(null)
+    setConfirmed(false)
+    useNotificationsStore.getState().addActivity({
+      kind: 'success',
+      context: 'Runtime',
+      message: 'Wallet keypair imported for launch signing',
+      projectId: activeProjectId,
+      projectName: activeProjectName,
+    })
+  }
+
   const handleRetry = () => {
     reset()
     setStep(3)
@@ -315,7 +386,14 @@ export function LaunchWizard() {
             <StepDetails s1={s1} setS1={setS1} onPickImage={handlePickImage} showErrors={hasAttemptedNext} />
           )}
           {step === 2 && (
-            <StepConfig s2={s2} setS2={setS2} wallets={wallets} launchpads={launchpads} />
+            <StepConfig
+              s2={s2}
+              setS2={setS2}
+              wallets={wallets}
+              launchpads={launchpads}
+              onUseDaemonDeployer={handleUseDaemonDeployer}
+              onImportSelectedWalletKeypair={handleImportSelectedWalletKeypair}
+            />
           )}
           {step === 3 && (
             <StepPreview
@@ -548,13 +626,19 @@ function StepConfig({
   setS2,
   wallets,
   launchpads,
+  onUseDaemonDeployer,
+  onImportSelectedWalletKeypair,
 }: {
   s2: Step2State
   setS2: React.Dispatch<React.SetStateAction<Step2State>>
   wallets: LaunchWalletOption[]
   launchpads: LaunchpadDefinition[]
+  onUseDaemonDeployer: () => void
+  onImportSelectedWalletKeypair: () => void
 }) {
   const selectedWallet = wallets.find((wallet) => wallet.id === s2.walletId) ?? null
+  const daemonDeployer = wallets.find((wallet) => wallet.ecosystemRole === 'daemon-deployer') ?? null
+  const selectedDaemonDeployer = selectedWallet?.ecosystemRole === 'daemon-deployer'
 
   return (
     <div>
@@ -600,6 +684,31 @@ function StepConfig({
 
       <div className="lw-field">
         <label className="lw-label">Signing Wallet</label>
+        <div className={`lw-daemon-deployer-card ${selectedDaemonDeployer ? 'active' : ''}`}>
+          <div>
+            <div className="lw-daemon-deployer-title">DAEMON Deployer</div>
+            <div className="lw-daemon-deployer-copy">
+              Use yk8R9ivCGdtQeyo71JYyB6CjfSsMnWcYthisPwT as the token deployer.
+            </div>
+            <div className="lw-daemon-deployer-status">
+              {daemonDeployer
+                ? daemonDeployer.hasKeypair
+                  ? 'Signer ready'
+                  : 'Keypair required'
+                : 'Not added yet'}
+            </div>
+          </div>
+          <div className="lw-daemon-deployer-actions">
+            <button type="button" className="lw-btn secondary" onClick={onUseDaemonDeployer}>
+              {selectedDaemonDeployer ? 'Selected' : 'Use Deployer'}
+            </button>
+            {selectedDaemonDeployer && !selectedWallet?.hasKeypair && (
+              <button type="button" className="lw-btn secondary" onClick={onImportSelectedWalletKeypair}>
+                Import Keypair
+              </button>
+            )}
+          </div>
+        </div>
         <select
           className="lw-input"
           value={s2.walletId}
@@ -612,6 +721,7 @@ function StepConfig({
           {wallets.map((w) => (
             <option key={w.id} value={w.id}>
               {w.name}
+              {w.ecosystemRole === 'daemon-deployer' ? ' (DAEMON Deployer)' : ''}
               {w.isAssignedToActiveProject ? ' (Project)' : w.isDefault ? ' (Default)' : ''}
               {!w.hasKeypair ? ' (Watch-only)' : ''}
               {' — '}
@@ -621,7 +731,9 @@ function StepConfig({
         </select>
         {selectedWallet && (
           <div className="lw-help-text">
-            {selectedWallet.isAssignedToActiveProject
+            {selectedDaemonDeployer
+              ? 'This launch will use the DAEMON deployer address if the matching keypair is imported.'
+              : selectedWallet.isAssignedToActiveProject
               ? 'This wallet is assigned to the active project.'
               : selectedWallet.isDefault
                 ? 'This wallet is your default portfolio wallet.'

--- a/src/panels/Onboarding/OnboardingWizard.css
+++ b/src/panels/Onboarding/OnboardingWizard.css
@@ -14,9 +14,23 @@
   background: var(--s1);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 32px;
+  padding: 28px;
   width: 440px;
   max-width: 90vw;
+}
+
+.wizard-brand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.wizard-brand-mark {
+  width: 34px;
+  height: 34px;
+  object-fit: contain;
 }
 
 .wizard-title {
@@ -25,7 +39,7 @@
   text-transform: uppercase;
   color: var(--t1);
   text-align: center;
-  margin-bottom: 20px;
+  margin: 0;
 }
 
 /* Progress bar */
@@ -34,7 +48,7 @@
   align-items: center;
   justify-content: center;
   gap: 0;
-  margin-bottom: 20px;
+  margin-bottom: 18px;
 }
 
 .wizard-progress-item {
@@ -93,7 +107,7 @@
   font-size: 12px;
   color: var(--t2);
   text-align: center;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 
 /* Step content */
@@ -424,7 +438,7 @@
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  padding: 12px 14px;
+  padding: 14px;
   background: var(--s2);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -432,6 +446,10 @@
   text-align: left;
   transition: border-color var(--transition-fast), background var(--transition-fast);
   width: 100%;
+}
+
+.step-profile-copy {
+  min-width: 0;
 }
 
 .step-profile-card:hover {

--- a/src/panels/Onboarding/OnboardingWizard.tsx
+++ b/src/panels/Onboarding/OnboardingWizard.tsx
@@ -7,6 +7,7 @@ import { StepClaude } from './steps/StepClaude'
 import { StepGmail } from './steps/StepGmail'
 import { StepVercel } from './steps/StepVercel'
 import { StepRailway } from './steps/StepRailway'
+import daemonIcon from '../../assets/daemon-icon.png'
 import './OnboardingWizard.css'
 
 const STEP_LABELS: Record<OnboardingStepId, string> = {
@@ -76,7 +77,10 @@ export function OnboardingWizard() {
       onKeyDown={handleKeyDown}
     >
       <div className="wizard-card">
-        <div className="wizard-title">DAEMON</div>
+        <div className="wizard-brand">
+          <img src={daemonIcon} alt="" className="wizard-brand-mark" draggable={false} />
+          <div className="wizard-title">DAEMON</div>
+        </div>
 
         {/* Progress dots */}
         <div className="wizard-progress">

--- a/src/panels/Onboarding/steps/StepProfile.tsx
+++ b/src/panels/Onboarding/steps/StepProfile.tsx
@@ -20,8 +20,10 @@ function ProfileCard({ name, label, description, icon, selected, onSelect }: Pro
       type="button"
     >
       <div className="step-profile-icon">{icon}</div>
-      <div className="step-profile-label">{label}</div>
-      <div className="step-profile-desc">{description}</div>
+      <div className="step-profile-copy">
+        <div className="step-profile-label">{label}</div>
+        <div className="step-profile-desc">{description}</div>
+      </div>
     </button>
   )
 }

--- a/src/panels/ProPanel/ProPanel.css
+++ b/src/panels/ProPanel/ProPanel.css
@@ -121,12 +121,87 @@
 }
 
 .pro-overview,
+.pro-staking,
 .pro-skills,
 .pro-sync,
 .pro-arena {
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+.pro-staking-hero,
+.pro-staking-actions-card,
+.pro-staking-tier-card {
+  padding: 16px;
+  background: var(--s1);
+  border: 1px solid var(--s4);
+  border-radius: 8px;
+}
+
+.pro-staking-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  background:
+    radial-gradient(circle at top right, rgba(62, 207, 142, 0.12), transparent 35%),
+    linear-gradient(145deg, rgba(15, 19, 17, 0.98), rgba(24, 30, 27, 0.92));
+}
+
+.pro-staking-pill-group,
+.pro-staking-action-row,
+.pro-staking-tier-head {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.pro-staking-pill {
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--s4);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--t3);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.pro-staking-pill.eligible,
+.pro-staking-pill.live {
+  border-color: rgba(62, 207, 142, 0.42);
+  color: var(--green);
+}
+
+.pro-staking-pill.planned {
+  border-color: rgba(241, 207, 117, 0.32);
+  color: #f1cf75;
+}
+
+.pro-staking-pill-live {
+  border-color: rgba(96, 165, 250, 0.35);
+  color: #8ab4ff;
+}
+
+.pro-staking-status-grid,
+.pro-staking-tier-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.pro-staking-tier-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.pro-staking-unlocks {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .pro-hero {
@@ -398,8 +473,13 @@
 }
 
 @media (max-width: 900px) {
+  .pro-staking-hero,
   .pro-arena-contest,
   .pro-form-split {
     grid-template-columns: 1fr;
+  }
+
+  .pro-staking-hero {
+    flex-direction: column;
   }
 }

--- a/src/panels/ProPanel/ProPanel.tsx
+++ b/src/panels/ProPanel/ProPanel.tsx
@@ -5,7 +5,51 @@ import type { ProFeature, ProSubscriptionState, ProPriceInfo } from '../../../el
 import { ArenaView } from './ArenaView'
 import './ProPanel.css'
 
-type ProTab = 'overview' | 'arena' | 'skills' | 'sync'
+type ProTab = 'overview' | 'staking' | 'arena' | 'skills' | 'sync'
+
+interface StakingTier {
+  id: string
+  label: string
+  threshold: string
+  status: 'live' | 'planned'
+  unlocks: string[]
+}
+
+const STAKING_TIERS: StakingTier[] = [
+  {
+    id: 'signal',
+    label: 'Signal',
+    threshold: '25K staked',
+    status: 'planned',
+    unlocks: [
+      'Staker badge in DAEMON',
+      'Early feature notes and release windows',
+      'Priority waitlist for new Solana modules',
+    ],
+  },
+  {
+    id: 'builder',
+    label: 'Builder',
+    threshold: '100K staked',
+    status: 'planned',
+    unlocks: [
+      'Higher concurrent agent caps',
+      'Premium project scaffolds and workflow packs',
+      'Priority execution queue for hosted actions',
+    ],
+  },
+  {
+    id: 'operator',
+    label: 'Operator',
+    threshold: '250K staked',
+    status: 'planned',
+    unlocks: [
+      'Launch addon access across supported protocols',
+      'Higher MCP sync and priority API allowances',
+      'Expanded arena voting weight and beta surfaces',
+    ],
+  },
+]
 
 export function ProPanel() {
   const subscription = useProStore((state) => state.subscription)
@@ -91,6 +135,7 @@ export function ProPanel() {
 
       <nav className="pro-tabs">
         <button className={`pro-tab ${activeTab === 'overview' ? 'active' : ''}`} onClick={() => setActiveTab('overview')}>Overview</button>
+        <button className={`pro-tab ${activeTab === 'staking' ? 'active' : ''}`} onClick={() => setActiveTab('staking')}>Staking</button>
         <button className={`pro-tab ${activeTab === 'arena' ? 'active' : ''}`} onClick={() => setActiveTab('arena')}>Arena</button>
         <button className={`pro-tab ${activeTab === 'skills' ? 'active' : ''}`} onClick={() => setActiveTab('skills')} disabled={!isActive}>Skills</button>
         <button className={`pro-tab ${activeTab === 'sync' ? 'active' : ''}`} onClick={() => setActiveTab('sync')} disabled={!isActive}>MCP Sync</button>
@@ -119,6 +164,21 @@ export function ProPanel() {
             accessSource={subscription.accessSource}
           />
         )}
+        {activeTab === 'staking' && (
+          <StakingView
+            selectedWalletLabel={selectedWallet ? `${selectedWallet.name} (${selectedWallet.address.slice(0, 4)}…${selectedWallet.address.slice(-4)})` : null}
+            hasWallet={wallets.length > 0}
+            holderStatus={subscription.holderStatus}
+            accessSource={subscription.accessSource}
+            onRefreshSelectedWallet={() => {
+              if (!selectedWallet?.address) return
+              void refreshStatus(selectedWallet.address)
+            }}
+            onClaimHolderAccess={handleClaimHolderAccess}
+            selectedWalletId={selectedWalletId}
+            subscribing={subscribing}
+          />
+        )}
         {activeTab === 'arena' && (isActive ? <ArenaView /> : <ArenaStatusLocked />)}
         {activeTab === 'skills' && isActive && <SkillsView />}
         {activeTab === 'sync' && isActive && <SyncView />}
@@ -130,6 +190,99 @@ export function ProPanel() {
         </div>
       </footer>
     </section>
+  )
+}
+
+function StakingView({
+  selectedWalletLabel,
+  hasWallet,
+  holderStatus,
+  accessSource,
+  onRefreshSelectedWallet,
+  onClaimHolderAccess,
+  selectedWalletId,
+  subscribing,
+}: {
+  selectedWalletLabel: string | null
+  hasWallet: boolean
+  holderStatus: ProSubscriptionState['holderStatus']
+  accessSource: ProSubscriptionState['accessSource']
+  onRefreshSelectedWallet: () => void
+  onClaimHolderAccess: () => void
+  selectedWalletId: string
+  subscribing: boolean
+}) {
+  const currentAmount = holderStatus.currentAmount ?? 0
+  const minAmount = holderStatus.minAmount ?? 0
+  const eligible = holderStatus.enabled && holderStatus.eligible
+
+  return (
+    <div className="pro-staking">
+      <section className="pro-staking-hero">
+        <div>
+          <div className="pro-section-title">DAEMON staking utility</div>
+          <div className="pro-section-caption">
+            Current wallet-gated access is live now. Staking tiers below define how DAEMON can unlock more of the
+            workspace over time without turning the token into a detached vanity asset.
+          </div>
+        </div>
+        <div className="pro-staking-pill-group">
+          <span className={`pro-staking-pill ${eligible ? 'eligible' : ''}`}>
+            {eligible ? 'Holder access available' : 'Access not yet unlocked'}
+          </span>
+          {accessSource && <span className="pro-staking-pill pro-staking-pill-live">Live source: {accessSource === 'holder' ? 'holder' : 'payment'}</span>}
+        </div>
+      </section>
+
+      <section className="pro-staking-status-grid">
+        <StatCard label="Selected wallet" value={selectedWalletLabel ?? 'No wallet selected'} mono={Boolean(selectedWalletLabel)} />
+        <StatCard label="Current DAEMON" value={currentAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} />
+        <StatCard label="Live access threshold" value={holderStatus.enabled ? minAmount.toLocaleString() : 'Not configured'} />
+        <StatCard label="Current path" value={accessSource === 'holder' ? 'Holder access active' : accessSource === 'payment' ? 'Paid access active' : 'No active access'} />
+      </section>
+
+      <section className="pro-staking-actions-card">
+        <div>
+          <div className="pro-subscribe-title">Current wallet check</div>
+          <div className="pro-section-caption">
+            Use this to refresh holder eligibility on the selected wallet. If live access is already unlocked, activate it on this device directly from here.
+          </div>
+        </div>
+        {!hasWallet ? (
+          <div className="pro-subscribe-empty">Create or import a wallet first so DAEMON can verify current access.</div>
+        ) : (
+          <div className="pro-staking-action-row">
+            <button className="pro-btn" onClick={onRefreshSelectedWallet} disabled={!selectedWalletId || subscribing}>
+              Refresh wallet status
+            </button>
+            <button className="pro-btn pro-btn-primary" onClick={onClaimHolderAccess} disabled={!eligible || !selectedWalletId || subscribing}>
+              {subscribing ? 'Activating…' : 'Activate holder access'}
+            </button>
+          </div>
+        )}
+      </section>
+
+      <section className="pro-staking-tier-grid">
+        {STAKING_TIERS.map((tier) => (
+          <div key={tier.id} className="pro-staking-tier-card">
+            <div className="pro-staking-tier-head">
+              <div>
+                <div className="pro-feature-title">{tier.label}</div>
+                <div className="pro-section-caption">{tier.threshold}</div>
+              </div>
+              <span className={`pro-staking-pill ${tier.status === 'live' ? 'live' : 'planned'}`}>{tier.status}</span>
+            </div>
+            <div className="pro-staking-unlocks">
+              {tier.unlocks.map((unlock) => (
+                <div key={unlock} className="pro-active-feature">
+                  <span className="pro-active-check">+</span> {unlock}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
   )
 }
 

--- a/src/panels/SettingsPanel/SettingsPanel.tsx
+++ b/src/panels/SettingsPanel/SettingsPanel.tsx
@@ -5,6 +5,7 @@ import { useWorkspaceProfileStore } from '../../store/workspaceProfile'
 import { useNotificationsStore } from '../../store/notifications'
 import { Toggle } from '../../components/Toggle'
 import { BUILTIN_TOOLS, TOOL_NAMES } from '../../components/CommandDrawer/CommandDrawer'
+import { isToolDisableable } from '../../constants/toolRegistry'
 import type { WorkspaceProfileName } from '../../../electron/shared/types'
 import './SettingsPanel.css'
 
@@ -741,7 +742,7 @@ function DisplaySection() {
       <div className="settings-section-label settings-tools-label">Tool Visibility</div>
       {BUILTIN_TOOLS.map((tool) => {
         const isVisible = toolVisibility[tool.id] ?? true
-        const isAlwaysOn = tool.id === 'settings'
+        const isAlwaysOn = !isToolDisableable(tool.id)
         return (
           <div key={tool.id} className="settings-display-row">
             <span className="settings-display-label">{TOOL_NAMES[tool.id] ?? tool.name}</span>

--- a/src/panels/Terminal/AgentGrid.tsx
+++ b/src/panels/Terminal/AgentGrid.tsx
@@ -78,11 +78,18 @@ export function AgentGrid() {
       return next
     })
 
-    const res = await window.daemon.terminal.spawnProvider({
-      providerId,
-      projectId: activeProjectId,
-      cwd: activeProjectPath ?? undefined,
-    })
+    let res: Awaited<ReturnType<typeof window.daemon.terminal.spawnProvider>>
+    try {
+      res = await window.daemon.terminal.spawnProvider({
+        providerId,
+        projectId: activeProjectId,
+        cwd: activeProjectPath ?? undefined,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to launch service'
+      setCellError((prev) => ({ ...prev, [index]: { code: 'IPC_ERROR', message } }))
+      return
+    }
 
     if (res.ok && res.data) {
       const termId = res.data.id

--- a/src/panels/Titlebar/Titlebar.css
+++ b/src/panels/Titlebar/Titlebar.css
@@ -257,61 +257,6 @@
   background: rgba(74, 140, 98, 0.25);
 }
 
-.titlebar-mode-toggle.browser {
-  background: rgba(96, 165, 250, 0.12);
-  color: var(--blue);
-}
-
-.titlebar-mode-toggle.browser:hover {
-  background: rgba(96, 165, 250, 0.2);
-}
-
-.titlebar-mode-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  min-width: 180px;
-  padding: 4px;
-  background: var(--glass-bg);
-  backdrop-filter: var(--glass-blur);
-  border: 1px solid var(--border-glass);
-  border-radius: 6px;
-  box-shadow: var(--shadow-float);
-  z-index: 50;
-}
-
-.titlebar-mode-option {
-  width: 100%;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 10px;
-  border-radius: 4px;
-  font-size: 11px;
-  color: var(--t2);
-  background: transparent;
-  border: none;
-  cursor: pointer;
-}
-
-.titlebar-mode-option:hover {
-  background: var(--hover-bg);
-  color: var(--t1);
-}
-
-.titlebar-mode-option.active {
-  color: var(--green);
-  background: var(--green-glow);
-}
-
-.titlebar-mode-shortcut {
-  margin-left: auto;
-  font-size: 9px;
-  color: var(--t3);
-  font-family: var(--font-code);
-}
-
 .titlebar-switcher {
   flex: 1;
   min-width: 0;

--- a/src/panels/Titlebar/Titlebar.tsx
+++ b/src/panels/Titlebar/Titlebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type JSX, type RefObject } from 'react'
+import { useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import { useUIStore, type CenterMode } from '../../store/ui'
 import { useWalletStore } from '../../store/wallet'
 import { useShellLayout } from '../../hooks/useShellLayout'
@@ -18,8 +18,6 @@ export function Titlebar({ projects, onAddProject, onRemoveProject }: TitlebarPr
   const setActiveProject = useUIStore((s) => s.setActiveProject)
   const centerMode = useUIStore((s) => s.centerMode)
   const setCenterMode = useUIStore((s) => s.setCenterMode)
-  const browserTabOpen = useUIStore((s) => s.browserTabOpen)
-  const toggleBrowserTab = useUIStore((s) => s.toggleBrowserTab)
   const { tier, isDesktop, isCompact, isTablet, isSmall } = useShellLayout()
 
   const activeProject = useMemo(
@@ -29,7 +27,6 @@ export function Titlebar({ projects, onAddProject, onRemoveProject }: TitlebarPr
 
   const showProjectTabs = isDesktop || isCompact
   const showPortfolioInline = isDesktop
-  const showBrowserInline = isDesktop || isCompact
   const showBrandText = !isTablet && !isSmall
   const showDevReloadInline = isDesktop
 
@@ -57,21 +54,15 @@ export function Titlebar({ projects, onAddProject, onRemoveProject }: TitlebarPr
 
       <div className="titlebar-controls">
         {showPortfolioInline && <TitlebarPortfolioSummary />}
-        {showBrowserInline && (
-          <BrowserToggle browserTabOpen={browserTabOpen} toggleBrowserTab={toggleBrowserTab} />
-        )}
-        <ModeDropdown
+        <ModeToggle
           centerMode={centerMode}
           setCenterMode={setCenterMode}
           compactLabel={isSmall}
         />
         {!isDesktop && (
           <TitlebarOverflowMenu
-            browserTabOpen={browserTabOpen}
-            showBrowserAction={!showBrowserInline}
             showPortfolioAction={!showPortfolioInline}
             showReloadAction={!showDevReloadInline && import.meta.env.DEV}
-            onToggleBrowserTab={toggleBrowserTab}
           />
         )}
         {showDevReloadInline && import.meta.env.DEV && (
@@ -216,42 +207,12 @@ function ProjectSwitcher({
   )
 }
 
-function BrowserToggle({
-  browserTabOpen,
-  toggleBrowserTab,
-}: {
-  browserTabOpen: boolean
-  toggleBrowserTab: () => void
-}) {
-  return (
-    <button
-      className={`titlebar-btn titlebar-btn-browser${browserTabOpen ? ' active' : ''}`}
-      onClick={toggleBrowserTab}
-      title="Toggle Browser Tab (Ctrl+Shift+B)"
-      aria-label="Toggle Browser Tab"
-      aria-pressed={browserTabOpen}
-    >
-      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <circle cx="12" cy="12" r="10"/>
-        <line x1="2" y1="12" x2="22" y2="12"/>
-        <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
-      </svg>
-    </button>
-  )
-}
-
 function TitlebarOverflowMenu({
-  browserTabOpen,
-  showBrowserAction,
   showPortfolioAction,
   showReloadAction,
-  onToggleBrowserTab,
 }: {
-  browserTabOpen: boolean
-  showBrowserAction: boolean
   showPortfolioAction: boolean
   showReloadAction: boolean
-  onToggleBrowserTab: () => void
 }) {
   const [isOpen, setIsOpen] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
@@ -262,7 +223,7 @@ function TitlebarOverflowMenu({
 
   const canShowPortfolio = showPortfolioAction && visible && dashboard && dashboard.portfolio.walletCount > 0
 
-  if (!showBrowserAction && !canShowPortfolio && !showReloadAction) return null
+  if (!canShowPortfolio && !showReloadAction) return null
 
   return (
     <div className="titlebar-overflow" ref={wrapRef}>
@@ -281,18 +242,6 @@ function TitlebarOverflowMenu({
       </button>
       {isOpen && (
         <div className="titlebar-overflow-menu" role="menu" aria-label="Titlebar actions">
-          {showBrowserAction && (
-            <button
-              className={`titlebar-overflow-item${browserTabOpen ? ' active' : ''}`}
-              role="menuitem"
-              onClick={() => {
-                onToggleBrowserTab()
-                setIsOpen(false)
-              }}
-            >
-              Browser
-            </button>
-          )}
           {canShowPortfolio && (
             <button
               className="titlebar-overflow-item"
@@ -323,31 +272,7 @@ function TitlebarOverflowMenu({
   )
 }
 
-const MODE_OPTIONS: Array<{ value: CenterMode; label: string; shortcut: string | null; icon: JSX.Element }> = [
-  {
-    value: 'canvas',
-    label: 'Canvas',
-    shortcut: null,
-    icon: (
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <rect x="2" y="3" width="20" height="18" rx="2"/><line x1="2" y1="9" x2="22" y2="9"/>
-      </svg>
-    ),
-  },
-  {
-    value: 'grind',
-    label: 'Agents',
-    shortcut: 'Ctrl+Shift+G',
-    icon: (
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/>
-        <rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>
-      </svg>
-    ),
-  },
-]
-
-function ModeDropdown({
+function ModeToggle({
   centerMode,
   setCenterMode,
   compactLabel,
@@ -356,48 +281,26 @@ function ModeDropdown({
   setCenterMode: (m: CenterMode) => void
   compactLabel?: boolean
 }) {
-  const [isOpen, setIsOpen] = useState(false)
-  const wrapRef = useRef<HTMLDivElement>(null)
-
-  useDismissOnOutsideClick(isOpen, wrapRef, () => setIsOpen(false))
-
-  const current = MODE_OPTIONS.find((option) => option.value === centerMode)!
+  const nextMode = centerMode === 'grind' ? 'canvas' : 'grind'
+  const label = centerMode === 'grind' ? 'Editor' : 'Agents'
 
   return (
-    <div className="titlebar-mode-wrap" ref={wrapRef}>
+    <div className="titlebar-mode-wrap">
       <button
         className={`titlebar-mode-toggle ${centerMode}${compactLabel ? ' titlebar-mode-toggle--icon-only' : ''}`}
-        onClick={() => setIsOpen((value) => !value)}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        aria-label={`Mode: ${current.label}`}
+        onClick={() => setCenterMode(nextMode)}
+        aria-label={centerMode === 'grind' ? 'Return to editor' : 'Open agent grid'}
+        title={centerMode === 'grind' ? 'Return to editor' : 'Agent Grid (Ctrl+Shift+G)'}
       >
-        {current.icon}
-        {!compactLabel && <span>{current.label}</span>}
-        <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-          <polyline points="6 9 12 15 18 9" />
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+          {centerMode === 'grind' ? (
+            <><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M7 8h10M7 12h7M7 16h5"/></>
+          ) : (
+            <><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></>
+          )}
         </svg>
+        {!compactLabel && <span>{label}</span>}
       </button>
-      {isOpen && (
-        <div className="titlebar-mode-menu" role="listbox" aria-label="Center mode">
-          {MODE_OPTIONS.map((option) => (
-            <button
-              key={option.value}
-              className={`titlebar-mode-option ${option.value === centerMode ? 'active' : ''}`}
-              role="option"
-              aria-selected={option.value === centerMode}
-              onClick={() => {
-                setCenterMode(option.value)
-                setIsOpen(false)
-              }}
-            >
-              {option.icon}
-              <span>{option.label}</span>
-              {option.shortcut && <span className="titlebar-mode-shortcut">{option.shortcut}</span>}
-            </button>
-          ))}
-        </div>
-      )}
     </div>
   )
 }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -152,7 +152,7 @@ export const useUIStore = create<UIState>((set) => ({
   launchWizardOpen: false,
   walletQuickViewOpen: false,
   emailQuickViewOpen: false,
-  pinnedTools: ['git', 'browser', 'activity', 'project-readiness', 'solana-toolbox', 'integrations', 'token-launch', 'pro'],
+  pinnedTools: ['git', 'browser', 'activity', 'project-readiness', 'solana-toolbox', 'integrations', 'pro'],
   drawerToolOrder: [],
 
   setActivePanel: (panel) => set({ activePanel: panel }),

--- a/src/store/workspaceProfile.ts
+++ b/src/store/workspaceProfile.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { WorkspaceProfileName, WorkspaceProfile } from '../../electron/shared/types'
 import { getDefaultVisibility, PROFILE_PRESETS } from '../constants/workspaceProfiles'
 import { BUILTIN_TOOL_IDS } from '../constants/toolIds'
+import { isToolDisableable } from '../constants/toolRegistry'
 import { useUIStore } from './ui'
 import { useNotificationsStore } from './notifications'
 import { daemon } from '../lib/daemonBridge'
@@ -67,8 +68,7 @@ export const useWorkspaceProfileStore = create<WorkspaceProfileState>((set, get)
 
   setToolVisible: async (toolId, visible) => {
     const { toolVisibility, profileName } = get()
-    // Settings is always visible — cannot be hidden
-    if (toolId === 'settings') return
+    if (!isToolDisableable(toolId)) return
     const updated = { ...toolVisibility, [toolId]: visible }
     set({ toolVisibility: updated, profileName: 'custom' })
     const profile: WorkspaceProfile = { name: 'custom', toolVisibility: updated }
@@ -76,7 +76,7 @@ export const useWorkspaceProfileStore = create<WorkspaceProfileState>((set, get)
   },
 
   isToolVisible: (toolId) => {
-    if (toolId === 'settings') return true
+    if (!isToolDisableable(toolId)) return true
     const { toolVisibility, loaded } = get()
     if (!loaded) return true
     // Unknown tools default to visible

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -170,6 +170,8 @@ declare global {
     name: string
     address: string
     isDefault: boolean
+    walletType: string
+    ecosystemRole: 'daemon-deployer' | null
     hasKeypair: boolean
     isAssignedToActiveProject: boolean
     assignedProjectIds: string[]
@@ -774,6 +776,7 @@ declare global {
   interface DaemonLaunch {
     listLaunchpads: () => Promise<IpcResponse<LaunchpadDefinition[]>>
     listWalletOptions: (projectId?: string | null) => Promise<IpcResponse<LaunchWalletOption[]>>
+    ensureDaemonDeployerWallet: (projectId?: string | null) => Promise<IpcResponse<LaunchWalletOption>>
     listPulseTokens: (input?: { category?: PulseTokenCategory; pageNumber?: number; pageSize?: number }) => Promise<IpcResponse<PulseTokenFeed>>
     pickImage: () => Promise<IpcResponse<string | null>>
     preflightToken: (input: {

--- a/test/panels/ProPanel.dom.test.tsx
+++ b/test/panels/ProPanel.dom.test.tsx
@@ -7,32 +7,37 @@ import { ProPanel } from '../../src/panels/ProPanel/ProPanel'
 import { useProStore } from '../../src/store/pro'
 import { useWalletStore } from '../../src/store/wallet'
 
-function installDaemonBridge() {
+function installDaemonBridge(statusOverride?: any) {
+  const statusData = statusOverride ?? {
+    active: false,
+    walletId: null,
+    walletAddress: null,
+    expiresAt: null,
+    features: [],
+    tier: null,
+    accessSource: null,
+    holderStatus: {
+      enabled: false,
+      eligible: false,
+      mint: null,
+      minAmount: null,
+      currentAmount: null,
+      symbol: 'DAEMON',
+    },
+    priceUsdc: null,
+    durationDays: null,
+  }
   Object.defineProperty(window, 'daemon', {
     configurable: true,
     value: {
       pro: {
         status: vi.fn().mockResolvedValue({
           ok: true,
-          data: {
-            active: false,
-            walletId: null,
-            walletAddress: null,
-            expiresAt: null,
-            features: [],
-            tier: null,
-            accessSource: null,
-            holderStatus: {
-              enabled: false,
-              eligible: false,
-              mint: null,
-              minAmount: null,
-              currentAmount: null,
-              symbol: 'DAEMON',
-            },
-            priceUsdc: null,
-            durationDays: null,
-          },
+          data: statusData,
+        }),
+        refreshStatus: vi.fn().mockResolvedValue({
+          ok: true,
+          data: statusData,
         }),
         fetchPrice: vi.fn().mockResolvedValue({
           ok: true,
@@ -42,6 +47,10 @@ function installDaemonBridge() {
             network: 'solana:mainnet',
             payTo: 'GNVxk3sn4iJ2iUaqEUskWQ1KNy9Mmcee3WF3AMtRjN7W',
           },
+        }),
+        claimHolderAccess: vi.fn().mockResolvedValue({
+          ok: true,
+          data: { state: statusData },
         }),
       },
     },
@@ -91,5 +100,47 @@ describe('ProPanel Arena status', () => {
 
     expect(screen.getByText('Arena submission is not active on this install.')).toBeInTheDocument()
     expect(screen.getByText('DAEMON_PRO_DEV_BYPASS=1')).toBeInTheDocument()
+  })
+
+  it('shows staking utility tiers and live holder status', async () => {
+    const statusData = {
+      active: false,
+      walletId: null,
+      walletAddress: null,
+      expiresAt: null,
+      features: [],
+      tier: null,
+      accessSource: null,
+      holderStatus: {
+        enabled: true,
+        eligible: true,
+        mint: 'daemon-mint',
+        minAmount: 1000000,
+        currentAmount: 2500000,
+        symbol: 'DAEMON',
+      },
+      priceUsdc: null,
+      durationDays: null,
+    }
+    installDaemonBridge(statusData)
+    useProStore.setState({ subscription: statusData as any })
+    useWalletStore.setState({
+      dashboard: {
+        wallets: [
+          { id: 'wallet-1', name: 'Main Wallet', address: '7Y12wallet9AbC', isDefault: true },
+        ],
+      } as any,
+    })
+
+    render(<ProPanel />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Staking' }))
+
+    expect(screen.getByText('DAEMON staking utility')).toBeInTheDocument()
+    expect(screen.getByText('Holder access available')).toBeInTheDocument()
+    expect(screen.getByText('Signal')).toBeInTheDocument()
+    expect(screen.getByText('Builder')).toBeInTheDocument()
+    expect(screen.getByText('Operator')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Activate holder access' })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- add a first-class Staking tab to DAEMON Pro
- show live wallet-aware holder status and current access path
- define planned staking tiers and unlocks inside the product
- keep current backend semantics honest: holder access is live, staking tiers are marked planned
- bump version to 3.0.3

## Validation
- pnpm run typecheck
- pnpm exec vitest run test/panels/ProPanel.dom.test.tsx test/panels/AppSurfaces.dom.test.tsx
- pnpm test