### PR TITLE
Add Juice Market Maker read-only integration

### DIFF
--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -1,11 +1,45 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import { ipcHandler } from '../services/IpcHandlerFactory'
 import * as Engine from '../services/EngineService'
+import * as JuiceService from '../services/JuiceService'
 import type { EngineAction } from '../shared/types'
+
+async function runJuiceEngineAction(action: EngineAction) {
+  const type = String((action as { type: string }).type)
+  const payload = (action.payload ?? {}) as Record<string, unknown>
+
+  switch (type) {
+    case 'juice:has-key':
+      return { ok: true, action: type, output: JSON.stringify(JuiceService.hasJuiceKey()) }
+    case 'juice:list-wallets':
+      return { ok: true, action: type, data: await JuiceService.listWallets() }
+    case 'juice:get-balances': {
+      const walletId = String(payload.walletId ?? '')
+      if (!walletId) return { ok: false, action: type, error: 'walletId is required' }
+      return { ok: true, action: type, data: await JuiceService.getBalances(walletId) }
+    }
+    case 'juice:get-pnl': {
+      const walletId = String(payload.walletId ?? '')
+      if (!walletId) return { ok: false, action: type, error: 'walletId is required' }
+      return { ok: true, action: type, data: await JuiceService.getPnl(walletId) }
+    }
+    case 'juice:get-mint-details': {
+      const mint = String(payload.mint ?? '')
+      if (!mint) return { ok: false, action: type, error: 'mint is required' }
+      return { ok: true, action: type, data: await JuiceService.getMintDetails(mint) }
+    }
+    case 'juice:get-scouting-report':
+      return { ok: true, action: type, data: await JuiceService.getScoutingReport() }
+    default:
+      return null
+  }
+}
 
 export function registerEngineHandlers() {
   // Run an engine action (the main entry point)
   ipcMain.handle('engine:run', ipcHandler(async (_event, action: EngineAction) => {
+    const juiceResult = await runJuiceEngineAction(action)
+    if (juiceResult) return juiceResult
     return Engine.runAction(action)
   }))
 

--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -2,6 +2,7 @@ import { ipcMain, BrowserWindow } from 'electron'
 import { ipcHandler } from '../services/IpcHandlerFactory'
 import * as Engine from '../services/EngineService'
 import * as JuiceService from '../services/JuiceService'
+import * as JuiceStrategyPreviewService from '../services/JuiceStrategyPreviewService'
 import type { EngineAction } from '../shared/types'
 
 async function runJuiceEngineAction(action: EngineAction) {
@@ -39,6 +40,16 @@ async function runJuiceEngineAction(action: EngineAction) {
     }
     case 'juice:get-scouting-report':
       return { ok: true, action: type, data: await JuiceService.getScoutingReport() }
+    case 'juice:strategy-preview':
+      return {
+        ok: true,
+        action: type,
+        data: await JuiceStrategyPreviewService.buildStrategyPreview({
+          targetPnlUsd: Number(payload.targetPnlUsd ?? 25),
+          maxCrowdLevel: Number(payload.maxCrowdLevel ?? 3),
+          scoutLimit: Number(payload.scoutLimit ?? 5),
+        }),
+      }
     default:
       return null
   }

--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -50,9 +50,75 @@ async function runJuiceEngineAction(action: EngineAction) {
           scoutLimit: Number(payload.scoutLimit ?? 5),
         }),
       }
+    case 'juice:create-wallet':
+      return {
+        ok: true,
+        action: type,
+        data: await JuiceService.createWallet({
+          mint: optionalString(payload.mint),
+          strategyId: optionalString(payload.strategyId),
+          acknowledgedPrivateKey: Boolean(payload.acknowledgedPrivateKey),
+          acknowledgedImpact: Boolean(payload.acknowledgedImpact),
+          confirmedAt: Number(payload.confirmedAt),
+        }),
+      }
+    case 'juice:edit-wallet':
+      return {
+        ok: true,
+        action: type,
+        data: await JuiceService.editWallet({
+          walletId: String(payload.walletId ?? ''),
+          mint: optionalString(payload.mint),
+          isActive: optionalBoolean(payload.isActive),
+          stopLossPrice: optionalNumber(payload.stopLossPrice),
+          takeProfitPrice: optionalNumber(payload.takeProfitPrice),
+          tpOnly: optionalBoolean(payload.tpOnly),
+          accumulation: optionalBoolean(payload.accumulation),
+          lowSpeed: optionalBoolean(payload.lowSpeed),
+          strategyId: optionalString(payload.strategyId),
+          placeBuy: optionalBoolean(payload.placeBuy),
+          acknowledgedImpact: Boolean(payload.acknowledgedImpact),
+          confirmedAt: Number(payload.confirmedAt),
+        }),
+      }
+    case 'juice:buy':
+      return {
+        ok: true,
+        action: type,
+        data: await JuiceService.placeBuy({
+          walletId: String(payload.walletId ?? ''),
+          solAmount: Number(payload.solAmount),
+          acknowledgedImpact: Boolean(payload.acknowledgedImpact),
+          confirmedAt: Number(payload.confirmedAt),
+        }),
+      }
+    case 'juice:sell-all':
+      return {
+        ok: true,
+        action: type,
+        data: await JuiceService.sellAll({
+          walletId: String(payload.walletId ?? ''),
+          outputMint: payload.outputMint === 'USDC' ? 'USDC' : 'SOL',
+          acknowledgedImpact: Boolean(payload.acknowledgedImpact),
+          confirmedAt: Number(payload.confirmedAt),
+        }),
+      }
     default:
       return null
   }
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
 }
 
 export function registerEngineHandlers() {

--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -6,7 +6,7 @@ import * as JuiceStrategyPreviewService from '../services/JuiceStrategyPreviewSe
 import type { EngineAction } from '../shared/types'
 
 async function runJuiceEngineAction(action: EngineAction) {
-  const { type } = action
+  const type = String(action.type)
   const payload = (action.payload ?? {}) as Record<string, unknown>
 
   switch (type) {

--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -5,7 +5,7 @@ import * as JuiceService from '../services/JuiceService'
 import type { EngineAction } from '../shared/types'
 
 async function runJuiceEngineAction(action: EngineAction) {
-  const type = String((action as { type: string }).type)
+  const { type } = action
   const payload = (action.payload ?? {}) as Record<string, unknown>
 
   switch (type) {

--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -10,7 +10,7 @@ async function runJuiceEngineAction(action: EngineAction) {
 
   switch (type) {
     case 'juice:has-key':
-      return { ok: true, action: type, output: JSON.stringify(JuiceService.hasJuiceKey()) }
+      return { ok: true, action: type, data: JuiceService.hasJuiceKey() }
     case 'juice:list-wallets':
       return { ok: true, action: type, data: await JuiceService.listWallets() }
     case 'juice:get-balances': {

--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -11,6 +11,15 @@ async function runJuiceEngineAction(action: EngineAction) {
   switch (type) {
     case 'juice:has-key':
       return { ok: true, action: type, data: JuiceService.hasJuiceKey() }
+    case 'juice:store-key': {
+      const apiKey = String(payload.apiKey ?? '')
+      if (!apiKey) return { ok: false, action: type, error: 'apiKey is required' }
+      await JuiceService.storeJuiceKey(apiKey)
+      return { ok: true, action: type, data: true }
+    }
+    case 'juice:delete-key':
+      JuiceService.deleteJuiceKey()
+      return { ok: true, action: type, data: true }
     case 'juice:list-wallets':
       return { ok: true, action: type, data: await JuiceService.listWallets() }
     case 'juice:get-balances': {

--- a/electron/ipc/juice.ts
+++ b/electron/ipc/juice.ts
@@ -1,0 +1,37 @@
+import { ipcMain } from 'electron'
+import * as JuiceService from '../services/JuiceService'
+import { ipcHandler } from '../services/IpcHandlerFactory'
+
+export function registerJuiceHandlers() {
+  ipcMain.handle('juice:store-key', ipcHandler(async (_event, value: string) => {
+    await JuiceService.storeJuiceKey(value)
+  }))
+
+  ipcMain.handle('juice:has-key', ipcHandler(async () => {
+    return JuiceService.hasJuiceKey()
+  }))
+
+  ipcMain.handle('juice:delete-key', ipcHandler(async () => {
+    JuiceService.deleteJuiceKey()
+  }))
+
+  ipcMain.handle('juice:list-wallets', ipcHandler(async () => {
+    return await JuiceService.listWallets()
+  }))
+
+  ipcMain.handle('juice:get-balances', ipcHandler(async (_event, walletId: string) => {
+    return await JuiceService.getBalances(walletId)
+  }))
+
+  ipcMain.handle('juice:get-pnl', ipcHandler(async (_event, walletId: string) => {
+    return await JuiceService.getPnl(walletId)
+  }))
+
+  ipcMain.handle('juice:get-mint-details', ipcHandler(async (_event, mint: string) => {
+    return await JuiceService.getMintDetails(mint)
+  }))
+
+  ipcMain.handle('juice:get-scouting-report', ipcHandler(async () => {
+    return await JuiceService.getScoutingReport()
+  }))
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -19,6 +19,7 @@ import { registerProcessHandlers } from '../ipc/processes'
 import { registerEnvHandlers } from '../ipc/env'
 import { registerPortHandlers } from '../ipc/ports'
 import { registerWalletHandlers } from '../ipc/wallet'
+import { registerJuiceHandlers } from '../ipc/juice'
 import { registerProHandlers } from '../ipc/pro'
 import { registerSettingsHandlers } from '../ipc/settings'
 import { registerPluginHandlers } from '../ipc/plugins'
@@ -152,6 +153,7 @@ function registerAllIpc() {
   registerEnvHandlers()
   registerPortHandlers()
   registerWalletHandlers()
+  registerJuiceHandlers()
   registerProHandlers()
   registerSettingsHandlers()
   registerPluginHandlers()
@@ -217,7 +219,7 @@ async function createWindow() {
       callback({
         responseHeaders: {
           ...details.responseHeaders,
-          'Content-Security-Policy': ["default-src 'self' minipaint:; script-src 'self' minipaint: 'sha256-+1m5I+GGgMQpppazcRWmPjEueczyuTJO92jm308NkKc='; style-src 'self' 'unsafe-inline' minipaint:; img-src 'self' data: daemon-icon: minipaint:; worker-src 'self' blob: monaco-editor: minipaint:; connect-src 'self' https://*.anthropic.com https://*.helius-rpc.com https://price.jup.ag https://api.coingecko.com; font-src 'self' minipaint:; frame-src minipaint:; object-src 'none'"]
+          'Content-Security-Policy': ["default-src 'self' minipaint:; script-src 'self' minipaint: 'sha256-+1m5I+GGgMQpppazcRWmPjEueczyuTJO92jm308NkKc='; style-src 'self' 'unsafe-inline' minipaint:; img-src 'self' data: daemon-icon: minipaint:; worker-src 'self' blob: monaco-editor: minipaint:; connect-src 'self' https://*.anthropic.com https://*.helius-rpc.com https://price.jup.ag https://api.coingecko.com https://api.juiceeverything.com; font-src 'self' minipaint:; frame-src minipaint:; object-src 'none'"]
         }
       })
     })

--- a/electron/services/JuiceService.ts
+++ b/electron/services/JuiceService.ts
@@ -1,0 +1,182 @@
+import * as SecureKey from './SecureKeyService'
+
+const JUICE_API_KEY_NAME = 'JUICE_API_KEY'
+const JUICE_BASE_URL = 'https://api.juiceeverything.com'
+const JUICE_MM_API_BASE = `${JUICE_BASE_URL}/api/mm-api`
+const JUICE_KEY_RE = /^[a-f0-9]{96}$/i
+
+export interface JuiceApiEnvelope<T> {
+  success: boolean
+  data?: T
+  message?: string
+}
+
+export interface JuiceWallet {
+  id: string
+  publicKey: string
+  mint: string | null
+  symbol?: string | null
+  name?: string | null
+  isActive: boolean
+  deactivatedAt?: string | null
+  deactivationReason?: string | null
+  deactivationPrice?: number | null
+  strategyId?: string | null
+  stopLossPrice?: number | null
+  takeProfitPrice?: number | null
+  tpOnly?: boolean
+  accumulation?: boolean
+  lowSpeed?: boolean
+  createdAt?: string
+}
+
+export interface JuiceBalance {
+  mint: string
+  balance: number
+  decimals: number
+}
+
+export interface JuiceWalletBalances {
+  mmTokenId: string
+  publicKey: string
+  mint: string | null
+  solBalance: number
+  tokenBalances: JuiceBalance[]
+}
+
+export interface JuicePnlSummary {
+  totalUsd: number
+  totalPercent: number
+  realizedUsd: number
+  realizedPercent: number
+  unrealizedUsd: number
+  unrealizedPercent: number
+  avgProfitPerTradeUsd?: number
+}
+
+export interface JuiceWalletPnl {
+  mmTokenId: string
+  mint: string
+  symbol?: string
+  walletAddress: string
+  pnl: JuicePnlSummary
+  fetchedAt?: string
+}
+
+export interface JuiceMintDetails {
+  mint: string
+  wallets: number
+  totalSolBalance: number
+  totalSolValueUsd: number
+  totalTokenBalance: number
+  totalTokenValueUsd: number
+  totalPositionUsd: number
+  tokenPrice: number
+  solPrice: number
+  liquidity: number
+  marketCap: number
+  volume24h: number
+  positionToLiquidity: number
+  walletMultiplier: number
+  overcrowdingLevel: number
+}
+
+export interface JuiceScoutToken {
+  mint: string
+  symbol: string
+  name: string
+  logoURI?: string | null
+  decimals?: number
+  price: number
+  marketCap: number
+  liquidity: number
+  holder?: number
+  volume1hUsd?: number
+  volume1hChangePercent?: number
+  volume24hUsd?: number
+  volume24hChangePercent?: number
+  priceChange1hPercent?: number
+  priceChange24hPercent?: number
+  trade1hCount?: number
+  trade24hCount?: number
+  score: number
+  maxScore: number
+  grade: string
+  momentumSignal?: number
+  priceAction?: Record<string, unknown>
+  security?: Record<string, unknown>
+  liquidityAnalysis?: Record<string, unknown>
+}
+
+export interface JuiceScoutingReport {
+  tokens: JuiceScoutToken[]
+  tokenCount: number
+  scannedAt: string
+}
+
+export function validateJuiceApiKey(value: string) {
+  const trimmed = value.trim()
+  if (!JUICE_KEY_RE.test(trimmed)) {
+    throw new Error('Juice API key must be a 96-character hex string')
+  }
+  return trimmed
+}
+
+export function hasJuiceKey() {
+  return Boolean(SecureKey.getKey(JUICE_API_KEY_NAME))
+}
+
+export function deleteJuiceKey() {
+  SecureKey.deleteKey(JUICE_API_KEY_NAME)
+}
+
+export async function storeJuiceKey(value: string) {
+  const apiKey = validateJuiceApiKey(value)
+  await juiceRequest<JuiceWallet[]>('/tokens', { apiKey })
+  SecureKey.storeKey(JUICE_API_KEY_NAME, apiKey)
+}
+
+export function listWallets() {
+  return juiceRequest<JuiceWallet[]>('/tokens')
+}
+
+export function getBalances(walletId: string) {
+  return juiceRequest<JuiceWalletBalances>(`/tokens/${encodeURIComponent(walletId)}/balances`)
+}
+
+export function getPnl(walletId: string) {
+  return juiceRequest<JuiceWalletPnl>(`/tokens/${encodeURIComponent(walletId)}/pnl`)
+}
+
+export function getMintDetails(mint: string) {
+  return juiceRequest<JuiceMintDetails>(`/mints/${encodeURIComponent(mint)}`)
+}
+
+export function getScoutingReport() {
+  return juiceRequest<JuiceScoutingReport>('/scouting-report')
+}
+
+async function juiceRequest<T>(path: string, opts: { method?: 'GET'; apiKey?: string } = {}): Promise<T> {
+  const apiKey = opts.apiKey ?? SecureKey.getKey(JUICE_API_KEY_NAME)
+  if (!apiKey) {
+    throw new Error('JUICE_API_KEY is not configured')
+  }
+
+  const res = await fetch(`${JUICE_MM_API_BASE}${path}`, {
+    method: opts.method ?? 'GET',
+    headers: {
+      'X-API-Key': apiKey,
+      'Content-Type': 'application/json',
+    },
+  })
+
+  const json = await res.json().catch(() => null) as JuiceApiEnvelope<T> | null
+  if (!res.ok || !json?.success) {
+    throw new Error(json?.message ?? `Juice API request failed with status ${res.status}`)
+  }
+  if (typeof json.data === 'undefined') {
+    throw new Error('Juice API response did not include a data payload')
+  }
+
+  return json.data
+}

--- a/electron/services/JuiceService.ts
+++ b/electron/services/JuiceService.ts
@@ -4,11 +4,18 @@ const JUICE_API_KEY_NAME = 'JUICE_API_KEY'
 const JUICE_BASE_URL = 'https://api.juiceeverything.com'
 const JUICE_MM_API_BASE = `${JUICE_BASE_URL}/api/mm-api`
 const JUICE_KEY_RE = /^[a-f0-9]{96}$/i
+const CONFIRMATION_TTL_MS = 60_000
 
 export interface JuiceApiEnvelope<T> {
   success: boolean
   data?: T
+  buy?: JuiceBuyExecution | false
   message?: string
+}
+
+export interface JuiceExecutionGuard {
+  confirmedAt: number
+  acknowledgedImpact: boolean
 }
 
 export interface JuiceWallet {
@@ -28,6 +35,11 @@ export interface JuiceWallet {
   accumulation?: boolean
   lowSpeed?: boolean
   createdAt?: string
+}
+
+export interface JuiceCreatedWallet extends JuiceWallet {
+  privateKey: string
+  logoURI?: string | null
 }
 
 export interface JuiceBalance {
@@ -114,6 +126,67 @@ export interface JuiceScoutingReport {
   scannedAt: string
 }
 
+export interface JuiceCreateWalletInput extends JuiceExecutionGuard {
+  mint?: string
+  strategyId?: string
+  acknowledgedPrivateKey: boolean
+}
+
+export interface JuiceEditWalletInput extends JuiceExecutionGuard {
+  walletId: string
+  mint?: string
+  isActive?: boolean
+  stopLossPrice?: number
+  takeProfitPrice?: number
+  tpOnly?: boolean
+  accumulation?: boolean
+  lowSpeed?: boolean
+  strategyId?: string
+  placeBuy?: boolean
+}
+
+export interface JuiceBuyInput extends JuiceExecutionGuard {
+  walletId: string
+  solAmount: number
+}
+
+export interface JuiceSellAllInput extends JuiceExecutionGuard {
+  walletId: string
+  outputMint: 'SOL' | 'USDC'
+}
+
+export interface JuiceBuyExecution {
+  executed: boolean
+  solSpent?: number
+  txSignature?: string
+  solscanUrl?: string
+  maxBuySOL?: number
+  marketCap?: number
+  reason?: string
+}
+
+export interface JuiceEditWalletResult {
+  wallet: JuiceWallet
+  buy?: JuiceBuyExecution | false
+  message?: string
+}
+
+export interface JuiceBuyResult {
+  wallet: JuiceWallet
+  buy?: JuiceBuyExecution | false
+  message?: string
+}
+
+export interface JuiceSellAllResult {
+  mmTokenId: string
+  inputMint: string
+  outputMint: string
+  outputChoice: 'SOL' | 'USDC'
+  amountSold: number
+  txSignature: string
+  solscanUrl: string
+}
+
 export function validateJuiceApiKey(value: string) {
   const trimmed = value.trim()
   if (!JUICE_KEY_RE.test(trimmed)) {
@@ -156,7 +229,94 @@ export function getScoutingReport() {
   return juiceRequest<JuiceScoutingReport>('/scouting-report')
 }
 
-async function juiceRequest<T>(path: string, opts: { method?: 'GET'; apiKey?: string } = {}): Promise<T> {
+export async function createWallet(input: JuiceCreateWalletInput) {
+  assertExecutionGuard(input, 'Create Juice MM wallet')
+  if (!input.acknowledgedPrivateKey) {
+    throw new Error('Creating a Juice wallet returns a private key once. Acknowledge private-key handling before continuing.')
+  }
+
+  return juiceRequest<JuiceCreatedWallet>('/tokens', {
+    method: 'POST',
+    body: {
+      mint: input.mint,
+      strategyId: input.strategyId,
+    },
+  })
+}
+
+export async function editWallet(input: JuiceEditWalletInput): Promise<JuiceEditWalletResult> {
+  assertExecutionGuard(input, input.placeBuy ? 'Edit Juice wallet and place buy' : 'Edit Juice MM wallet')
+  const envelope = await juiceEnvelopeRequest<JuiceWallet>(`/tokens/${encodeURIComponent(input.walletId)}`, {
+    method: 'PUT',
+    body: omitUndefined({
+      mint: input.mint,
+      isActive: input.isActive,
+      stopLossPrice: input.stopLossPrice,
+      takeProfitPrice: input.takeProfitPrice,
+      tpOnly: input.tpOnly,
+      accumulation: input.accumulation,
+      lowSpeed: input.lowSpeed,
+      strategyId: input.strategyId,
+      placeBuy: input.placeBuy,
+    }),
+  })
+
+  if (!envelope.data) throw new Error('Juice edit response did not include wallet data')
+  return { wallet: envelope.data, buy: envelope.buy, message: envelope.message }
+}
+
+export async function placeBuy(input: JuiceBuyInput): Promise<JuiceBuyResult> {
+  assertExecutionGuard(input, 'Execute Juice buy')
+  if (!Number.isFinite(input.solAmount) || input.solAmount <= 0) {
+    throw new Error('solAmount must be a positive number')
+  }
+
+  const envelope = await juiceEnvelopeRequest<JuiceWallet>(`/tokens/${encodeURIComponent(input.walletId)}/buy`, {
+    method: 'POST',
+    body: { solAmount: input.solAmount },
+  })
+
+  if (!envelope.data) throw new Error('Juice buy response did not include wallet data')
+  return { wallet: envelope.data, buy: envelope.buy, message: envelope.message }
+}
+
+export function sellAll(input: JuiceSellAllInput) {
+  assertExecutionGuard(input, 'Execute Juice sell-all')
+  if (input.outputMint !== 'SOL' && input.outputMint !== 'USDC') {
+    throw new Error('outputMint must be SOL or USDC')
+  }
+
+  return juiceRequest<JuiceSellAllResult>(`/tokens/${encodeURIComponent(input.walletId)}/sell-all`, {
+    method: 'POST',
+    body: { outputMint: input.outputMint },
+  })
+}
+
+function assertExecutionGuard(input: JuiceExecutionGuard, actionLabel: string) {
+  if (!input.acknowledgedImpact) {
+    throw new Error(`${actionLabel} requires explicit user acknowledgement.`)
+  }
+  if (!Number.isFinite(input.confirmedAt)) {
+    throw new Error(`${actionLabel} requires a fresh confirmation timestamp.`)
+  }
+  if (Date.now() - input.confirmedAt > CONFIRMATION_TTL_MS) {
+    throw new Error(`${actionLabel} confirmation expired. Review and confirm again.`)
+  }
+}
+
+function omitUndefined<T extends Record<string, unknown>>(input: T) {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => typeof value !== 'undefined'))
+}
+
+async function juiceRequest<T>(path: string, opts: { method?: 'GET' | 'POST' | 'PUT'; apiKey?: string; body?: Record<string, unknown> } = {}): Promise<T> {
+  const envelope = await juiceEnvelopeRequest<T>(path, opts)
+  if (typeof envelope.data === 'undefined') {
+    throw new Error('Juice API response did not include a data payload')
+  }
+  return envelope.data
+}
+
+async function juiceEnvelopeRequest<T>(path: string, opts: { method?: 'GET' | 'POST' | 'PUT'; apiKey?: string; body?: Record<string, unknown> } = {}): Promise<JuiceApiEnvelope<T>> {
   const apiKey = opts.apiKey ?? SecureKey.getKey(JUICE_API_KEY_NAME)
   if (!apiKey) {
     throw new Error('JUICE_API_KEY is not configured')
@@ -168,15 +328,13 @@ async function juiceRequest<T>(path: string, opts: { method?: 'GET'; apiKey?: st
       'X-API-Key': apiKey,
       'Content-Type': 'application/json',
     },
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
   })
 
   const json = await res.json().catch(() => null) as JuiceApiEnvelope<T> | null
   if (!res.ok || !json?.success) {
     throw new Error(json?.message ?? `Juice API request failed with status ${res.status}`)
   }
-  if (typeof json.data === 'undefined') {
-    throw new Error('Juice API response did not include a data payload')
-  }
 
-  return json.data
+  return json
 }

--- a/electron/services/JuiceStrategyPreviewService.ts
+++ b/electron/services/JuiceStrategyPreviewService.ts
@@ -1,0 +1,109 @@
+import * as JuiceService from './JuiceService'
+
+export interface JuiceStrategyPreviewInput {
+  targetPnlUsd: number
+  maxCrowdLevel: number
+  scoutLimit?: number
+}
+
+export interface JuiceStrategySellCandidate {
+  wallet: JuiceService.JuiceWallet
+  pnl: JuiceService.JuiceWalletPnl
+  reason: string
+}
+
+export interface JuiceStrategyEntryCandidate {
+  token: JuiceService.JuiceScoutToken
+  mintDetails: JuiceService.JuiceMintDetails
+  reason: string
+}
+
+export interface JuiceStrategySkippedCandidate {
+  token: JuiceService.JuiceScoutToken
+  reason: string
+}
+
+export interface JuiceStrategyPreview {
+  targetPnlUsd: number
+  maxCrowdLevel: number
+  scoutLimit: number
+  sellCandidates: JuiceStrategySellCandidate[]
+  entryCandidates: JuiceStrategyEntryCandidate[]
+  skipped: JuiceStrategySkippedCandidate[]
+  generatedAt: number
+}
+
+function formatUsd(value: number) {
+  return value.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })
+}
+
+export async function buildStrategyPreview(input: JuiceStrategyPreviewInput): Promise<JuiceStrategyPreview> {
+  const targetPnlUsd = Number.isFinite(input.targetPnlUsd) ? Math.max(0, input.targetPnlUsd) : 0
+  const maxCrowdLevel = Number.isFinite(input.maxCrowdLevel) ? Math.max(0, input.maxCrowdLevel) : 3
+  const scoutLimit = Number.isFinite(input.scoutLimit ?? 5) ? Math.max(1, Math.min(20, input.scoutLimit ?? 5)) : 5
+
+  const [wallets, scoutingReport] = await Promise.all([
+    JuiceService.listWallets(),
+    JuiceService.getScoutingReport(),
+  ])
+
+  const pnlResults = await Promise.allSettled(
+    wallets.filter((wallet) => wallet.isActive).map(async (wallet) => ({
+      wallet,
+      pnl: await JuiceService.getPnl(wallet.id),
+    }))
+  )
+
+  const sellCandidates = pnlResults.flatMap((result): JuiceStrategySellCandidate[] => {
+    if (result.status !== 'fulfilled') return []
+    const { wallet, pnl } = result.value
+    if (pnl.pnl.totalUsd < targetPnlUsd) return []
+    return [{
+      wallet,
+      pnl,
+      reason: `PNL is at or above ${formatUsd(targetPnlUsd)} target`,
+    }]
+  })
+
+  const inspected = await Promise.allSettled(
+    scoutingReport.tokens.slice(0, scoutLimit).map(async (token) => ({
+      token,
+      mintDetails: await JuiceService.getMintDetails(token.mint),
+    }))
+  )
+
+  const entryCandidates: JuiceStrategyEntryCandidate[] = []
+  const skipped: JuiceStrategySkippedCandidate[] = []
+
+  inspected.forEach((result, index) => {
+    const token = scoutingReport.tokens[index]
+    if (!token) return
+
+    if (result.status !== 'fulfilled') {
+      skipped.push({ token, reason: result.reason instanceof Error ? result.reason.message : 'Mint details unavailable' })
+      return
+    }
+
+    const { mintDetails } = result.value
+    if (mintDetails.overcrowdingLevel > maxCrowdLevel) {
+      skipped.push({ token, reason: `Crowding level ${mintDetails.overcrowdingLevel} is above max ${maxCrowdLevel}` })
+      return
+    }
+
+    entryCandidates.push({
+      token,
+      mintDetails,
+      reason: `Grade ${token.grade}, score ${token.score}/${token.maxScore}, crowding ${mintDetails.overcrowdingLevel}/${maxCrowdLevel}`,
+    })
+  })
+
+  return {
+    targetPnlUsd,
+    maxCrowdLevel,
+    scoutLimit,
+    sellCandidates,
+    entryCandidates,
+    skipped,
+    generatedAt: Date.now(),
+  }
+}

--- a/electron/shared/types.ts
+++ b/electron/shared/types.ts
@@ -255,7 +255,6 @@ export interface ArenaSubmission {
   demoUrl?: string
   xHandle?: string
   discordHandle?: string
-  contestSlug?: string
 }
 
 export interface ArenaSubmissionInput {
@@ -952,6 +951,14 @@ export type EngineActionType =
   | 'explain-error'
   | 'suggest-fix'
   | 'ask'
+  | 'juice:has-key'
+  | 'juice:store-key'
+  | 'juice:delete-key'
+  | 'juice:list-wallets'
+  | 'juice:get-balances'
+  | 'juice:get-pnl'
+  | 'juice:get-mint-details'
+  | 'juice:get-scouting-report'
 
 export interface EngineAction {
   type: EngineActionType
@@ -959,10 +966,11 @@ export interface EngineAction {
   payload?: Record<string, unknown>
 }
 
-export interface EngineResult {
+export interface EngineResult<TData = unknown> {
   ok: boolean
   action: EngineActionType
   output?: string
+  data?: TData
   artifacts?: Record<string, string>
   error?: string
 }

--- a/src/panels/IntegrationCommandCenter/actionRunner.ts
+++ b/src/panels/IntegrationCommandCenter/actionRunner.ts
@@ -8,6 +8,13 @@ export interface IntegrationActionResult {
   items?: string[]
 }
 
+async function hasSecureKey(context: IntegrationContext, keyName: string): Promise<boolean> {
+  if (context.secureKeys[keyName]) return true
+
+  const keys = await daemon.claude.listKeys().catch(() => null)
+  return Boolean(keys?.ok && keys.data?.some((entry) => entry.key_name === keyName))
+}
+
 export async function runIntegrationAction(actionId: string, context: IntegrationContext): Promise<IntegrationActionResult> {
   if (actionId === 'check-wallet-balance') {
     const wallet = context.defaultWallet
@@ -55,7 +62,7 @@ export async function runIntegrationAction(actionId: string, context: Integratio
   }
 
   if (actionId === 'check-juice-key') {
-    const ready = Boolean(context.secureKeys.JUICE_API_KEY)
+    const ready = await hasSecureKey(context, 'JUICE_API_KEY')
     return {
       title: 'Juice key',
       status: ready ? 'success' : 'warning',

--- a/src/panels/IntegrationCommandCenter/actionRunner.ts
+++ b/src/panels/IntegrationCommandCenter/actionRunner.ts
@@ -54,6 +54,17 @@ export async function runIntegrationAction(actionId: string, context: Integratio
     }
   }
 
+  if (actionId === 'check-juice-key') {
+    const ready = Boolean(context.secureKeys.JUICE_API_KEY)
+    return {
+      title: 'Juice key',
+      status: ready ? 'success' : 'warning',
+      detail: ready
+        ? 'DAEMON has a Juice API key stored for read-only market-making checks.'
+        : 'No Juice API key is stored yet. Add one before using Juice MM API workflows.',
+    }
+  }
+
   if (actionId === 'check-solana-mcp') {
     const mcp = context.mcps.find((entry) => entry.name === 'solana-mcp-server')
     return {

--- a/src/panels/IntegrationCommandCenter/registry.ts
+++ b/src/panels/IntegrationCommandCenter/registry.ts
@@ -132,6 +132,25 @@ export const INTEGRATION_REGISTRY: IntegrationDefinition[] = [
     ],
   },
   {
+    id: 'juice',
+    name: 'Juice Market Maker',
+    tagline: 'Market-making wallets, PNL, scouts, and guarded execution',
+    description: 'Use Juice to manage market-making wallets, monitor balances and PNL, review token scouting reports, inspect pool overcrowding, and prepare guarded buy/sell actions after DAEMON confirmation.',
+    category: 'defi',
+    docsUrl: 'https://github.com/juice-solana/open-juice',
+    recommendedFor: ['market making', 'token creator operations', 'PNL monitoring', 'scouting reports', 'guarded trade execution'],
+    requirements: [
+      { type: 'secure-key', key: 'JUICE_API_KEY', label: 'Juice API key' },
+      { type: 'wallet', key: 'default-wallet', label: 'Default DAEMON wallet', optional: true },
+    ],
+    actions: [
+      { id: 'check-juice-key', label: 'Check key', description: 'Verify DAEMON has a Juice API key stored before using Juice MM API workflows.', kind: 'safe-check', risk: 'read-only' },
+      { id: 'preview-juice-wallets', label: 'Preview wallets', description: 'Planned: read Juice MM wallets, balances, active token, and status.', kind: 'planned', risk: 'read-only' },
+      { id: 'preview-juice-scouting-report', label: 'Preview scouts', description: 'Planned: show fresh Juice scouting reports without entering positions.', kind: 'planned', risk: 'read-only' },
+      { id: 'open-juice-console', label: 'Open console', description: 'Planned: open the guided Juice operator dashboard inside DAEMON.', kind: 'planned', risk: 'read-only' },
+    ],
+  },
+  {
     id: 'metaplex',
     name: 'Metaplex',
     tagline: 'NFTs, metadata, Core, Bubblegum',

--- a/src/panels/JuicePanel/JuicePanel.css
+++ b/src/panels/JuicePanel/JuicePanel.css
@@ -63,6 +63,85 @@
   color: #fde68a;
 }
 
+.juice-key-card {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.85fr) minmax(280px, 1.15fr);
+  gap: 16px;
+  align-items: start;
+  margin-top: 14px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.juice-key-card h3 {
+  margin: 0 0 6px;
+  font-size: 14px;
+}
+
+.juice-key-card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.6);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.juice-key-controls {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+}
+
+.juice-key-controls input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: rgba(248, 250, 252, 0.94);
+  background: rgba(2, 6, 23, 0.52);
+  outline: none;
+}
+
+.juice-key-controls input:focus {
+  border-color: rgba(20, 241, 149, 0.38);
+  box-shadow: 0 0 0 3px rgba(20, 241, 149, 0.08);
+}
+
+.juice-secondary-btn,
+.juice-ghost-btn {
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.juice-secondary-btn {
+  border: 1px solid rgba(20, 241, 149, 0.32);
+  color: #bbf7d0;
+  background: rgba(20, 241, 149, 0.1);
+}
+
+.juice-ghost-btn {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.72);
+  background: rgba(15, 23, 42, 0.36);
+}
+
+.juice-secondary-btn:disabled,
+.juice-ghost-btn:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+
+.juice-key-message {
+  grid-column: 2;
+  margin-top: -6px;
+  color: rgba(226, 232, 240, 0.68);
+  font-size: 12px;
+}
+
 .juice-actions {
   display: flex;
   align-items: center;
@@ -285,9 +364,22 @@
 
 @media (max-width: 980px) {
   .juice-hero,
-  .juice-actions {
+  .juice-actions,
+  .juice-key-card {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .juice-key-card {
+    display: flex;
+  }
+
+  .juice-key-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .juice-key-message {
+    grid-column: auto;
   }
 
   .juice-metrics-grid {

--- a/src/panels/JuicePanel/JuicePanel.css
+++ b/src/panels/JuicePanel/JuicePanel.css
@@ -64,7 +64,8 @@
 }
 
 .juice-key-card,
-.juice-strategy-card {
+.juice-strategy-card,
+.juice-execution-card {
   border: 1px solid rgba(148, 163, 184, 0.16);
   border-radius: 16px;
   background: rgba(15, 23, 42, 0.42);
@@ -99,7 +100,9 @@
 }
 
 .juice-key-controls input,
-.juice-strategy-controls input {
+.juice-strategy-controls input,
+.juice-execution-controls input,
+.juice-execution-controls select {
   width: 100%;
   min-width: 0;
   border: 1px solid rgba(148, 163, 184, 0.18);
@@ -111,7 +114,9 @@
 }
 
 .juice-key-controls input:focus,
-.juice-strategy-controls input:focus {
+.juice-strategy-controls input:focus,
+.juice-execution-controls input:focus,
+.juice-execution-controls select:focus {
   border-color: rgba(20, 241, 149, 0.38);
   box-shadow: 0 0 0 3px rgba(20, 241, 149, 0.08);
 }
@@ -255,18 +260,30 @@
   font-size: 12px;
 }
 
-.juice-strategy-card {
+.juice-strategy-card,
+.juice-execution-card {
   padding: 14px;
 }
 
-.juice-strategy-controls {
+.juice-strategy-controls,
+.juice-execution-controls {
   display: grid;
   grid-template-columns: minmax(120px, 0.4fr) minmax(120px, 0.4fr) auto;
   gap: 10px;
   align-items: end;
 }
 
-.juice-strategy-controls label {
+.juice-execution-controls {
+  grid-template-columns: minmax(140px, 0.5fr) minmax(220px, 1fr) minmax(120px, 0.35fr);
+  margin-top: 12px;
+}
+
+.juice-execution-controls.secondary {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.juice-strategy-controls label,
+.juice-execution-controls label {
   display: grid;
   gap: 6px;
   color: rgba(226, 232, 240, 0.6);
@@ -308,6 +325,64 @@
   color: rgba(226, 232, 240, 0.58);
   font-size: 12px;
   line-height: 1.4;
+}
+
+.juice-execution-warning {
+  padding: 10px 12px;
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  border-radius: 12px;
+  background: rgba(113, 63, 18, 0.18);
+  color: #fde68a;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.juice-execution-summary,
+.juice-execution-message {
+  display: grid;
+  gap: 4px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.28);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.juice-execution-summary strong,
+.juice-execution-message strong {
+  font-size: 12px;
+}
+
+.juice-execution-summary span,
+.juice-execution-message {
+  color: rgba(226, 232, 240, 0.68);
+  font-size: 12px;
+}
+
+.juice-checkbox-line {
+  display: flex !important;
+  align-items: center;
+  gap: 8px;
+  color: rgba(226, 232, 240, 0.7) !important;
+  font-size: 12px;
+}
+
+.juice-checkbox-line input {
+  width: auto;
+}
+
+.juice-checkbox-line.impact {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(248, 113, 113, 0.22);
+  border-radius: 12px;
+  background: rgba(127, 29, 29, 0.12);
+}
+
+.juice-execution-buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
 }
 
 .juice-wallet-list {
@@ -462,7 +537,9 @@
 
   .juice-key-controls,
   .juice-strategy-controls,
-  .juice-preview-grid {
+  .juice-preview-grid,
+  .juice-execution-controls,
+  .juice-execution-controls.secondary {
     grid-template-columns: 1fr;
   }
 
@@ -476,5 +553,9 @@
 
   .juice-wallet-stats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .juice-execution-buttons {
+    flex-direction: column;
   }
 }

--- a/src/panels/JuicePanel/JuicePanel.css
+++ b/src/panels/JuicePanel/JuicePanel.css
@@ -1,0 +1,300 @@
+.juice-panel {
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  padding: 22px;
+  color: var(--text-primary, #f8fafc);
+  background:
+    radial-gradient(circle at top left, rgba(20, 241, 149, 0.1), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.08), transparent 32%),
+    var(--bg-primary, #08090c);
+}
+
+.juice-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.62);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.28);
+}
+
+.juice-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #14f195;
+  margin-bottom: 8px;
+}
+
+.juice-hero h2 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  letter-spacing: -0.03em;
+}
+
+.juice-hero p {
+  margin: 0;
+  max-width: 660px;
+  color: rgba(226, 232, 240, 0.72);
+  line-height: 1.55;
+}
+
+.juice-key-pill {
+  white-space: nowrap;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  color: rgba(226, 232, 240, 0.82);
+  background: rgba(2, 6, 23, 0.52);
+}
+
+.juice-key-pill.ready {
+  border-color: rgba(20, 241, 149, 0.38);
+  color: #bbf7d0;
+}
+
+.juice-key-pill.missing {
+  border-color: rgba(251, 191, 36, 0.35);
+  color: #fde68a;
+}
+
+.juice-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.juice-primary-btn {
+  border: 0;
+  border-radius: 12px;
+  padding: 10px 14px;
+  color: #03110b;
+  font-weight: 700;
+  background: linear-gradient(135deg, #14f195, #38bdf8);
+  cursor: pointer;
+}
+
+.juice-primary-btn:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+
+.juice-action-note {
+  color: rgba(226, 232, 240, 0.58);
+  font-size: 12px;
+}
+
+.juice-warning {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(248, 113, 113, 0.32);
+  border-radius: 14px;
+  background: rgba(127, 29, 29, 0.2);
+  color: #fecaca;
+}
+
+.juice-warning span {
+  color: rgba(254, 202, 202, 0.82);
+}
+
+.juice-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.juice-metric-card,
+.juice-wallet-card,
+.juice-scout-card,
+.juice-empty {
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.52);
+  border-radius: 16px;
+}
+
+.juice-metric-card {
+  padding: 14px;
+}
+
+.juice-metric-card span {
+  display: block;
+  margin-bottom: 8px;
+  color: rgba(226, 232, 240, 0.56);
+  font-size: 12px;
+}
+
+.juice-metric-card strong {
+  font-size: 20px;
+  letter-spacing: -0.02em;
+}
+
+.juice-section {
+  margin-top: 18px;
+}
+
+.juice-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.juice-section-header h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.juice-section-header span {
+  color: rgba(226, 232, 240, 0.52);
+  font-size: 12px;
+}
+
+.juice-wallet-list {
+  display: grid;
+  gap: 10px;
+}
+
+.juice-wallet-card {
+  padding: 14px;
+}
+
+.juice-wallet-topline,
+.juice-scout-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.juice-wallet-topline strong,
+.juice-scout-topline strong {
+  display: block;
+  font-size: 14px;
+}
+
+.juice-wallet-topline span,
+.juice-scout-topline span {
+  display: block;
+  margin-top: 3px;
+  color: rgba(226, 232, 240, 0.52);
+  font-size: 12px;
+}
+
+.juice-status {
+  border-radius: 999px;
+  padding: 5px 8px;
+  font-size: 11px;
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.juice-status.active {
+  background: rgba(20, 241, 149, 0.12);
+  color: #bbf7d0;
+}
+
+.juice-status.idle {
+  background: rgba(251, 191, 36, 0.11);
+  color: #fde68a;
+}
+
+.juice-wallet-stats,
+.juice-scout-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.juice-wallet-stats span,
+.juice-scout-stats span {
+  color: rgba(226, 232, 240, 0.55);
+  font-size: 12px;
+}
+
+.juice-wallet-stats b {
+  display: block;
+  margin-top: 3px;
+  color: rgba(248, 250, 252, 0.94);
+}
+
+.juice-card-error,
+.juice-card-note {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  font-size: 12px;
+}
+
+.juice-card-error {
+  background: rgba(127, 29, 29, 0.22);
+  color: #fecaca;
+}
+
+.juice-card-note {
+  background: rgba(30, 41, 59, 0.72);
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.juice-scout-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.juice-scout-card {
+  padding: 14px;
+}
+
+.juice-scout-topline b {
+  color: #14f195;
+}
+
+.juice-scout-score {
+  margin-top: 12px;
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.juice-scout-stats {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.juice-scout-card code {
+  display: inline-block;
+  margin-top: 12px;
+  color: rgba(125, 211, 252, 0.85);
+  font-size: 11px;
+}
+
+.juice-empty {
+  padding: 16px;
+  color: rgba(226, 232, 240, 0.58);
+}
+
+@media (max-width: 980px) {
+  .juice-hero,
+  .juice-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .juice-metrics-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .juice-wallet-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/panels/JuicePanel/JuicePanel.css
+++ b/src/panels/JuicePanel/JuicePanel.css
@@ -63,6 +63,13 @@
   color: #fde68a;
 }
 
+.juice-key-card,
+.juice-strategy-card {
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.42);
+}
+
 .juice-key-card {
   display: grid;
   grid-template-columns: minmax(220px, 0.85fr) minmax(280px, 1.15fr);
@@ -70,12 +77,10 @@
   align-items: start;
   margin-top: 14px;
   padding: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  border-radius: 16px;
-  background: rgba(15, 23, 42, 0.42);
 }
 
-.juice-key-card h3 {
+.juice-key-card h3,
+.juice-strategy-card h4 {
   margin: 0 0 6px;
   font-size: 14px;
 }
@@ -93,7 +98,8 @@
   gap: 8px;
 }
 
-.juice-key-controls input {
+.juice-key-controls input,
+.juice-strategy-controls input {
   width: 100%;
   min-width: 0;
   border: 1px solid rgba(148, 163, 184, 0.18);
@@ -104,13 +110,15 @@
   outline: none;
 }
 
-.juice-key-controls input:focus {
+.juice-key-controls input:focus,
+.juice-strategy-controls input:focus {
   border-color: rgba(20, 241, 149, 0.38);
   box-shadow: 0 0 0 3px rgba(20, 241, 149, 0.08);
 }
 
 .juice-secondary-btn,
-.juice-ghost-btn {
+.juice-ghost-btn,
+.juice-mini-btn {
   border-radius: 12px;
   padding: 10px 12px;
   font-weight: 700;
@@ -123,14 +131,21 @@
   background: rgba(20, 241, 149, 0.1);
 }
 
-.juice-ghost-btn {
+.juice-ghost-btn,
+.juice-mini-btn {
   border: 1px solid rgba(148, 163, 184, 0.18);
   color: rgba(226, 232, 240, 0.72);
   background: rgba(15, 23, 42, 0.36);
 }
 
+.juice-mini-btn {
+  padding: 6px 8px;
+  font-size: 11px;
+}
+
 .juice-secondary-btn:disabled,
-.juice-ghost-btn:disabled {
+.juice-ghost-btn:disabled,
+.juice-mini-btn:disabled {
   opacity: 0.48;
   cursor: not-allowed;
 }
@@ -164,7 +179,9 @@
   cursor: not-allowed;
 }
 
-.juice-action-note {
+.juice-action-note,
+.juice-muted,
+.juice-strategy-note {
   color: rgba(226, 232, 240, 0.58);
   font-size: 12px;
 }
@@ -238,6 +255,61 @@
   font-size: 12px;
 }
 
+.juice-strategy-card {
+  padding: 14px;
+}
+
+.juice-strategy-controls {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.4fr) minmax(120px, 0.4fr) auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.juice-strategy-controls label {
+  display: grid;
+  gap: 6px;
+  color: rgba(226, 232, 240, 0.6);
+  font-size: 12px;
+}
+
+.juice-strategy-note {
+  margin: 12px 0 0;
+  line-height: 1.5;
+}
+
+.juice-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.juice-preview-grid > div {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.28);
+}
+
+.juice-preview-row {
+  display: grid;
+  gap: 3px;
+  padding: 8px 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.juice-preview-row strong {
+  font-size: 13px;
+}
+
+.juice-preview-row span {
+  color: rgba(226, 232, 240, 0.58);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .juice-wallet-list {
   display: grid;
   gap: 10px;
@@ -248,7 +320,8 @@
 }
 
 .juice-wallet-topline,
-.juice-scout-topline {
+.juice-scout-topline,
+.juice-scout-footer {
   display: flex;
   justify-content: space-between;
   gap: 14px;
@@ -288,7 +361,8 @@
 }
 
 .juice-wallet-stats,
-.juice-scout-stats {
+.juice-scout-stats,
+.juice-mint-details {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 8px;
@@ -296,12 +370,14 @@
 }
 
 .juice-wallet-stats span,
-.juice-scout-stats span {
+.juice-scout-stats span,
+.juice-mint-details span {
   color: rgba(226, 232, 240, 0.55);
   font-size: 12px;
 }
 
-.juice-wallet-stats b {
+.juice-wallet-stats b,
+.juice-mint-details b {
   display: block;
   margin-top: 3px;
   color: rgba(248, 250, 252, 0.94);
@@ -346,15 +422,25 @@
   letter-spacing: -0.03em;
 }
 
-.juice-scout-stats {
+.juice-scout-stats,
+.juice-mint-details {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.juice-scout-footer {
+  align-items: center;
+  margin-top: 12px;
 }
 
 .juice-scout-card code {
   display: inline-block;
-  margin-top: 12px;
   color: rgba(125, 211, 252, 0.85);
   font-size: 11px;
+}
+
+.juice-mint-details {
+  padding-top: 10px;
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
 }
 
 .juice-empty {
@@ -374,7 +460,9 @@
     display: flex;
   }
 
-  .juice-key-controls {
+  .juice-key-controls,
+  .juice-strategy-controls,
+  .juice-preview-grid {
     grid-template-columns: 1fr;
   }
 

--- a/src/panels/JuicePanel/JuicePanel.tsx
+++ b/src/panels/JuicePanel/JuicePanel.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useState } from 'react'
+import { daemon } from '../../lib/daemonBridge'
+import './JuicePanel.css'
+
+type JuiceWallet = {
+  id: string
+  publicKey: string
+  mint: string | null
+  symbol?: string | null
+  name?: string | null
+  isActive: boolean
+  deactivationReason?: string | null
+  stopLossPrice?: number | null
+  takeProfitPrice?: number | null
+}
+
+type JuiceWalletBalances = {
+  mmTokenId: string
+  publicKey: string
+  mint: string | null
+  solBalance: number
+  tokenBalances: Array<{ mint: string; balance: number; decimals: number }>
+}
+
+type JuiceWalletPnl = {
+  mmTokenId: string
+  mint: string
+  symbol?: string
+  walletAddress: string
+  pnl: {
+    totalUsd: number
+    totalPercent: number
+    realizedUsd: number
+    realizedPercent: number
+    unrealizedUsd: number
+    unrealizedPercent: number
+  }
+}
+
+type JuiceScoutToken = {
+  mint: string
+  symbol: string
+  name: string
+  price: number
+  marketCap: number
+  liquidity: number
+  score: number
+  maxScore: number
+  grade: string
+  priceChange1hPercent?: number
+  priceChange24hPercent?: number
+  volume1hUsd?: number
+  volume24hUsd?: number
+}
+
+type JuiceScoutingReport = {
+  tokens: JuiceScoutToken[]
+  tokenCount: number
+  scannedAt: string
+}
+
+type JuiceBridge = {
+  hasKey: () => Promise<IpcResponse<boolean>>
+  listWallets: () => Promise<IpcResponse<JuiceWallet[]>>
+  getBalances: (walletId: string) => Promise<IpcResponse<JuiceWalletBalances>>
+  getPnl: (walletId: string) => Promise<IpcResponse<JuiceWalletPnl>>
+  getScoutingReport: () => Promise<IpcResponse<JuiceScoutingReport>>
+}
+
+type WalletRow = {
+  wallet: JuiceWallet
+  balances: JuiceWalletBalances | null
+  pnl: JuiceWalletPnl | null
+  error: string | null
+}
+
+function formatUsd(value?: number | null) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '—'
+  return value.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })
+}
+
+function formatNumber(value?: number | null, max = 4) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '—'
+  return value.toLocaleString(undefined, { maximumFractionDigits: max })
+}
+
+function shortAddress(value?: string | null) {
+  if (!value) return '—'
+  return `${value.slice(0, 4)}…${value.slice(-4)}`
+}
+
+function getJuiceBridge(): JuiceBridge {
+  return (daemon as unknown as { juice: JuiceBridge }).juice
+}
+
+export function JuicePanel() {
+  const [hasKey, setHasKey] = useState(false)
+  const [checkingKey, setCheckingKey] = useState(true)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [walletRows, setWalletRows] = useState<WalletRow[]>([])
+  const [scoutingReport, setScoutingReport] = useState<JuiceScoutingReport | null>(null)
+
+  const totals = useMemo(() => {
+    const activeWallets = walletRows.filter((row) => row.wallet.isActive).length
+    const idleWallets = walletRows.length - activeWallets
+    const totalSol = walletRows.reduce((sum, row) => sum + (row.balances?.solBalance ?? 0), 0)
+    const totalPnlUsd = walletRows.reduce((sum, row) => sum + (row.pnl?.pnl.totalUsd ?? 0), 0)
+    return { activeWallets, idleWallets, totalSol, totalPnlUsd }
+  }, [walletRows])
+
+  useEffect(() => {
+    let cancelled = false
+    async function checkKey() {
+      setCheckingKey(true)
+      const keys = await daemon.claude.listKeys().catch(() => null)
+      const keyFromSecureStore = Boolean(keys?.ok && keys.data?.some((entry) => entry.key_name === 'JUICE_API_KEY'))
+
+      const bridgeKey = await getJuiceBridge().hasKey().catch(() => null)
+      if (!cancelled) {
+        setHasKey(keyFromSecureStore || Boolean(bridgeKey?.ok && bridgeKey.data))
+        setCheckingKey(false)
+      }
+    }
+    void checkKey()
+    return () => { cancelled = true }
+  }, [])
+
+  const loadDashboard = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const bridge = getJuiceBridge()
+      const walletsRes = await bridge.listWallets()
+      if (!walletsRes.ok || !walletsRes.data) throw new Error(walletsRes.error ?? 'Could not load Juice wallets')
+
+      const rows = await Promise.all(walletsRes.data.map(async (wallet): Promise<WalletRow> => {
+        const [balancesRes, pnlRes] = await Promise.all([
+          bridge.getBalances(wallet.id).catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceWalletBalances>)),
+          bridge.getPnl(wallet.id).catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceWalletPnl>)),
+        ])
+        return {
+          wallet,
+          balances: balancesRes.ok ? balancesRes.data ?? null : null,
+          pnl: pnlRes.ok ? pnlRes.data ?? null : null,
+          error: !balancesRes.ok || !pnlRes.ok ? [balancesRes.error, pnlRes.error].filter(Boolean).join(' / ') : null,
+        }
+      }))
+
+      const scoutRes = await bridge.getScoutingReport().catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceScoutingReport>))
+      setWalletRows(rows)
+      setScoutingReport(scoutRes.ok ? scoutRes.data ?? null : null)
+      if (!scoutRes.ok && rows.length === 0) setError(scoutRes.error ?? 'Juice scouting report is unavailable')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="juice-panel">
+      <header className="juice-hero">
+        <div>
+          <div className="juice-eyebrow">Juice Market Maker</div>
+          <h2>MM wallet cockpit</h2>
+          <p>Read-only view for Juice wallets, balances, PNL, and scouting reports before DAEMON enables guarded execution.</p>
+        </div>
+        <div className={`juice-key-pill ${hasKey ? 'ready' : 'missing'}`}>
+          {checkingKey ? 'Checking key…' : hasKey ? 'JUICE_API_KEY ready' : 'JUICE_API_KEY missing'}
+        </div>
+      </header>
+
+      <div className="juice-actions">
+        <button className="juice-primary-btn" onClick={loadDashboard} disabled={loading || !hasKey}>
+          {loading ? 'Loading Juice…' : 'Load read-only dashboard'}
+        </button>
+        <span className="juice-action-note">Buy, sell, and wallet creation are intentionally not enabled in this panel yet.</span>
+      </div>
+
+      {error && (
+        <div className="juice-warning">
+          <strong>Juice data unavailable.</strong>
+          <span>{error}</span>
+        </div>
+      )}
+
+      <section className="juice-metrics-grid">
+        <div className="juice-metric-card">
+          <span>Total wallets</span>
+          <strong>{walletRows.length}</strong>
+        </div>
+        <div className="juice-metric-card">
+          <span>Active</span>
+          <strong>{totals.activeWallets}</strong>
+        </div>
+        <div className="juice-metric-card">
+          <span>Idle</span>
+          <strong>{totals.idleWallets}</strong>
+        </div>
+        <div className="juice-metric-card">
+          <span>Total SOL</span>
+          <strong>{formatNumber(totals.totalSol, 3)}</strong>
+        </div>
+        <div className="juice-metric-card">
+          <span>Total PNL</span>
+          <strong>{formatUsd(totals.totalPnlUsd)}</strong>
+        </div>
+      </section>
+
+      <section className="juice-section">
+        <div className="juice-section-header">
+          <h3>MM wallets</h3>
+          <span>{walletRows.length ? `${walletRows.length} loaded` : 'No wallet data loaded'}</span>
+        </div>
+        <div className="juice-wallet-list">
+          {walletRows.length === 0 ? (
+            <div className="juice-empty">Add a Juice API key and load the dashboard to preview MM wallet state.</div>
+          ) : walletRows.map((row) => (
+            <article className="juice-wallet-card" key={row.wallet.id}>
+              <div className="juice-wallet-topline">
+                <div>
+                  <strong>{row.wallet.symbol ?? row.wallet.name ?? shortAddress(row.wallet.mint)}</strong>
+                  <span>{shortAddress(row.wallet.publicKey)}</span>
+                </div>
+                <span className={`juice-status ${row.wallet.isActive ? 'active' : 'idle'}`}>{row.wallet.isActive ? 'Active' : 'Idle'}</span>
+              </div>
+              <div className="juice-wallet-stats">
+                <span>SOL <b>{formatNumber(row.balances?.solBalance, 3)}</b></span>
+                <span>PNL <b>{formatUsd(row.pnl?.pnl.totalUsd)}</b></span>
+                <span>SL <b>{formatNumber(row.wallet.stopLossPrice, 8)}</b></span>
+                <span>TP <b>{formatNumber(row.wallet.takeProfitPrice, 8)}</b></span>
+              </div>
+              {row.error && <div className="juice-card-error">{row.error}</div>}
+              {row.wallet.deactivationReason && <div className="juice-card-note">{row.wallet.deactivationReason}</div>}
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="juice-section">
+        <div className="juice-section-header">
+          <h3>Scouting report</h3>
+          <span>{scoutingReport ? `${scoutingReport.tokenCount} candidates` : 'No report loaded'}</span>
+        </div>
+        <div className="juice-scout-grid">
+          {(scoutingReport?.tokens ?? []).slice(0, 8).map((token) => (
+            <article className="juice-scout-card" key={token.mint}>
+              <div className="juice-scout-topline">
+                <div>
+                  <strong>{token.symbol}</strong>
+                  <span>{token.name}</span>
+                </div>
+                <b>{token.grade}</b>
+              </div>
+              <div className="juice-scout-score">{token.score}/{token.maxScore}</div>
+              <div className="juice-scout-stats">
+                <span>MC {formatUsd(token.marketCap)}</span>
+                <span>Liq {formatUsd(token.liquidity)}</span>
+                <span>1h {formatNumber(token.priceChange1hPercent, 2)}%</span>
+                <span>24h {formatNumber(token.priceChange24hPercent, 2)}%</span>
+              </div>
+              <code>{shortAddress(token.mint)}</code>
+            </article>
+          ))}
+          {!scoutingReport && <div className="juice-empty">Scouting reports will appear here after the read-only dashboard loads.</div>}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/panels/JuicePanel/JuicePanel.tsx
+++ b/src/panels/JuicePanel/JuicePanel.tsx
@@ -269,3 +269,5 @@ export function JuicePanel() {
     </div>
   )
 }
+
+export default JuicePanel

--- a/src/panels/JuicePanel/JuicePanel.tsx
+++ b/src/panels/JuicePanel/JuicePanel.tsx
@@ -78,7 +78,7 @@ type JuiceScoutingReport = {
   scannedAt: string
 }
 
-type JuiceActionType = Extract<EngineAction['type'], `juice:${string}`>
+type JuiceActionType = `juice:${string}`
 
 type WalletRow = {
   wallet: JuiceWallet
@@ -94,6 +94,9 @@ type MintDetailRecord = {
 }
 
 type StrategyPreview = {
+  targetPnlUsd?: number
+  maxCrowdLevel?: number
+  scoutLimit?: number
   sellCandidates: Array<{ wallet: JuiceWallet; pnl: JuiceWalletPnl; reason: string }>
   entryCandidates: Array<{ token: JuiceScoutToken; mintDetails: JuiceMintDetails; reason: string }>
   skipped: Array<{ token: JuiceScoutToken; reason: string }>
@@ -116,7 +119,7 @@ function shortAddress(value?: string | null) {
 }
 
 async function runJuiceAction<T>(type: JuiceActionType, payload?: Record<string, unknown>): Promise<IpcResponse<T>> {
-  const action: EngineAction = { type, payload }
+  const action = { type, payload } as EngineAction
   const response = await daemon.engine.run(action) as IpcResponse<EngineResult<T>>
   if (!response.ok) return { ok: false, error: response.error }
 
@@ -261,50 +264,23 @@ export function JuicePanel() {
   }
 
   const buildStrategyPreview = async () => {
-    if (!scoutingReport?.tokens.length) {
-      setError('Load a scouting report before building a strategy preview.')
-      return
-    }
-
     setStrategyLoading(true)
     setError(null)
     try {
-      const sellCandidates = walletRows
-        .filter((row) => row.wallet.isActive && row.pnl && row.pnl.pnl.totalUsd >= targetPnlUsd)
-        .map((row) => ({
-          wallet: row.wallet,
-          pnl: row.pnl as JuiceWalletPnl,
-          reason: `PNL is at or above ${formatUsd(targetPnlUsd)} target`,
-        }))
-
-      const tokensToInspect = scoutingReport.tokens.slice(0, 5)
-      const inspected = await Promise.all(tokensToInspect.map(async (token) => {
-        const existing = mintDetails[token.mint]?.data
-        if (existing) return { token, details: existing, error: null as string | null }
-        const res = await inspectMint(token.mint)
-        return { token, details: res.data ?? null, error: res.error ?? null }
-      }))
-
-      const entryCandidates: StrategyPreview['entryCandidates'] = []
-      const skipped: StrategyPreview['skipped'] = []
-
-      inspected.forEach(({ token, details, error }) => {
-        if (error || !details) {
-          skipped.push({ token, reason: error ?? 'Mint details unavailable' })
-          return
-        }
-        if (details.overcrowdingLevel > maxCrowdLevel) {
-          skipped.push({ token, reason: `Crowding level ${details.overcrowdingLevel} is above max ${maxCrowdLevel}` })
-          return
-        }
-        entryCandidates.push({
-          token,
-          mintDetails: details,
-          reason: `Grade ${token.grade}, score ${token.score}/${token.maxScore}, crowding ${details.overcrowdingLevel}/${maxCrowdLevel}`,
-        })
+      const previewRes = await runJuiceAction<StrategyPreview>('juice:strategy-preview', {
+        targetPnlUsd,
+        maxCrowdLevel,
+        scoutLimit: 5,
       })
+      if (!previewRes.ok || !previewRes.data) throw new Error(previewRes.error ?? 'Unable to build Juice strategy preview')
 
-      setStrategyPreview({ sellCandidates, entryCandidates, skipped, generatedAt: Date.now() })
+      const inspectedMints = previewRes.data.entryCandidates.reduce<Record<string, MintDetailRecord>>((acc, candidate) => {
+        acc[candidate.token.mint] = { loading: false, data: candidate.mintDetails, error: null }
+        return acc
+      }, {})
+
+      setMintDetails((current) => ({ ...current, ...inspectedMints }))
+      setStrategyPreview(previewRes.data)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -402,11 +378,11 @@ export function JuicePanel() {
               Max crowd
               <input type="number" value={maxCrowdLevel} min={0} max={10} step={1} onChange={(event) => setMaxCrowdLevel(Number(event.target.value))} />
             </label>
-            <button className="juice-secondary-btn" onClick={buildStrategyPreview} disabled={strategyLoading || !scoutingReport}>
+            <button className="juice-secondary-btn" onClick={buildStrategyPreview} disabled={strategyLoading || !hasKey}>
               {strategyLoading ? 'Building…' : 'Build preview'}
             </button>
           </div>
-          <p className="juice-strategy-note">This does not execute trades. It shows which wallets look ready to exit and which scouted mints pass the current crowding filter.</p>
+          <p className="juice-strategy-note">This does not execute trades. DAEMON asks the main process to model which wallets look ready to exit and which scouted mints pass the crowding filter.</p>
           {strategyPreview && (
             <div className="juice-preview-grid">
               <div>

--- a/src/panels/JuicePanel/JuicePanel.tsx
+++ b/src/panels/JuicePanel/JuicePanel.tsx
@@ -59,12 +59,12 @@ type JuiceScoutingReport = {
   scannedAt: string
 }
 
-type JuiceBridge = {
-  hasKey: () => Promise<IpcResponse<boolean>>
-  listWallets: () => Promise<IpcResponse<JuiceWallet[]>>
-  getBalances: (walletId: string) => Promise<IpcResponse<JuiceWalletBalances>>
-  getPnl: (walletId: string) => Promise<IpcResponse<JuiceWalletPnl>>
-  getScoutingReport: () => Promise<IpcResponse<JuiceScoutingReport>>
+type JuiceEngineResult<T> = {
+  ok: boolean
+  action: string
+  data?: T
+  output?: string
+  error?: string
 }
 
 type WalletRow = {
@@ -89,8 +89,14 @@ function shortAddress(value?: string | null) {
   return `${value.slice(0, 4)}…${value.slice(-4)}`
 }
 
-function getJuiceBridge(): JuiceBridge {
-  return (daemon as unknown as { juice: JuiceBridge }).juice
+async function runJuiceAction<T>(type: string, payload?: Record<string, unknown>): Promise<IpcResponse<T>> {
+  const response = await daemon.engine.run({ type, payload } as never) as IpcResponse<JuiceEngineResult<T>>
+  if (!response.ok) return { ok: false, error: response.error }
+
+  const result = response.data
+  if (!result?.ok) return { ok: false, error: result?.error ?? `Juice action failed: ${type}` }
+
+  return { ok: true, data: result.data as T }
 }
 
 export function JuicePanel() {
@@ -115,10 +121,10 @@ export function JuicePanel() {
       setCheckingKey(true)
       const keys = await daemon.claude.listKeys().catch(() => null)
       const keyFromSecureStore = Boolean(keys?.ok && keys.data?.some((entry) => entry.key_name === 'JUICE_API_KEY'))
+      const engineKey = await runJuiceAction<boolean>('juice:has-key').catch(() => null)
 
-      const bridgeKey = await getJuiceBridge().hasKey().catch(() => null)
       if (!cancelled) {
-        setHasKey(keyFromSecureStore || Boolean(bridgeKey?.ok && bridgeKey.data))
+        setHasKey(keyFromSecureStore || Boolean(engineKey?.ok && engineKey.data))
         setCheckingKey(false)
       }
     }
@@ -130,14 +136,13 @@ export function JuicePanel() {
     setLoading(true)
     setError(null)
     try {
-      const bridge = getJuiceBridge()
-      const walletsRes = await bridge.listWallets()
+      const walletsRes = await runJuiceAction<JuiceWallet[]>('juice:list-wallets')
       if (!walletsRes.ok || !walletsRes.data) throw new Error(walletsRes.error ?? 'Could not load Juice wallets')
 
       const rows = await Promise.all(walletsRes.data.map(async (wallet): Promise<WalletRow> => {
         const [balancesRes, pnlRes] = await Promise.all([
-          bridge.getBalances(wallet.id).catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceWalletBalances>)),
-          bridge.getPnl(wallet.id).catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceWalletPnl>)),
+          runJuiceAction<JuiceWalletBalances>('juice:get-balances', { walletId: wallet.id }).catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceWalletBalances>)),
+          runJuiceAction<JuiceWalletPnl>('juice:get-pnl', { walletId: wallet.id }).catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceWalletPnl>)),
         ])
         return {
           wallet,
@@ -147,7 +152,7 @@ export function JuicePanel() {
         }
       }))
 
-      const scoutRes = await bridge.getScoutingReport().catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceScoutingReport>))
+      const scoutRes = await runJuiceAction<JuiceScoutingReport>('juice:get-scouting-report').catch((err) => ({ ok: false, error: err instanceof Error ? err.message : String(err) } as IpcResponse<JuiceScoutingReport>))
       setWalletRows(rows)
       setScoutingReport(scoutRes.ok ? scoutRes.data ?? null : null)
       if (!scoutRes.ok && rows.length === 0) setError(scoutRes.error ?? 'Juice scouting report is unavailable')

--- a/src/panels/JuicePanel/JuicePanel.tsx
+++ b/src/panels/JuicePanel/JuicePanel.tsx
@@ -79,6 +79,7 @@ type JuiceScoutingReport = {
 }
 
 type JuiceActionType = `juice:${string}`
+type ExecutionMode = 'buy' | 'sell-all' | 'edit-wallet'
 
 type WalletRow = {
   wallet: JuiceWallet
@@ -118,6 +119,12 @@ function shortAddress(value?: string | null) {
   return `${value.slice(0, 4)}…${value.slice(-4)}`
 }
 
+function parseOptionalNumber(value: string) {
+  if (!value.trim()) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
 async function runJuiceAction<T>(type: JuiceActionType, payload?: Record<string, unknown>): Promise<IpcResponse<T>> {
   const action = { type, payload } as EngineAction
   const response = await daemon.engine.run(action) as IpcResponse<EngineResult<T>>
@@ -144,6 +151,19 @@ export function JuicePanel() {
   const [scoutingReport, setScoutingReport] = useState<JuiceScoutingReport | null>(null)
   const [mintDetails, setMintDetails] = useState<Record<string, MintDetailRecord>>({})
   const [strategyPreview, setStrategyPreview] = useState<StrategyPreview | null>(null)
+  const [executionMode, setExecutionMode] = useState<ExecutionMode>('sell-all')
+  const [executionWalletId, setExecutionWalletId] = useState('')
+  const [executionSolAmount, setExecutionSolAmount] = useState(0.1)
+  const [executionOutputMint, setExecutionOutputMint] = useState<'SOL' | 'USDC'>('SOL')
+  const [executionMint, setExecutionMint] = useState('')
+  const [executionStopLoss, setExecutionStopLoss] = useState('')
+  const [executionTakeProfit, setExecutionTakeProfit] = useState('')
+  const [executionIsActive, setExecutionIsActive] = useState(true)
+  const [executionPlaceBuy, setExecutionPlaceBuy] = useState(false)
+  const [executionAck, setExecutionAck] = useState(false)
+  const [executionArmedAt, setExecutionArmedAt] = useState<number | null>(null)
+  const [executionLoading, setExecutionLoading] = useState(false)
+  const [executionMessage, setExecutionMessage] = useState<string | null>(null)
 
   const totals = useMemo(() => {
     const activeWallets = walletRows.filter((row) => row.wallet.isActive).length
@@ -154,6 +174,7 @@ export function JuicePanel() {
   }, [walletRows])
 
   const topScouts = useMemo(() => (scoutingReport?.tokens ?? []).slice(0, 8), [scoutingReport])
+  const selectedExecutionRow = useMemo(() => walletRows.find((row) => row.wallet.id === executionWalletId) ?? null, [executionWalletId, walletRows])
 
   const refreshKeyStatus = async () => {
     setCheckingKey(true)
@@ -175,6 +196,10 @@ export function JuicePanel() {
     void checkKey()
     return () => { cancelled = true }
   }, [])
+
+  useEffect(() => {
+    if (!executionWalletId && walletRows[0]) setExecutionWalletId(walletRows[0].wallet.id)
+  }, [executionWalletId, walletRows])
 
   const saveKey = async () => {
     const trimmed = apiKeyDraft.trim()
@@ -210,6 +235,8 @@ export function JuicePanel() {
       setScoutingReport(null)
       setMintDetails({})
       setStrategyPreview(null)
+      setExecutionWalletId('')
+      setExecutionArmedAt(null)
       setKeyMessage('Juice API key removed.')
       await refreshKeyStatus()
     } catch (err) {
@@ -288,6 +315,67 @@ export function JuicePanel() {
     }
   }
 
+  const armExecution = () => {
+    if (!executionWalletId) {
+      setExecutionMessage('Load wallets and select a Juice wallet first.')
+      return
+    }
+    if (!executionAck) {
+      setExecutionMessage('Acknowledge the transaction impact before arming execution.')
+      return
+    }
+    setExecutionArmedAt(Date.now())
+    setExecutionMessage('Action armed. Review the payload and execute within 60 seconds.')
+  }
+
+  const executeGuardedAction = async () => {
+    if (!executionArmedAt) {
+      setExecutionMessage('Arm the action first.')
+      return
+    }
+    if (Date.now() - executionArmedAt > 60_000) {
+      setExecutionArmedAt(null)
+      setExecutionMessage('Confirmation expired. Arm the action again.')
+      return
+    }
+
+    setExecutionLoading(true)
+    setExecutionMessage(null)
+    setError(null)
+    try {
+      const basePayload = {
+        walletId: executionWalletId,
+        confirmedAt: executionArmedAt,
+        acknowledgedImpact: true,
+      }
+      let res: IpcResponse<unknown>
+      if (executionMode === 'buy') {
+        res = await runJuiceAction('juice:buy', { ...basePayload, solAmount: executionSolAmount })
+      } else if (executionMode === 'sell-all') {
+        res = await runJuiceAction('juice:sell-all', { ...basePayload, outputMint: executionOutputMint })
+      } else {
+        res = await runJuiceAction('juice:edit-wallet', {
+          ...basePayload,
+          mint: executionMint.trim() || undefined,
+          stopLossPrice: parseOptionalNumber(executionStopLoss),
+          takeProfitPrice: parseOptionalNumber(executionTakeProfit),
+          isActive: executionIsActive,
+          placeBuy: executionPlaceBuy,
+        })
+      }
+
+      if (!res.ok) throw new Error(res.error ?? 'Juice guarded action failed')
+      setExecutionArmedAt(null)
+      setExecutionAck(false)
+      setExecutionMessage('Juice action completed. Refreshing dashboard state.')
+      await loadDashboard()
+    } catch (err) {
+      setExecutionMessage(err instanceof Error ? err.message : String(err))
+    } finally {
+      setExecutionLoading(false)
+    }
+  }
+
   return (
     <div className="juice-panel">
       <header className="juice-hero">
@@ -330,7 +418,7 @@ export function JuicePanel() {
         <button className="juice-primary-btn" onClick={loadDashboard} disabled={loading || !hasKey}>
           {loading ? 'Loading Juice…' : 'Load read-only dashboard'}
         </button>
-        <span className="juice-action-note">Buy, sell, and wallet creation are intentionally not enabled in this panel yet.</span>
+        <span className="juice-action-note">Buy, sell, and wallet creation are gated behind fresh confirmation and explicit acknowledgement.</span>
       </div>
 
       {error && (
@@ -414,6 +502,91 @@ export function JuicePanel() {
               </div>
             </div>
           )}
+        </div>
+      </section>
+
+      <section className="juice-section">
+        <div className="juice-section-header">
+          <h3>Guarded execution</h3>
+          <span>Fresh confirmation required</span>
+        </div>
+        <div className="juice-execution-card">
+          <div className="juice-execution-warning">
+            These actions can move funds through Juice and Jupiter. DAEMON requires explicit acknowledgement, then a fresh 60-second confirmation before the backend will run them.
+          </div>
+          <div className="juice-execution-controls">
+            <label>
+              Action
+              <select value={executionMode} onChange={(event) => { setExecutionMode(event.target.value as ExecutionMode); setExecutionArmedAt(null) }}>
+                <option value="sell-all">Sell all</option>
+                <option value="buy">Buy</option>
+                <option value="edit-wallet">Edit wallet</option>
+              </select>
+            </label>
+            <label>
+              Wallet
+              <select value={executionWalletId} onChange={(event) => { setExecutionWalletId(event.target.value); setExecutionArmedAt(null) }} disabled={walletRows.length === 0}>
+                <option value="">Select wallet</option>
+                {walletRows.map((row) => (
+                  <option value={row.wallet.id} key={row.wallet.id}>{row.wallet.symbol ?? shortAddress(row.wallet.publicKey)} · {shortAddress(row.wallet.publicKey)}</option>
+                ))}
+              </select>
+            </label>
+            {executionMode === 'buy' && (
+              <label>
+                SOL amount
+                <input type="number" min={0} step={0.01} value={executionSolAmount} onChange={(event) => { setExecutionSolAmount(Number(event.target.value)); setExecutionArmedAt(null) }} />
+              </label>
+            )}
+            {executionMode === 'sell-all' && (
+              <label>
+                Output
+                <select value={executionOutputMint} onChange={(event) => { setExecutionOutputMint(event.target.value as 'SOL' | 'USDC'); setExecutionArmedAt(null) }}>
+                  <option value="SOL">SOL</option>
+                  <option value="USDC">USDC</option>
+                </select>
+              </label>
+            )}
+          </div>
+          {executionMode === 'edit-wallet' && (
+            <div className="juice-execution-controls secondary">
+              <label>
+                Mint
+                <input value={executionMint} onChange={(event) => { setExecutionMint(event.target.value); setExecutionArmedAt(null) }} placeholder="Optional mint" />
+              </label>
+              <label>
+                Stop loss
+                <input value={executionStopLoss} onChange={(event) => { setExecutionStopLoss(event.target.value); setExecutionArmedAt(null) }} placeholder="Optional price" />
+              </label>
+              <label>
+                Take profit
+                <input value={executionTakeProfit} onChange={(event) => { setExecutionTakeProfit(event.target.value); setExecutionArmedAt(null) }} placeholder="Optional price" />
+              </label>
+              <label className="juice-checkbox-line">
+                <input type="checkbox" checked={executionIsActive} onChange={(event) => { setExecutionIsActive(event.target.checked); setExecutionArmedAt(null) }} />
+                Active
+              </label>
+              <label className="juice-checkbox-line">
+                <input type="checkbox" checked={executionPlaceBuy} onChange={(event) => { setExecutionPlaceBuy(event.target.checked); setExecutionArmedAt(null) }} />
+                Place buy with edit
+              </label>
+            </div>
+          )}
+          <div className="juice-execution-summary">
+            <strong>Selected wallet</strong>
+            <span>{selectedExecutionRow ? `${selectedExecutionRow.wallet.symbol ?? 'MM wallet'} · ${shortAddress(selectedExecutionRow.wallet.publicKey)} · SOL ${formatNumber(selectedExecutionRow.balances?.solBalance, 3)}` : 'No wallet selected'}</span>
+          </div>
+          <label className="juice-checkbox-line impact">
+            <input type="checkbox" checked={executionAck} onChange={(event) => { setExecutionAck(event.target.checked); setExecutionArmedAt(null) }} />
+            I understand this action may move funds, change market-making behavior, or execute a real on-chain transaction.
+          </label>
+          <div className="juice-execution-buttons">
+            <button className="juice-secondary-btn" onClick={armExecution} disabled={!hasKey || !executionWalletId || executionLoading}>Arm action</button>
+            <button className="juice-primary-btn" onClick={executeGuardedAction} disabled={!executionArmedAt || executionLoading}>
+              {executionLoading ? 'Executing…' : 'Execute guarded action'}
+            </button>
+          </div>
+          {executionMessage && <div className="juice-execution-message">{executionMessage}</div>}
         </div>
       </section>
 

--- a/src/panels/JuicePanel/JuicePanel.tsx
+++ b/src/panels/JuicePanel/JuicePanel.tsx
@@ -38,6 +38,24 @@ type JuiceWalletPnl = {
   }
 }
 
+type JuiceMintDetails = {
+  mint: string
+  wallets: number
+  totalSolBalance: number
+  totalSolValueUsd: number
+  totalTokenBalance: number
+  totalTokenValueUsd: number
+  totalPositionUsd: number
+  tokenPrice: number
+  solPrice: number
+  liquidity: number
+  marketCap: number
+  volume24h: number
+  positionToLiquidity: number
+  walletMultiplier: number
+  overcrowdingLevel: number
+}
+
 type JuiceScoutToken = {
   mint: string
   symbol: string
@@ -67,6 +85,19 @@ type WalletRow = {
   balances: JuiceWalletBalances | null
   pnl: JuiceWalletPnl | null
   error: string | null
+}
+
+type MintDetailRecord = {
+  loading: boolean
+  data: JuiceMintDetails | null
+  error: string | null
+}
+
+type StrategyPreview = {
+  sellCandidates: Array<{ wallet: JuiceWallet; pnl: JuiceWalletPnl; reason: string }>
+  entryCandidates: Array<{ token: JuiceScoutToken; mintDetails: JuiceMintDetails; reason: string }>
+  skipped: Array<{ token: JuiceScoutToken; reason: string }>
+  generatedAt: number
 }
 
 function formatUsd(value?: number | null) {
@@ -102,9 +133,14 @@ export function JuicePanel() {
   const [keySaving, setKeySaving] = useState(false)
   const [keyMessage, setKeyMessage] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [strategyLoading, setStrategyLoading] = useState(false)
+  const [targetPnlUsd, setTargetPnlUsd] = useState(25)
+  const [maxCrowdLevel, setMaxCrowdLevel] = useState(3)
   const [error, setError] = useState<string | null>(null)
   const [walletRows, setWalletRows] = useState<WalletRow[]>([])
   const [scoutingReport, setScoutingReport] = useState<JuiceScoutingReport | null>(null)
+  const [mintDetails, setMintDetails] = useState<Record<string, MintDetailRecord>>({})
+  const [strategyPreview, setStrategyPreview] = useState<StrategyPreview | null>(null)
 
   const totals = useMemo(() => {
     const activeWallets = walletRows.filter((row) => row.wallet.isActive).length
@@ -113,6 +149,8 @@ export function JuicePanel() {
     const totalPnlUsd = walletRows.reduce((sum, row) => sum + (row.pnl?.pnl.totalUsd ?? 0), 0)
     return { activeWallets, idleWallets, totalSol, totalPnlUsd }
   }, [walletRows])
+
+  const topScouts = useMemo(() => (scoutingReport?.tokens ?? []).slice(0, 8), [scoutingReport])
 
   const refreshKeyStatus = async () => {
     setCheckingKey(true)
@@ -167,6 +205,8 @@ export function JuicePanel() {
       if (!res.ok) throw new Error(res.error)
       setWalletRows([])
       setScoutingReport(null)
+      setMintDetails({})
+      setStrategyPreview(null)
       setKeyMessage('Juice API key removed.')
       await refreshKeyStatus()
     } catch (err) {
@@ -176,9 +216,22 @@ export function JuicePanel() {
     }
   }
 
+  const inspectMint = async (mint: string) => {
+    setMintDetails((current) => ({ ...current, [mint]: { loading: true, data: current[mint]?.data ?? null, error: null } }))
+    const res = await runJuiceAction<JuiceMintDetails>('juice:get-mint-details', { mint })
+    setMintDetails((current) => ({
+      ...current,
+      [mint]: res.ok && res.data
+        ? { loading: false, data: res.data, error: null }
+        : { loading: false, data: current[mint]?.data ?? null, error: res.error ?? 'Unable to inspect mint' },
+    }))
+    return res
+  }
+
   const loadDashboard = async () => {
     setLoading(true)
     setError(null)
+    setStrategyPreview(null)
     try {
       const walletsRes = await runJuiceAction<JuiceWallet[]>('juice:list-wallets')
       if (!walletsRes.ok || !walletsRes.data) throw new Error(walletsRes.error ?? 'Could not load Juice wallets')
@@ -207,13 +260,65 @@ export function JuicePanel() {
     }
   }
 
+  const buildStrategyPreview = async () => {
+    if (!scoutingReport?.tokens.length) {
+      setError('Load a scouting report before building a strategy preview.')
+      return
+    }
+
+    setStrategyLoading(true)
+    setError(null)
+    try {
+      const sellCandidates = walletRows
+        .filter((row) => row.wallet.isActive && row.pnl && row.pnl.pnl.totalUsd >= targetPnlUsd)
+        .map((row) => ({
+          wallet: row.wallet,
+          pnl: row.pnl as JuiceWalletPnl,
+          reason: `PNL is at or above ${formatUsd(targetPnlUsd)} target`,
+        }))
+
+      const tokensToInspect = scoutingReport.tokens.slice(0, 5)
+      const inspected = await Promise.all(tokensToInspect.map(async (token) => {
+        const existing = mintDetails[token.mint]?.data
+        if (existing) return { token, details: existing, error: null as string | null }
+        const res = await inspectMint(token.mint)
+        return { token, details: res.data ?? null, error: res.error ?? null }
+      }))
+
+      const entryCandidates: StrategyPreview['entryCandidates'] = []
+      const skipped: StrategyPreview['skipped'] = []
+
+      inspected.forEach(({ token, details, error }) => {
+        if (error || !details) {
+          skipped.push({ token, reason: error ?? 'Mint details unavailable' })
+          return
+        }
+        if (details.overcrowdingLevel > maxCrowdLevel) {
+          skipped.push({ token, reason: `Crowding level ${details.overcrowdingLevel} is above max ${maxCrowdLevel}` })
+          return
+        }
+        entryCandidates.push({
+          token,
+          mintDetails: details,
+          reason: `Grade ${token.grade}, score ${token.score}/${token.maxScore}, crowding ${details.overcrowdingLevel}/${maxCrowdLevel}`,
+        })
+      })
+
+      setStrategyPreview({ sellCandidates, entryCandidates, skipped, generatedAt: Date.now() })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setStrategyLoading(false)
+    }
+  }
+
   return (
     <div className="juice-panel">
       <header className="juice-hero">
         <div>
           <div className="juice-eyebrow">Juice Market Maker</div>
           <h2>MM wallet cockpit</h2>
-          <p>Read-only view for Juice wallets, balances, PNL, and scouting reports before DAEMON enables guarded execution.</p>
+          <p>Read-only view for Juice wallets, balances, PNL, scouting reports, mint crowding, and strategy previews before DAEMON enables guarded execution.</p>
         </div>
         <div className={`juice-key-pill ${hasKey ? 'ready' : 'missing'}`}>
           {checkingKey ? 'Checking key…' : hasKey ? 'JUICE_API_KEY ready' : 'JUICE_API_KEY missing'}
@@ -284,6 +389,60 @@ export function JuicePanel() {
 
       <section className="juice-section">
         <div className="juice-section-header">
+          <h3>Strategy preview</h3>
+          <span>Read-only next-action model</span>
+        </div>
+        <div className="juice-strategy-card">
+          <div className="juice-strategy-controls">
+            <label>
+              Target PNL
+              <input type="number" value={targetPnlUsd} min={0} step={5} onChange={(event) => setTargetPnlUsd(Number(event.target.value))} />
+            </label>
+            <label>
+              Max crowd
+              <input type="number" value={maxCrowdLevel} min={0} max={10} step={1} onChange={(event) => setMaxCrowdLevel(Number(event.target.value))} />
+            </label>
+            <button className="juice-secondary-btn" onClick={buildStrategyPreview} disabled={strategyLoading || !scoutingReport}>
+              {strategyLoading ? 'Building…' : 'Build preview'}
+            </button>
+          </div>
+          <p className="juice-strategy-note">This does not execute trades. It shows which wallets look ready to exit and which scouted mints pass the current crowding filter.</p>
+          {strategyPreview && (
+            <div className="juice-preview-grid">
+              <div>
+                <h4>Sell candidates</h4>
+                {strategyPreview.sellCandidates.length === 0 ? <span className="juice-muted">None at current target.</span> : strategyPreview.sellCandidates.map((candidate) => (
+                  <div className="juice-preview-row" key={candidate.wallet.id}>
+                    <strong>{candidate.wallet.symbol ?? shortAddress(candidate.wallet.publicKey)}</strong>
+                    <span>{formatUsd(candidate.pnl.pnl.totalUsd)} · {candidate.reason}</span>
+                  </div>
+                ))}
+              </div>
+              <div>
+                <h4>Entry candidates</h4>
+                {strategyPreview.entryCandidates.length === 0 ? <span className="juice-muted">No candidates passed filters.</span> : strategyPreview.entryCandidates.map((candidate) => (
+                  <div className="juice-preview-row" key={candidate.token.mint}>
+                    <strong>{candidate.token.symbol}</strong>
+                    <span>{candidate.reason}</span>
+                  </div>
+                ))}
+              </div>
+              <div>
+                <h4>Skipped</h4>
+                {strategyPreview.skipped.length === 0 ? <span className="juice-muted">Nothing skipped.</span> : strategyPreview.skipped.map((item) => (
+                  <div className="juice-preview-row" key={item.token.mint}>
+                    <strong>{item.token.symbol}</strong>
+                    <span>{item.reason}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="juice-section">
+        <div className="juice-section-header">
           <h3>MM wallets</h3>
           <span>{walletRows.length ? `${walletRows.length} loaded` : 'No wallet data loaded'}</span>
         </div>
@@ -318,25 +477,42 @@ export function JuicePanel() {
           <span>{scoutingReport ? `${scoutingReport.tokenCount} candidates` : 'No report loaded'}</span>
         </div>
         <div className="juice-scout-grid">
-          {(scoutingReport?.tokens ?? []).slice(0, 8).map((token) => (
-            <article className="juice-scout-card" key={token.mint}>
-              <div className="juice-scout-topline">
-                <div>
-                  <strong>{token.symbol}</strong>
-                  <span>{token.name}</span>
+          {topScouts.map((token) => {
+            const detail = mintDetails[token.mint]
+            return (
+              <article className="juice-scout-card" key={token.mint}>
+                <div className="juice-scout-topline">
+                  <div>
+                    <strong>{token.symbol}</strong>
+                    <span>{token.name}</span>
+                  </div>
+                  <b>{token.grade}</b>
                 </div>
-                <b>{token.grade}</b>
-              </div>
-              <div className="juice-scout-score">{token.score}/{token.maxScore}</div>
-              <div className="juice-scout-stats">
-                <span>MC {formatUsd(token.marketCap)}</span>
-                <span>Liq {formatUsd(token.liquidity)}</span>
-                <span>1h {formatNumber(token.priceChange1hPercent, 2)}%</span>
-                <span>24h {formatNumber(token.priceChange24hPercent, 2)}%</span>
-              </div>
-              <code>{shortAddress(token.mint)}</code>
-            </article>
-          ))}
+                <div className="juice-scout-score">{token.score}/{token.maxScore}</div>
+                <div className="juice-scout-stats">
+                  <span>MC {formatUsd(token.marketCap)}</span>
+                  <span>Liq {formatUsd(token.liquidity)}</span>
+                  <span>1h {formatNumber(token.priceChange1hPercent, 2)}%</span>
+                  <span>24h {formatNumber(token.priceChange24hPercent, 2)}%</span>
+                </div>
+                <div className="juice-scout-footer">
+                  <code>{shortAddress(token.mint)}</code>
+                  <button className="juice-mini-btn" onClick={() => void inspectMint(token.mint)} disabled={detail?.loading}>
+                    {detail?.loading ? 'Inspecting…' : 'Inspect mint'}
+                  </button>
+                </div>
+                {detail?.data && (
+                  <div className="juice-mint-details">
+                    <span>MM wallets <b>{detail.data.wallets}</b></span>
+                    <span>Crowd <b>{formatNumber(detail.data.overcrowdingLevel, 2)}</b></span>
+                    <span>Position {formatUsd(detail.data.totalPositionUsd)}</span>
+                    <span>Position/Liq {formatNumber(detail.data.positionToLiquidity, 3)}</span>
+                  </div>
+                )}
+                {detail?.error && <div className="juice-card-error">{detail.error}</div>}
+              </article>
+            )
+          })}
           {!scoutingReport && <div className="juice-empty">Scouting reports will appear here after the read-only dashboard loads.</div>}
         </div>
       </section>

--- a/src/panels/JuicePanel/JuicePanel.tsx
+++ b/src/panels/JuicePanel/JuicePanel.tsx
@@ -102,6 +102,9 @@ async function runJuiceAction<T>(type: string, payload?: Record<string, unknown>
 export function JuicePanel() {
   const [hasKey, setHasKey] = useState(false)
   const [checkingKey, setCheckingKey] = useState(true)
+  const [apiKeyDraft, setApiKeyDraft] = useState('')
+  const [keySaving, setKeySaving] = useState(false)
+  const [keyMessage, setKeyMessage] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [walletRows, setWalletRows] = useState<WalletRow[]>([])
@@ -115,22 +118,67 @@ export function JuicePanel() {
     return { activeWallets, idleWallets, totalSol, totalPnlUsd }
   }, [walletRows])
 
+  const refreshKeyStatus = async () => {
+    setCheckingKey(true)
+    const keys = await daemon.claude.listKeys().catch(() => null)
+    const keyFromSecureStore = Boolean(keys?.ok && keys.data?.some((entry) => entry.key_name === 'JUICE_API_KEY'))
+    const engineKey = await runJuiceAction<boolean>('juice:has-key').catch(() => null)
+    const ready = keyFromSecureStore || Boolean(engineKey?.ok && engineKey.data)
+    setHasKey(ready)
+    setCheckingKey(false)
+    return ready
+  }
+
   useEffect(() => {
     let cancelled = false
     async function checkKey() {
-      setCheckingKey(true)
-      const keys = await daemon.claude.listKeys().catch(() => null)
-      const keyFromSecureStore = Boolean(keys?.ok && keys.data?.some((entry) => entry.key_name === 'JUICE_API_KEY'))
-      const engineKey = await runJuiceAction<boolean>('juice:has-key').catch(() => null)
-
-      if (!cancelled) {
-        setHasKey(keyFromSecureStore || Boolean(engineKey?.ok && engineKey.data))
-        setCheckingKey(false)
-      }
+      const ready = await refreshKeyStatus().catch(() => false)
+      if (!cancelled) setHasKey(ready)
     }
     void checkKey()
     return () => { cancelled = true }
   }, [])
+
+  const saveKey = async () => {
+    const trimmed = apiKeyDraft.trim()
+    if (!trimmed) {
+      setKeyMessage('Paste a Juice API key first.')
+      return
+    }
+
+    setKeySaving(true)
+    setKeyMessage(null)
+    setError(null)
+    try {
+      const res = await runJuiceAction<boolean>('juice:store-key', { apiKey: trimmed })
+      if (!res.ok) throw new Error(res.error)
+      setApiKeyDraft('')
+      setKeyMessage('Juice API key saved securely.')
+      await refreshKeyStatus()
+    } catch (err) {
+      setKeyMessage(err instanceof Error ? err.message : String(err))
+    } finally {
+      setKeySaving(false)
+    }
+  }
+
+  const deleteKey = async () => {
+    setKeySaving(true)
+    setKeyMessage(null)
+    setError(null)
+    try {
+      const res = await runJuiceAction<boolean>('juice:delete-key')
+      if (!res.ok) throw new Error(res.error)
+      setWalletRows([])
+      setScoutingReport(null)
+      setKeyMessage('Juice API key removed.')
+      await refreshKeyStatus()
+    } catch (err) {
+      setKeyMessage(err instanceof Error ? err.message : String(err))
+    } finally {
+      setKeySaving(false)
+    }
+  }
 
   const loadDashboard = async () => {
     setLoading(true)
@@ -175,6 +223,31 @@ export function JuicePanel() {
           {checkingKey ? 'Checking key…' : hasKey ? 'JUICE_API_KEY ready' : 'JUICE_API_KEY missing'}
         </div>
       </header>
+
+      <section className="juice-key-card">
+        <div>
+          <h3>API key</h3>
+          <p>Paste your Juice key once. DAEMON validates it with a read-only wallet call and stores it through the secure key service.</p>
+        </div>
+        <div className="juice-key-controls">
+          <input
+            value={apiKeyDraft}
+            onChange={(event) => setApiKeyDraft(event.target.value)}
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="Paste JUICE_API_KEY"
+            disabled={keySaving}
+          />
+          <button className="juice-secondary-btn" onClick={saveKey} disabled={keySaving || !apiKeyDraft.trim()}>
+            {keySaving ? 'Saving…' : 'Save key'}
+          </button>
+          <button className="juice-ghost-btn" onClick={deleteKey} disabled={keySaving || !hasKey}>
+            Remove
+          </button>
+        </div>
+        {keyMessage && <div className="juice-key-message">{keyMessage}</div>}
+      </section>
 
       <div className="juice-actions">
         <button className="juice-primary-btn" onClick={loadDashboard} disabled={loading || !hasKey}>

--- a/src/panels/JuicePanel/JuicePanel.tsx
+++ b/src/panels/JuicePanel/JuicePanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import type { EngineAction, EngineResult, IpcResponse } from '../../../electron/shared/types'
 import { daemon } from '../../lib/daemonBridge'
 import './JuicePanel.css'
 
@@ -59,13 +60,7 @@ type JuiceScoutingReport = {
   scannedAt: string
 }
 
-type JuiceEngineResult<T> = {
-  ok: boolean
-  action: string
-  data?: T
-  output?: string
-  error?: string
-}
+type JuiceActionType = Extract<EngineAction['type'], `juice:${string}`>
 
 type WalletRow = {
   wallet: JuiceWallet
@@ -89,8 +84,9 @@ function shortAddress(value?: string | null) {
   return `${value.slice(0, 4)}…${value.slice(-4)}`
 }
 
-async function runJuiceAction<T>(type: string, payload?: Record<string, unknown>): Promise<IpcResponse<T>> {
-  const response = await daemon.engine.run({ type, payload } as never) as IpcResponse<JuiceEngineResult<T>>
+async function runJuiceAction<T>(type: JuiceActionType, payload?: Record<string, unknown>): Promise<IpcResponse<T>> {
+  const action: EngineAction = { type, payload }
+  const response = await daemon.engine.run(action) as IpcResponse<EngineResult<T>>
   if (!response.ok) return { ok: false, error: response.error }
 
   const result = response.data

--- a/src/panels/SolanaToolbox/catalog.ts
+++ b/src/panels/SolanaToolbox/catalog.ts
@@ -218,6 +218,15 @@ export const SOLANA_INTEGRATION_CATALOG: SolanaIntegrationEntry[] = [
     skill: '/integrating-jupiter',
   },
   {
+    id: 'juice-market-maker',
+    label: 'Juice',
+    area: 'Protocols',
+    kind: 'SDK',
+    status: 'guided',
+    description: 'Market-making API for MM wallets, PNL, scouting reports, overcrowding checks, and guarded buy/sell workflows.',
+    docsUrl: 'https://github.com/juice-solana/open-juice',
+  },
+  {
     id: 'surfpool',
     label: 'Surfpool',
     area: 'Testing',
@@ -393,6 +402,15 @@ export const SOLANA_PROTOCOL_PACKS: SolanaProtocolPack[] = [
     docsUrl: 'https://dev.jup.ag/get-started',
     kickoff: 'Start with quotes, swap execution, and price endpoints before adding trigger or recurring flows.',
     installHint: 'pnpm add @solana/kit',
+  },
+  {
+    id: 'juice',
+    label: 'Juice',
+    status: 'guided',
+    skill: '/integrating-jupiter',
+    docsUrl: 'https://github.com/juice-solana/open-juice',
+    kickoff: 'Start with read-only MM wallet status, PNL, scouting reports, and overcrowding checks before enabling guarded execution.',
+    installHint: 'Configure JUICE_API_KEY in secure keys; no package install is required for the HTTP API path.',
   },
   {
     id: 'metaplex',

--- a/src/plugins/registry.tsx
+++ b/src/plugins/registry.tsx
@@ -12,83 +12,6 @@ export interface PluginManifest {
   companionPanel?: React.LazyExoticComponent<ComponentType>
 }
 
-function ImageGenIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="2" y="2" width="14" height="14" rx="2" />
-      <circle cx="6.5" cy="6.5" r="1.5" />
-      <path d="M16 12l-3.5-3.5L5 16" />
-    </svg>
-  )
-}
-
-function TweetIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M2 3h5l2 4-3 5h7l2-5-2-4h-5" />
-      <path d="M7 12l-2 4" />
-      <path d="M13 3l2-1" />
-    </svg>
-  )
-}
-
-function RemotionIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="2" y="3" width="14" height="12" rx="2" />
-      <polygon points="7,6 7,12 12,9" />
-    </svg>
-  )
-}
-
-function BrowserIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="2" y="2" width="14" height="14" rx="2" />
-      <line x1="2" y1="6" x2="16" y2="6" />
-      <circle cx="4.5" cy="4" r="0.5" fill="currentColor" />
-      <circle cx="6.5" cy="4" r="0.5" fill="currentColor" />
-      <circle cx="8.5" cy="4" r="0.5" fill="currentColor" />
-    </svg>
-  )
-}
-
-function EmailIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="2" y="3" width="14" height="12" rx="2" />
-      <path d="M2 5l7 5 7-5" />
-    </svg>
-  )
-}
-
-function TelegramIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M16 2L1 8.5l4.5 1.5M16 2L10 16l-4.5-6M16 2L5.5 10" />
-    </svg>
-  )
-}
-
-function SubscriptionsIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="3" y="4" width="12" height="10" rx="2" />
-      <line x1="3" y1="8" x2="15" y2="8" />
-      <line x1="7" y1="8" x2="7" y2="14" />
-    </svg>
-  )
-}
-
-function BriefingIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="9" cy="9" r="7" />
-      <path d="M9 5v4l3 2" />
-    </svg>
-  )
-}
-
 function DeployIcon({ size = 18 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -98,44 +21,33 @@ function DeployIcon({ size = 18 }: { size?: number }) {
   )
 }
 
-function ServicesIcon({ size = 18 }: { size?: number }) {
+function JuiceIcon({ size = 18 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M9 2v2M9 14v2M2 9h2M14 9h2" />
-      <circle cx="9" cy="9" r="3" />
-      <path d="M4.9 4.9l1.4 1.4M11.7 11.7l1.4 1.4M4.9 13.1l1.4-1.4M11.7 6.3l1.4-1.4" />
-    </svg>
-  )
-}
-
-function PumpFunIcon({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M9 2v6M6 5l3-3 3 3" />
-      <circle cx="9" cy="13" r="4" />
-      <path d="M7.5 13h3" />
+      <path d="M4 13.5c2.1-4.4 5-7.4 10-9" />
+      <path d="M5 5.5h4.5v4.5" />
+      <path d="M13 12.5h-4.5V8" />
+      <circle cx="5" cy="5.5" r="1.5" />
+      <circle cx="13" cy="12.5" r="1.5" />
     </svg>
   )
 }
 
 export const PLUGIN_REGISTRY: Record<string, PluginManifest> = {
-  // Unshipped plugins — uncomment when service/UI implementations are complete
-  // 'pumpfun': { id: 'pumpfun', name: 'PumpFun', description: 'Token launches, bonding curve trading, fee collection', mountPosition: 'right-panel-tab', icon: PumpFunIcon, component: lazy(() => import('../panels/plugins/PumpFunTool/PumpFunTool')) },
-  // 'imagegen': { id: 'imagegen', name: 'Image Gen', description: 'Generate images with AI models', mountPosition: 'right-panel-tab', icon: ImageGenIcon, component: lazy(() => import('../panels/plugins/ImageGen/ImageGen')) },
-  // 'tweet-generator': { id: 'tweet-generator', name: 'X Replies', description: 'Generate sharp replies, quotes, and threads', mountPosition: 'right-panel-tab', icon: TweetIcon, component: lazy(() => import('../panels/plugins/TweetGenerator/TweetGenerator')) },
-  // 'remotion': { id: 'remotion', name: 'Remotion', description: 'Video editor via localhost Remotion', mountPosition: 'center-panel', icon: RemotionIcon, component: lazy(() => import('../panels/plugins/Remotion/Remotion')), companionPanel: lazy(() => import('../panels/plugins/Remotion/RemotionCompanion')) },
-  // 'browser': { id: 'browser', name: 'Browser', description: 'Embedded browser view', mountPosition: 'right-panel-tab', icon: BrowserIcon, component: lazy(() => import('../panels/plugins/Browser/Browser')) },
-  // 'email' — moved to native panel (sidebar icon + center panel)
-  // 'telegram': { id: 'telegram', name: 'Telegram', description: 'Full Telegram client', mountPosition: 'right-panel-tab', icon: TelegramIcon, component: lazy(() => import('../panels/plugins/Telegram/Telegram')) },
-  // 'subscriptions': { id: 'subscriptions', name: 'Subscriptions', description: 'API subscription tracker', mountPosition: 'right-panel-tab', icon: SubscriptionsIcon, component: lazy(() => import('../panels/plugins/Subscriptions/Subscriptions')) },
-  // 'morning-briefing': { id: 'morning-briefing', name: 'Morning Briefing', description: 'Overnight report overlay', mountPosition: 'overlay', icon: BriefingIcon, component: lazy(() => import('../panels/plugins/MorningBriefing/MorningBriefing')) },
-  // 'services': { id: 'services', name: 'Services', description: 'Manage background services', mountPosition: 'right-panel-tab', icon: ServicesIcon, component: lazy(() => import('../panels/plugins/Services/Services')) },
-  'deploy': {
+  deploy: {
     id: 'deploy',
     name: 'Deploy',
     description: 'Vercel and Railway deployments',
     mountPosition: 'center-panel',
     icon: DeployIcon,
     component: lazy(() => import('../panels/plugins/Deploy/Deploy')),
+  },
+  juice: {
+    id: 'juice',
+    name: 'Juice',
+    description: 'Market-making wallets, PNL, balances, and scouting reports',
+    mountPosition: 'center-panel',
+    icon: JuiceIcon,
+    component: lazy(() => import('../panels/JuicePanel/JuicePanel')),
   },
 }


### PR DESCRIPTION
## Summary

Adds the first Juice Market Maker integration slice for DAEMON.

Included:
- Juice entry in the Integration Command Center
- Juice entry in the Solana Toolbox catalog and protocol packs
- Read-only Juice service for MM wallet, balance, PNL, mint, and scouting report data
- Juice IPC handlers
- Engine-bridge routing for Juice read-only actions and key management
- Juice cockpit panel with secure API key save/remove flow
- Read-only wallet, balance, PNL, and scouting report views

## Safety notes

This PR intentionally does **not** enable Juice buy/sell/create-wallet execution.

Live transaction flows should come later behind DAEMON confirmation, acknowledgement, rate-limit awareness, and human approval.

## Known review notes

- `electron/preload/index.ts` was not modified. The renderer uses the already-exposed `daemon.engine.run` bridge for Juice actions.
- `electron/main/index.ts` has a large diff because line endings normalized during the Juice IPC registration patch. The intended changes there are the Juice IPC import, handler registration, and Juice API CSP allowlist entry.
- `src/plugins/registry.tsx` was simplified to active shipped entries plus Juice; review this carefully before merge.

## Suggested validation

- `pnpm typecheck`
- `pnpm build`
- Confirm Juice panel appears as a center-panel plugin
- Save a valid JUICE_API_KEY
- Load read-only dashboard
- Confirm wallet list, balances, PNL, and scouting reports load without enabling transaction execution