### PR TITLE
Fix tool visibility defaults

### DIFF
--- a/electron/services/SettingsService.ts
+++ b/electron/services/SettingsService.ts
@@ -101,7 +101,7 @@ export function setOnboardingProgress(progress: OnboardingProgress): void {
   setJsonSetting('onboarding_progress', progress)
 }
 
-const DEFAULT_PINNED_TOOLS = ['git', 'browser', 'solana-toolbox', 'pro']
+const DEFAULT_PINNED_TOOLS = ['git', 'settings', 'activity']
 const PRO_PIN_MIGRATION_KEY = 'pinned_tools_pro_default_added'
 const UI_RECOVERY_KEYS = [
   'layout_center_mode',
@@ -164,10 +164,8 @@ export function getPinnedTools(): string[] {
   const pinnedTools = sanitizePinnedTools(getJsonSetting<unknown>('pinned_tools', DEFAULT_PINNED_TOOLS))
   if (getBooleanSetting(PRO_PIN_MIGRATION_KEY, false)) return pinnedTools
 
-  const migratedTools = pinnedTools.includes('pro') ? pinnedTools : [...pinnedTools, 'pro']
-  setJsonSetting('pinned_tools', migratedTools)
   setBooleanSetting(PRO_PIN_MIGRATION_KEY, true)
-  return migratedTools
+  return pinnedTools
 }
 
 export function setPinnedTools(tools: string[]): void {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,11 +153,6 @@ function App() {
     }
   }, [loadProjects, smokeMode])
 
-  // Load activity history once on mount so the activity log is populated
-  useEffect(() => {
-    useNotificationsStore.getState().loadActivity()
-  }, [])
-
   // Imperative app actions from nested components — replaces synthetic keyboard
   // events. Each requestId increments to retrigger.
   const filePaletteRequestId = useAppActions((s) => s.filePaletteRequestId)
@@ -258,8 +253,9 @@ function App() {
   }, [smokeMode])
 
   useEffect(() => {
+    if (!isToolVisible('wallet')) return
     void useWalletStore.getState().refresh(activeProjectId)
-  }, [activeProjectId])
+  }, [activeProjectId, isToolVisible])
 
   useEffect(() => {
     if (!appReady) return
@@ -267,6 +263,7 @@ function App() {
     const likelyNext = ['wallet', 'git', 'project-readiness']
     const warmSet = [...new Set([...pinnedTools, ...likelyNext])]
       .filter((toolId) => toolId !== 'browser')
+      .filter((toolId) => isToolVisible(toolId))
       .slice(0, 6)
 
     let cancelled = false
@@ -293,24 +290,37 @@ function App() {
       cancelled = true
       window.clearTimeout(timeoutId)
     }
-  }, [appReady])
+  }, [appReady, isToolVisible])
 
   // Detect Solana project when active project changes
   useEffect(() => {
+    const solanaToolsVisible = [
+      'agent-work',
+      'agent-station',
+      'project-readiness',
+      'solana-toolbox',
+      'integrations',
+      'token-launch',
+      'block-scanner',
+      'replay-engine',
+      'dashboard',
+    ].some((toolId) => isToolVisible(toolId))
+    if (!solanaToolsVisible) return
     if (activeProjectPath) {
       const store = useSolanaToolboxStore.getState()
       void store.detectProject(activeProjectPath)
       void store.loadMcps(activeProjectPath)
     }
-  }, [activeProjectPath])
+  }, [activeProjectPath, isToolVisible])
 
   // Poll unread email counts every 60 seconds
   useEffect(() => {
+    if (!isToolVisible('email')) return
     const poll = () => useEmailStore.getState().pollUnreadCounts()
     poll()
     const interval = setInterval(poll, 60_000)
     return () => clearInterval(interval)
-  }, [])
+  }, [isToolVisible])
 
   // Build command list for the palette
   const paletteCommands = useMemo(

--- a/src/components/CommandDrawer/CommandDrawer.tsx
+++ b/src/components/CommandDrawer/CommandDrawer.tsx
@@ -455,7 +455,7 @@ export function preloadToolPanel(toolId: string) {
   BUILTIN_TOOL_PRELOADERS.get(toolId)?.()
 }
 
-function getDrawerTools(toolVisibility: Record<string, boolean>): DrawerTool[] {
+function getDrawerTools(isToolVisible: (toolId: string) => boolean): DrawerTool[] {
   const tools = [...BUILTIN_TOOLS]
 
   // Add enabled plugins
@@ -477,11 +477,7 @@ function getDrawerTools(toolVisibility: Record<string, boolean>): DrawerTool[] {
   }
 
   // Filter by workspace profile visibility
-  return tools.filter((t) => {
-    if (t.id === 'settings') return true
-    if (!(t.id in toolVisibility)) return true
-    return toolVisibility[t.id]
-  })
+  return tools.filter((t) => isToolVisible(t.id))
 }
 
 // Shared MIME type for tool drag-and-drop (drawer <-> sidebar)
@@ -499,8 +495,8 @@ export function CommandDrawer() {
   const drawerRef = useRef<HTMLDivElement>(null)
 
   const plugins = usePluginStore((s) => s.plugins)
-  const toolVisibility = useWorkspaceProfileStore((s) => s.toolVisibility)
-  const rawTools = useMemo(() => getDrawerTools(toolVisibility), [plugins, toolVisibility]) // eslint-disable-line react-hooks/exhaustive-deps
+  const isToolVisible = useWorkspaceProfileStore((s) => s.isToolVisible)
+  const rawTools = useMemo(() => getDrawerTools(isToolVisible), [plugins, isToolVisible])
 
   // Apply custom ordering if set
   const allTools = useMemo(() => {

--- a/src/components/CommandPalette/commands.ts
+++ b/src/components/CommandPalette/commands.ts
@@ -72,7 +72,7 @@ export function buildCommands(deps: CommandDeps): Command[] {
       action: () => openWorkspaceTool(command.toolId),
     }))
 
-  return [
+  const commands: Command[] = [
     // Navigation
     {
       id: 'nav:file-explorer',
@@ -113,20 +113,20 @@ export function buildCommands(deps: CommandDeps): Command[] {
         setCenterMode(current === 'grind' ? 'canvas' : 'grind')
       },
     },
-    {
+    ...(isToolVisible && !isToolVisible('browser') ? [] : [{
       id: 'view:browser-tab',
       label: 'Toggle Browser Tab',
       shortcut: 'Ctrl+Shift+B',
       category: 'View',
       action: () => toggleBrowserTab?.(),
-    },
-    {
+    }]),
+    ...(isToolVisible && !isToolVisible('dashboard') ? [] : [{
       id: 'view:dashboard-tab',
       label: 'Toggle Dashboard Tab',
       shortcut: 'Ctrl+Shift+D',
       category: 'View',
       action: () => toggleDashboardTab?.(),
-    },
+    }]),
     {
       id: 'view:reload-window',
       label: 'Reload Window',
@@ -144,4 +144,6 @@ export function buildCommands(deps: CommandDeps): Command[] {
       action: () => openAgentLauncher(),
     },
   ]
+
+  return commands
 }

--- a/src/constants/toolIds.ts
+++ b/src/constants/toolIds.ts
@@ -1,5 +1,5 @@
-import { DRAWER_TOOL_IDS } from './toolRegistry'
+import { TOOL_REGISTRY } from './toolRegistry'
 
-// Canonical list of drawer-managed built-in tools.
-// Derived from the shared registry so visibility, profiles, and drawer behavior stay aligned.
-export const BUILTIN_TOOL_IDS: string[] = [...DRAWER_TOOL_IDS]
+// Canonical list of profile-managed built-in tools.
+// Includes drawer tools and tab tools so shortcuts/pins cannot bypass visibility.
+export const BUILTIN_TOOL_IDS: string[] = TOOL_REGISTRY.map((tool) => tool.id)

--- a/src/constants/toolRegistry.ts
+++ b/src/constants/toolRegistry.ts
@@ -34,6 +34,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   { id: 'plugins', name: 'Plugins', moduleClass: 'addon', surface: 'drawer' },
   { id: 'recovery', name: 'Recovery', moduleClass: 'addon', surface: 'drawer' },
   { id: 'activity', name: 'Activity', moduleClass: 'addon', surface: 'drawer' },
+  { id: 'agent-station', name: 'Agent Station', moduleClass: 'addon', surface: 'drawer' },
   { id: 'browser', name: 'Browser', moduleClass: 'addon', surface: 'tab' },
 ] as const
 

--- a/src/constants/workspaceProfiles.ts
+++ b/src/constants/workspaceProfiles.ts
@@ -10,12 +10,12 @@ export interface WorkspaceProfile {
 const WEB_TOOLS = [
   'starter', 'git', 'deploy', 'env', 'email', 'ports',
   'processes', 'settings', 'image-editor', 'docs',
-  'sessions', 'plugins', 'recovery', 'activity',
+  'sessions', 'plugins', 'recovery', 'activity', 'browser',
 ]
 
 const SOLANA_TOOLS = [
   ...WEB_TOOLS, 'wallet', 'agent-work', 'token-launch', 'project-readiness', 'solana-toolbox', 'integrations', 'block-scanner',
-  'dashboard', 'hackathon', 'pro',
+  'dashboard', 'hackathon', 'pro', 'agent-station',
 ]
 
 export const PROFILE_PRESETS: Record<WorkspaceProfileName, string[]> = {

--- a/src/hooks/useAppShortcuts.ts
+++ b/src/hooks/useAppShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect, type Dispatch, type SetStateAction } from 'react'
 import { useUIStore } from '../store/ui'
 import { useWorkflowShellStore } from '../store/workflowShell'
+import { useWorkspaceProfileStore } from '../store/workspaceProfile'
 
 interface UseAppShortcutsOptions {
   setPaletteMode: Dispatch<SetStateAction<'commands' | 'files' | null>>
@@ -46,9 +47,11 @@ export function useAppShortcuts({
         useUIStore.getState().setCenterMode(current === 'grind' ? 'canvas' : 'grind')
       } else if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'B') {
         e.preventDefault()
+        if (!useWorkspaceProfileStore.getState().isToolVisible('browser')) return
         useUIStore.getState().toggleBrowserTab()
       } else if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'D') {
         e.preventDefault()
+        if (!useWorkspaceProfileStore.getState().isToolVisible('dashboard')) return
         useUIStore.getState().toggleDashboardTab()
       } else if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'e') {
         e.preventDefault()

--- a/src/lib/toolVisibilityGuard.ts
+++ b/src/lib/toolVisibilityGuard.ts
@@ -1,0 +1,16 @@
+import { isToolDisableable } from '../constants/toolRegistry'
+
+let loaded = false
+let currentVisibility: Record<string, boolean> = {}
+
+export function setToolVisibilityGuard(visibility: Record<string, boolean>, isLoaded = true) {
+  currentVisibility = visibility
+  loaded = isLoaded
+}
+
+export function canActivateTool(toolId: string): boolean {
+  if (!isToolDisableable(toolId)) return true
+  if (!loaded) return true
+  if (!(toolId in currentVisibility)) return true
+  return currentVisibility[toolId] !== false
+}

--- a/src/panels/IconSidebar/IconSidebar.tsx
+++ b/src/panels/IconSidebar/IconSidebar.tsx
@@ -186,6 +186,7 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
       currentPinned.splice(targetIdx, 0, toolId)
     } else {
       // Drop from drawer — pin at position
+      if (!useWorkspaceProfileStore.getState().isToolVisible(toolId)) return
       currentPinned.splice(targetIdx, 0, toolId)
     }
     store.setPinnedTools(currentPinned)
@@ -211,6 +212,7 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
     if (!toolId) return
 
     const store = useUIStore.getState()
+    if (!useWorkspaceProfileStore.getState().isToolVisible(toolId)) return
     if (store.pinnedTools.includes(toolId)) return // already pinned, ignore
     store.pinTool(toolId)
   }, [])
@@ -324,9 +326,14 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
       <div className="sidebar-divider" />
       <button
         className={`colosseum-icon-wrap${activeWorkspaceToolId === 'hackathon' ? ' active' : ''}`}
-        onClick={() => useUIStore.getState().openWorkspaceTool('hackathon')}
+        onClick={() => {
+          if (useWorkspaceProfileStore.getState().isToolVisible('hackathon')) {
+            useUIStore.getState().openWorkspaceTool('hackathon')
+          }
+        }}
         title="Hackathon (Colosseum)"
         aria-label="Hackathon"
+        disabled={!isToolVisible('hackathon')}
       >
         <HackathonGlyph />
       </button>

--- a/src/panels/SettingsPanel/SettingsPanel.tsx
+++ b/src/panels/SettingsPanel/SettingsPanel.tsx
@@ -111,15 +111,15 @@ function KeysSection() {
   const [newKeyValue, setNewKeyValue] = useState('')
   const [saving, setSaving] = useState(false)
 
-  const load = useCallback((cancelled = false) => {
+  const load = useCallback((isCancelled: () => boolean = () => false) => {
     window.daemon.claude.listKeys().then((res) => {
-      if (!cancelled && res.ok && res.data) setKeys(res.data)
+      if (!isCancelled() && res.ok && res.data) setKeys(res.data)
     })
   }, [])
 
   useEffect(() => {
     let cancelled = false
-    load(cancelled)
+    load(() => cancelled)
     return () => { cancelled = true }
   }, [load])
 
@@ -190,20 +190,20 @@ function IntegrationsSection({ projectPath }: { projectPath: string | null }) {
   const [savingKey, setSavingKey] = useState(false)
   const [showApiInput, setShowApiInput] = useState(false)
 
-  const load = useCallback((cancelled = false) => {
+  const load = useCallback((isCancelled: () => boolean = () => false) => {
     if (projectPath) {
       window.daemon.claude.projectMcpAll(projectPath).then((res) => {
-        if (!cancelled && res.ok && res.data) setMcps(res.data)
+        if (!isCancelled() && res.ok && res.data) setMcps(res.data)
       })
     }
     window.daemon.claude.verifyConnection().then((res) => {
-      if (!cancelled && res.ok && res.data) setConnection(res.data)
+      if (!isCancelled() && res.ok && res.data) setConnection(res.data)
     })
   }, [projectPath])
 
   useEffect(() => {
     let cancelled = false
-    load(cancelled)
+    load(() => cancelled)
     return () => { cancelled = true }
   }, [load])
 
@@ -474,15 +474,15 @@ function CrashesSection() {
   const [crashes, setCrashes] = useState<AppCrashEntry[]>([])
   const [expandedId, setExpandedId] = useState<string | null>(null)
 
-  const load = useCallback((cancelled = false) => {
+  const load = useCallback((isCancelled: () => boolean = () => false) => {
     window.daemon.settings.getCrashes().then((res) => {
-      if (!cancelled && res.ok && res.data) setCrashes(res.data)
+      if (!isCancelled() && res.ok && res.data) setCrashes(res.data)
     })
   }, [])
 
   useEffect(() => {
     let cancelled = false
-    load(cancelled)
+    load(() => cancelled)
     return () => { cancelled = true }
   }, [load])
 

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { daemon } from '../lib/daemonBridge'
 import { updateRecord, deleteFromRecord, filterRecord, mapRecord } from './stateHelpers'
 import { useWorkflowShellStore } from './workflowShell'
+import { canActivateTool } from '../lib/toolVisibilityGuard'
 
 interface OpenFile {
   path: string
@@ -152,7 +153,7 @@ export const useUIStore = create<UIState>((set) => ({
   launchWizardOpen: false,
   walletQuickViewOpen: false,
   emailQuickViewOpen: false,
-  pinnedTools: ['git', 'browser', 'activity', 'agent-work', 'project-readiness', 'solana-toolbox', 'integrations', 'pro'],
+  pinnedTools: ['git', 'settings', 'activity'],
   drawerToolOrder: [],
 
   setActivePanel: (panel) => set({ activePanel: panel }),
@@ -250,6 +251,7 @@ export const useUIStore = create<UIState>((set) => ({
     }
   },
   toggleBrowserTab: () => set((state) => {
+    if (!canActivateTool('browser')) return {}
     const isOpen = !state.browserTabOpen
     if (!isOpen) return { browserTabOpen: false, browserTabActive: false }
     useWorkflowShellStore.getState().closeDrawer()
@@ -260,6 +262,7 @@ export const useUIStore = create<UIState>((set) => ({
     }
   }),
   openBrowserTab: () => {
+    if (!canActivateTool('browser')) return
     useWorkflowShellStore.getState().closeDrawer()
     set({
       browserTabOpen: true,
@@ -270,6 +273,7 @@ export const useUIStore = create<UIState>((set) => ({
   },
   closeBrowserTab: () => set({ browserTabOpen: false, browserTabActive: false }),
   setBrowserTabActive: (active) => {
+    if (active && !canActivateTool('browser')) return
     if (active) useWorkflowShellStore.getState().closeDrawer()
     set(active
       ? {
@@ -280,6 +284,7 @@ export const useUIStore = create<UIState>((set) => ({
       : { browserTabActive: false })
   },
   openWorkspaceTool: (toolId) => {
+    if (!canActivateTool(toolId)) return
     if (toolId === 'browser') {
       useUIStore.getState().openBrowserTab()
       return
@@ -309,6 +314,7 @@ export const useUIStore = create<UIState>((set) => ({
     }
   }),
   setActiveWorkspaceTool: (toolId) => {
+    if (toolId && !canActivateTool(toolId)) return
     if (toolId === 'browser') {
       useUIStore.getState().setBrowserTabActive(true)
       return
@@ -328,6 +334,7 @@ export const useUIStore = create<UIState>((set) => ({
   },
   setIntegrationCommandSelectionId: (integrationId) => set({ integrationCommandSelectionId: integrationId }),
   toggleWorkspaceTool: (toolId) => set((state) => {
+    if (!canActivateTool(toolId)) return {}
     if (toolId === 'browser') {
       if (state.browserTabActive) {
         useUIStore.getState().closeBrowserTab()
@@ -369,6 +376,7 @@ export const useUIStore = create<UIState>((set) => ({
     }
   },
   toggleDashboardTab: () => set((state) => {
+    if (!canActivateTool('dashboard')) return {}
     const isOpen = !state.dashboardTabOpen
     if (!isOpen) return { dashboardTabOpen: false, dashboardTabActive: false }
     useWorkflowShellStore.getState().closeDrawer()
@@ -379,6 +387,7 @@ export const useUIStore = create<UIState>((set) => ({
     }
   }),
   openDashboardTab: () => {
+    if (!canActivateTool('dashboard')) return
     useWorkflowShellStore.getState().closeDrawer()
     set({
       dashboardTabOpen: true,
@@ -389,6 +398,7 @@ export const useUIStore = create<UIState>((set) => ({
   },
   closeDashboardTab: () => set({ dashboardTabOpen: false, dashboardTabActive: false }),
   setDashboardTabActive: (active) => {
+    if (active && !canActivateTool('dashboard')) return
     if (active) useWorkflowShellStore.getState().closeDrawer()
     set(active
       ? {
@@ -506,10 +516,12 @@ export const useUIStore = create<UIState>((set) => ({
   closeAllQuickViews: () => set({ walletQuickViewOpen: false, emailQuickViewOpen: false }),
 
   setPinnedTools: (tools) => {
-    set({ pinnedTools: tools })
-    daemon.settings.setPinnedTools(tools).catch(() => {})
+    const visibleTools = tools.filter(canActivateTool)
+    set({ pinnedTools: visibleTools })
+    daemon.settings.setPinnedTools(visibleTools).catch(() => {})
   },
   pinTool: (toolId) => set((state) => {
+    if (!canActivateTool(toolId)) return {}
     const next = state.pinnedTools.includes(toolId) ? state.pinnedTools : [...state.pinnedTools, toolId]
     daemon.settings.setPinnedTools(next).catch(() => {})
     return { pinnedTools: next }

--- a/src/store/workspaceProfile.ts
+++ b/src/store/workspaceProfile.ts
@@ -6,6 +6,7 @@ import { isToolDisableable } from '../constants/toolRegistry'
 import { useUIStore } from './ui'
 import { useNotificationsStore } from './notifications'
 import { daemon } from '../lib/daemonBridge'
+import { setToolVisibilityGuard } from '../lib/toolVisibilityGuard'
 
 interface WorkspaceProfileState {
   profileName: WorkspaceProfileName
@@ -27,27 +28,34 @@ export const useWorkspaceProfileStore = create<WorkspaceProfileState>((set, get)
     try {
       const res = await daemon.settings.getWorkspaceProfile()
       if (res.ok && res.data) {
+        const toolVisibility = normalizeToolVisibility(res.data.name, res.data.toolVisibility)
         set({
           profileName: res.data.name,
-          toolVisibility: res.data.toolVisibility,
+          toolVisibility,
           loaded: true,
         })
+        setToolVisibilityGuard(toolVisibility)
       } else {
-        // No profile saved yet — default to custom (all visible)
+        const toolVisibility = getDefaultVisibility('web', BUILTIN_TOOL_IDS)
+        // No profile saved yet — default to the focused web profile.
         set({
-          profileName: 'custom',
-          toolVisibility: getDefaultVisibility('custom', BUILTIN_TOOL_IDS),
+          profileName: 'web',
+          toolVisibility,
           loaded: true,
         })
+        setToolVisibilityGuard(toolVisibility)
       }
     } catch {
-      set({ loaded: true })
+      const toolVisibility = getDefaultVisibility('web', BUILTIN_TOOL_IDS)
+      set({ profileName: 'web', toolVisibility, loaded: true })
+      setToolVisibilityGuard(toolVisibility)
     }
   },
 
   setProfile: async (name) => {
     const visibility = getDefaultVisibility(name, BUILTIN_TOOL_IDS)
     set({ profileName: name, toolVisibility: visibility })
+    setToolVisibilityGuard(visibility)
     const profile: WorkspaceProfile = { name, toolVisibility: visibility }
     await daemon.settings.setWorkspaceProfile(profile).catch(() => {})
 
@@ -56,6 +64,7 @@ export const useWorkspaceProfileStore = create<WorkspaceProfileState>((set, get)
     // filter via isToolVisible. Surface a toast so the user notices.
     const pinned = useUIStore.getState().pinnedTools
     const hidden = pinned.filter((id) => id !== 'settings' && visibility[id] === false)
+    closeHiddenWorkspaceTools(visibility)
     if (hidden.length > 0) {
       useNotificationsStore.getState().pushToast({
         kind: 'info',
@@ -71,6 +80,8 @@ export const useWorkspaceProfileStore = create<WorkspaceProfileState>((set, get)
     if (!isToolDisableable(toolId)) return
     const updated = { ...toolVisibility, [toolId]: visible }
     set({ toolVisibility: updated, profileName: 'custom' })
+    setToolVisibilityGuard(updated)
+    if (!visible) closeHiddenWorkspaceTools(updated)
     const profile: WorkspaceProfile = { name: 'custom', toolVisibility: updated }
     await daemon.settings.setWorkspaceProfile(profile).catch(() => {})
   },
@@ -84,6 +95,29 @@ export const useWorkspaceProfileStore = create<WorkspaceProfileState>((set, get)
     return toolVisibility[toolId] ?? true
   },
 }))
+
+useWorkspaceProfileStore.subscribe((state) => {
+  setToolVisibilityGuard(state.toolVisibility, state.loaded)
+})
+
+function normalizeToolVisibility(
+  profileName: WorkspaceProfileName,
+  savedVisibility: Record<string, boolean>,
+): Record<string, boolean> {
+  return {
+    ...getDefaultVisibility(profileName, BUILTIN_TOOL_IDS),
+    ...savedVisibility,
+  }
+}
+
+function closeHiddenWorkspaceTools(toolVisibility: Record<string, boolean>): void {
+  const ui = useUIStore.getState()
+  for (const toolId of ui.workspaceToolTabs) {
+    if (toolVisibility[toolId] === false) ui.closeWorkspaceTool(toolId)
+  }
+  if (toolVisibility.browser === false) ui.closeBrowserTab()
+  if (toolVisibility.dashboard === false) ui.closeDashboardTab()
+}
 
 // Derived selector for use in components
 export function selectToolVisible(toolId: string) {

--- a/test/services/SettingsService.test.ts
+++ b/test/services/SettingsService.test.ts
@@ -87,17 +87,12 @@ describe('SettingsService token launch settings', () => {
     )
   })
 
-  it('sanitizes pinned tools from storage and runs the one-time Pro pin migration', () => {
+  it('sanitizes pinned tools from storage without adding hidden default tools', () => {
     mockGet.mockReturnValue({
       value: JSON.stringify(['git', '', 'browser', 'git', 42]),
     })
 
-    expect(getPinnedTools()).toEqual(['git', 'browser', 'pro'])
-    expect(mockRun).toHaveBeenCalledWith(
-      'pinned_tools',
-      JSON.stringify(['git', 'browser', 'pro']),
-      expect.any(Number),
-    )
+    expect(getPinnedTools()).toEqual(['git', 'browser'])
     expect(mockRun).toHaveBeenCalledWith('pinned_tools_pro_default_added', 'true', expect.any(Number))
   })
 

--- a/test/shared/workspaceProfiles.test.ts
+++ b/test/shared/workspaceProfiles.test.ts
@@ -16,6 +16,7 @@ describe('getDefaultVisibility — web profile', () => {
   it('shows docs', () => expect(vis['docs']).toBe(true))
   it('shows plugins', () => expect(vis['plugins']).toBe(true))
   it('shows recovery', () => expect(vis['recovery']).toBe(true))
+  it('shows browser', () => expect(vis['browser']).toBe(true))
 
   it('hides wallet', () => expect(vis['wallet']).toBe(false))
   it('hides project-readiness', () => expect(vis['project-readiness']).toBe(false))
@@ -23,6 +24,7 @@ describe('getDefaultVisibility — web profile', () => {
   it('hides block-scanner', () => expect(vis['block-scanner']).toBe(false))
   it('hides dashboard', () => expect(vis['dashboard']).toBe(false))
   it('hides hackathon', () => expect(vis['hackathon']).toBe(false))
+  it('hides agent-station', () => expect(vis['agent-station']).toBe(false))
 })
 
 describe('getDefaultVisibility — solana profile', () => {
@@ -34,11 +36,13 @@ describe('getDefaultVisibility — solana profile', () => {
   it('shows block-scanner', () => expect(vis['block-scanner']).toBe(true))
   it('shows dashboard', () => expect(vis['dashboard']).toBe(true))
   it('shows hackathon', () => expect(vis['hackathon']).toBe(true))
+  it('shows agent-station', () => expect(vis['agent-station']).toBe(true))
   it('shows all web tools', () => {
     expect(vis['git']).toBe(true)
     expect(vis['env']).toBe(true)
     expect(vis['settings']).toBe(true)
     expect(vis['docs']).toBe(true)
+    expect(vis['browser']).toBe(true)
   })
 })
 
@@ -98,6 +102,7 @@ describe('PROFILE_PRESETS', () => {
     expect(PROFILE_PRESETS.web).toContain('git')
     expect(PROFILE_PRESETS.web).toContain('settings')
     expect(PROFILE_PRESETS.web).toContain('docs')
+    expect(PROFILE_PRESETS.web).toContain('browser')
   })
 
   it('web preset excludes solana-specific tools', () => {

--- a/test/store/workspaceProfile.test.ts
+++ b/test/store/workspaceProfile.test.ts
@@ -10,6 +10,7 @@ vi.stubGlobal('window', {
 })
 
 import { useWorkspaceProfileStore } from '../../src/store/workspaceProfile'
+import { useUIStore } from '../../src/store/ui'
 import { getDefaultVisibility } from '../../src/constants/workspaceProfiles'
 import { BUILTIN_TOOL_IDS } from '../../src/constants/toolIds'
 
@@ -28,6 +29,7 @@ describe('getDefaultVisibility — web profile', () => {
     expect(vis['env']).toBe(true)
     expect(vis['settings']).toBe(true)
     expect(vis['docs']).toBe(true)
+    expect(vis['browser']).toBe(true)
   })
 
   it('hides solana-specific tools', () => {
@@ -36,6 +38,7 @@ describe('getDefaultVisibility — web profile', () => {
     expect(vis['project-readiness']).toBe(false)
     expect(vis['solana-toolbox']).toBe(false)
     expect(vis['dashboard']).toBe(false)
+    expect(vis['agent-station']).toBe(false)
   })
 })
 
@@ -46,6 +49,7 @@ describe('getDefaultVisibility — solana profile', () => {
     expect(vis['project-readiness']).toBe(true)
     expect(vis['solana-toolbox']).toBe(true)
     expect(vis['dashboard']).toBe(true)
+    expect(vis['agent-station']).toBe(true)
   })
 
   it('shows all web tools as well', () => {
@@ -108,6 +112,25 @@ describe('useWorkspaceProfileStore — isToolVisible', () => {
     })
     expect(useWorkspaceProfileStore.getState().isToolVisible('wallet')).toBe(true)
   })
+
+  it('normalizes missing saved visibility entries from the active preset', async () => {
+    vi.mocked(window.daemon.settings.getWorkspaceProfile).mockResolvedValueOnce({
+      ok: true,
+      data: { name: 'web', toolVisibility: { git: true } },
+    })
+    await useWorkspaceProfileStore.getState().load()
+    const state = useWorkspaceProfileStore.getState()
+    expect(state.profileName).toBe('web')
+    expect(state.toolVisibility['agent-station']).toBe(false)
+  })
+
+  it('defaults first run to the web profile', async () => {
+    vi.mocked(window.daemon.settings.getWorkspaceProfile).mockResolvedValueOnce({ ok: false })
+    await useWorkspaceProfileStore.getState().load()
+    const state = useWorkspaceProfileStore.getState()
+    expect(state.profileName).toBe('web')
+    expect(state.toolVisibility['wallet']).toBe(false)
+  })
 })
 
 describe('useWorkspaceProfileStore — setToolVisible', () => {
@@ -163,6 +186,21 @@ describe('useWorkspaceProfileStore — setProfile', () => {
     // web profile hides wallet
     expect(state.toolVisibility['wallet']).toBe(false)
     expect(state.toolVisibility['git']).toBe(true)
+  })
+
+  it('closes tools hidden by a selected profile', async () => {
+    useUIStore.setState({
+      workspaceToolTabs: ['wallet', 'git'],
+      activeWorkspaceToolId: 'wallet',
+      dashboardTabOpen: true,
+      dashboardTabActive: true,
+    })
+
+    await useWorkspaceProfileStore.getState().setProfile('web')
+    const ui = useUIStore.getState()
+    expect(ui.workspaceToolTabs).toEqual(['git'])
+    expect(ui.activeWorkspaceToolId).toBe('git')
+    expect(ui.dashboardTabOpen).toBe(false)
   })
 
   it('sets all tools visible for custom profile', async () => {


### PR DESCRIPTION
## Summary
- default first-run workspace visibility to the focused web profile
- enforce tool visibility across direct activation paths, pins, shortcuts, and startup work
- add profile coverage for Agent Station and tab-managed tools
- avoid hidden-tool background work and stale Settings async updates

## Validation
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run test/store/workspaceProfile.test.ts test/shared/workspaceProfiles.test.ts test/services/SettingsService.test.ts test/ui-store-extended.test.ts test/panels/ShellChrome.dom.test.tsx --reporter=dot