### PR TITLE
fix: harden Solana wallet and launch flows

### DIFF
--- a/electron/ipc/wallet.ts
+++ b/electron/ipc/wallet.ts
@@ -74,8 +74,8 @@ export function registerWalletHandlers() {
     return await WalletService.transferToken(input.fromWalletId, input.toAddress, input.mint, input.amount, input.sendMax === true)
   }))
 
-  ipcMain.handle('wallet:swap-quote', ipcHandler(async (_event, input: { inputMint: string; outputMint: string; amount: number; slippageBps: number }) => {
-    return await WalletService.getSwapQuote(input.inputMint, input.outputMint, input.amount, input.slippageBps)
+  ipcMain.handle('wallet:swap-quote', ipcHandler(async (_event, input: { walletId: string; inputMint: string; outputMint: string; amount: number; slippageBps: number }) => {
+    return await WalletService.getSwapQuote(input.walletId, input.inputMint, input.outputMint, input.amount, input.slippageBps)
   }))
 
   ipcMain.handle('wallet:transaction-preview', ipcHandler(async (_event, input: SolanaTransactionPreviewInput) => {
@@ -106,7 +106,9 @@ export function registerWalletHandlers() {
     // H1: if the quote has high price impact, acknowledgedImpact must be true
     if (input.rawQuoteResponse != null) {
       const quote = input.rawQuoteResponse as Record<string, unknown>
-      const impactPct = parseFloat(String(quote.priceImpactPct ?? '0'))
+      const impactPct = typeof quote.priceImpact === 'number'
+        ? Math.abs(quote.priceImpact) * 100
+        : parseFloat(String(quote.priceImpactPct ?? '0'))
       if (impactPct >= 5 && input.acknowledgedImpact !== true) {
         throw new Error('High price impact must be explicitly acknowledged before executing')
       }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -253,7 +253,7 @@ contextBridge.exposeInMainWorld('daemon', {
     sendToken: (input: { fromWalletId: string; toAddress: string; mint: string; amount?: number; sendMax?: boolean }) => ipcRenderer.invoke('wallet:send-token', input),
     balance: (walletId: string) => ipcRenderer.invoke('wallet:balance', walletId),
     holdings: (walletId: string) => ipcRenderer.invoke('wallet:holdings', walletId),
-    swapQuote: (input: { inputMint: string; outputMint: string; amount: number; slippageBps: number }) => ipcRenderer.invoke('wallet:swap-quote', input),
+    swapQuote: (input: { walletId: string; inputMint: string; outputMint: string; amount: number; slippageBps: number }) => ipcRenderer.invoke('wallet:swap-quote', input),
     transactionPreview: (input: object) => ipcRenderer.invoke('wallet:transaction-preview', input),
     swapExecute: (input: { walletId: string; inputMint: string; outputMint: string; amount: number; slippageBps: number; rawQuoteResponse?: unknown; confirmedAt: number; acknowledgedImpact: boolean }) => ipcRenderer.invoke('wallet:swap-execute', input),
     agentWallets: (agentId?: string) => ipcRenderer.invoke('wallet:agent-wallets', agentId),

--- a/electron/services/PumpFunService.ts
+++ b/electron/services/PumpFunService.ts
@@ -13,6 +13,12 @@ import { executeInstructions, getConnectionStrict, withKeypair, loadKeypair } fr
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
 
+const PUMPFUN_METADATA_ENDPOINT = 'https://pump.fun/api/ipfs'
+const METADATA_UPLOAD_TIMEOUT_MS = 30_000
+const METADATA_UPLOAD_MAX_ATTEMPTS = 3
+const METADATA_UPLOAD_RETRY_BASE_MS = 250
+const PUMPFUN_CREATE_BUY_COMPUTE_UNITS = 500_000
+
 let _sdk: typeof import('@nirholas/pump-sdk') | null = null
 function getSdk() {
   if (!_sdk) _sdk = require('@nirholas/pump-sdk') as typeof import('@nirholas/pump-sdk')
@@ -60,6 +66,72 @@ export interface TokenCreateResult extends TxResult {
   metadataUri: string
   bondingCurveAddress: string
   associatedBondingCurveAddress: string | null
+}
+
+function buildMetadataFormData(input: TokenCreateInput): FormData {
+  const formData = new FormData()
+  formData.append('name', input.name)
+  formData.append('symbol', input.symbol)
+  formData.append('description', input.description)
+  formData.append('showName', 'true')
+
+  if (input.imagePath) {
+    const imageBuffer = fs.readFileSync(input.imagePath)
+    const ext = input.imagePath.split('.').pop()?.toLowerCase() ?? 'png'
+    const mimeType = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' : ext === 'gif' ? 'image/gif' : 'image/png'
+    const blob = new Blob([imageBuffer], { type: mimeType })
+    formData.append('file', blob, `token.${ext}`)
+  }
+
+  return formData
+}
+
+function isRetryableMetadataStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function uploadPumpFunMetadata(input: TokenCreateInput): Promise<{ metadataUri: string }> {
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= METADATA_UPLOAD_MAX_ATTEMPTS; attempt++) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), METADATA_UPLOAD_TIMEOUT_MS)
+    try {
+      const metaRes = await fetch(PUMPFUN_METADATA_ENDPOINT, {
+        method: 'POST',
+        body: buildMetadataFormData(input),
+        signal: controller.signal,
+      })
+      if (metaRes.ok) {
+        const json = await metaRes.json() as { metadataUri?: string }
+        if (!json.metadataUri) throw new Error('Token metadata upload did not return a metadataUri')
+        return { metadataUri: json.metadataUri }
+      }
+
+      const body = await metaRes.text().catch(() => '')
+      const message = `Failed to upload token metadata (${metaRes.status})${body ? `: ${body}` : ''}`
+      lastError = new Error(message)
+      if (!isRetryableMetadataStatus(metaRes.status) || attempt === METADATA_UPLOAD_MAX_ATTEMPTS) {
+        throw lastError
+      }
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') {
+        throw new Error('Token metadata upload timed out after 30s')
+      }
+      lastError = e
+      if (attempt === METADATA_UPLOAD_MAX_ATTEMPTS) throw e
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    await sleep(METADATA_UPLOAD_RETRY_BASE_MS * Math.pow(2, attempt - 1))
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Failed to upload token metadata')
 }
 
 export async function getBondingCurveState(mint: string): Promise<BondingCurveInfo> {
@@ -111,35 +183,7 @@ export async function createToken(input: TokenCreateInput): Promise<TokenCreateR
   const onlineSdk = new sdk.OnlinePumpSdk(connection)
   const pumpSdk = new sdk.PumpSdk()
 
-  // Upload metadata to IPFS via pump.fun API
-  const formData = new FormData()
-  formData.append('name', input.name)
-  formData.append('symbol', input.symbol)
-  formData.append('description', input.description)
-  formData.append('showName', 'true')
-
-  if (input.imagePath) {
-    const imageBuffer = fs.readFileSync(input.imagePath)
-    const ext = input.imagePath.split('.').pop()?.toLowerCase() ?? 'png'
-    const mimeType = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' : ext === 'gif' ? 'image/gif' : 'image/png'
-    const blob = new Blob([imageBuffer], { type: mimeType })
-    formData.append('file', blob, `token.${ext}`)
-  }
-
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), 30_000)
-  let metaJson: { metadataUri: string }
-  try {
-    const metaRes = await fetch('https://pump.fun/api/ipfs', { method: 'POST', body: formData, signal: controller.signal })
-    if (!metaRes.ok) throw new Error('Failed to upload token metadata')
-    metaJson = await metaRes.json() as { metadataUri: string }
-  } catch (e) {
-    throw e instanceof Error && e.name === 'AbortError'
-      ? new Error('Token metadata upload timed out after 30s')
-      : e
-  } finally {
-    clearTimeout(timeoutId)
-  }
+  const metaJson = await uploadPumpFunMetadata(input)
 
   const mintKeypair = Keypair.generate()
   const bondingCurve = sdk.bondingCurvePda(mintKeypair.publicKey)
@@ -167,9 +211,21 @@ export async function createToken(input: TokenCreateInput): Promise<TokenCreateR
     mayhemMode: input.mayhemMode,
   })
 
-  const { signature } = await executeInstructions(connection, instructions, [keypair, mintKeypair], {
-    payer: keypair.publicKey,
-  })
+  let signature: string
+  try {
+    const result = await executeInstructions(connection, instructions, [keypair, mintKeypair], {
+      payer: keypair.publicKey,
+      computeUnitLimit: PUMPFUN_CREATE_BUY_COMPUTE_UNITS,
+    })
+    signature = result.signature
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    throw new Error(
+      `Pump.fun create+buy failed for mint ${mintKeypair.publicKey.toBase58()}: ${reason}. ` +
+      'The create and initial buy are submitted together; if this failed after broadcast or confirmation timed out, verify the mint on-chain before retrying.'
+    )
+  }
+
   return {
     signature,
     success: true,

--- a/electron/services/RecoveryService.ts
+++ b/electron/services/RecoveryService.ts
@@ -51,14 +51,14 @@ function isAborted(): boolean {
   return abortController?.signal.aborted ?? false
 }
 
-async function getPriorityFee(conn: Connection): Promise<number> {
+async function getPriorityFee(conn: Connection, accountKeys: PublicKey[] = [TOKEN_PROGRAM_ID]): Promise<number> {
   try {
     const res = await fetch(conn.rpcEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         jsonrpc: '2.0', id: 1, method: 'getPriorityFeeEstimate',
-        params: [{ accountKeys: [TOKEN_PROGRAM_ID.toBase58()], options: { priorityLevel: 'High' } }],
+        params: [{ accountKeys: accountKeys.map((key) => key.toBase58()), options: { priorityLevel: 'High' } }],
       }),
     })
     const data = await res.json() as { result?: { priorityFeeEstimate: number } }
@@ -222,7 +222,7 @@ export async function executeRecovery(
     walletCount: loadedPubkeys.length, completed: 0, failed: 0,
   }
 
-  const priorityFee = await getPriorityFee(conn)
+  const tokenPriorityFee = await getPriorityFee(conn, [TOKEN_PROGRAM_ID, TOKEN_2022_ID])
 
   try {
   // ─── Phase 1: Close empty token accounts ──────────────────────────────
@@ -295,7 +295,7 @@ export async function executeRecovery(
             recentBlockhash: blockhash,
             instructions: [
               ComputeBudgetProgram.setComputeUnitLimit({ units: 80_000 }),
-              ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFee }),
+              ComputeBudgetProgram.setComputeUnitPrice({ microLamports: tokenPriorityFee }),
               burnIx, closeIx,
             ],
           }).compileToV0Message()
@@ -333,7 +333,7 @@ export async function executeRecovery(
             recentBlockhash: blockhash,
             instructions: [
               ComputeBudgetProgram.setComputeUnitLimit({ units: 20_000 * batch.length }),
-              ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFee }),
+              ComputeBudgetProgram.setComputeUnitPrice({ microLamports: tokenPriorityFee }),
               ...closeIxs,
             ],
           }).compileToV0Message()
@@ -378,13 +378,14 @@ export async function executeRecovery(
 
       emit(win, { type: 'wallet-start', walletIndex: wi, pubkey: pub })
 
+      const solPriorityFee = await getPriorityFee(conn, [kp.publicKey])
       const { blockhash } = await conn.getLatestBlockhash('finalized')
       const msg = new TransactionMessage({
         payerKey: masterPubkey,
         recentBlockhash: blockhash,
         instructions: [
           ComputeBudgetProgram.setComputeUnitLimit({ units: 20_000 }),
-          ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFee }),
+          ComputeBudgetProgram.setComputeUnitPrice({ microLamports: solPriorityFee }),
           SystemProgram.transfer({
             fromPubkey: kp.publicKey,
             toPubkey: masterPubkey,

--- a/electron/services/SolanaService.ts
+++ b/electron/services/SolanaService.ts
@@ -1,7 +1,8 @@
-import { Connection, Keypair, Transaction, TransactionMessage, VersionedTransaction, type SendOptions, type TransactionInstruction, type PublicKey } from '@solana/web3.js'
+import { ComputeBudgetProgram, Connection, Keypair, SystemProgram, Transaction, TransactionMessage, VersionedTransaction, type SendOptions, type TransactionInstruction, type PublicKey } from '@solana/web3.js'
 import * as SecureKey from './SecureKeyService'
 import { getDb } from '../db/db'
 import { getWalletInfrastructureSettings } from './SettingsService'
+import { LogService } from './LogService'
 import bs58 from 'bs58'
 import fs from 'node:fs'
 
@@ -9,6 +10,21 @@ import fs from 'node:fs'
  * Shared Solana utilities used by WalletService and PumpFunService.
  * Centralizes RPC connection creation and keypair lifecycle management.
  */
+
+const PUBLIC_RPC_ENDPOINT = 'https://api.mainnet-beta.solana.com'
+const DEFAULT_COMPUTE_UNIT_LIMIT = 200_000
+const DEFAULT_COMPUTE_UNIT_PRICE_MICRO_LAMPORTS = 100_000
+const PRIORITY_FEE_CACHE_MS = 30_000
+const COMPUTE_BUDGET_SET_UNIT_LIMIT = 2
+const COMPUTE_BUDGET_SET_UNIT_PRICE = 3
+
+interface BlockheightConfirmationStrategy {
+  blockhash: string
+  lastValidBlockHeight: number
+}
+
+let publicRpcFallbackWarned = false
+let priorityFeeCache: { endpoint: string; value: number; expiresAt: number } | null = null
 
 export function getHeliusApiKey(): string | null {
   return SecureKey.getKey('HELIUS_API_KEY') ?? process.env.HELIUS_API_KEY ?? null
@@ -20,19 +36,26 @@ export function getJupiterApiKey(): string | null {
 
 export function getRpcEndpoint(): string {
   const settings = getWalletInfrastructureSettings()
-  if (settings.rpcProvider === 'quicknode' && settings.quicknodeRpcUrl) {
-    return settings.quicknodeRpcUrl
+  if (settings.rpcProvider === 'quicknode') {
+    if (settings.quicknodeRpcUrl) return settings.quicknodeRpcUrl
+    warnPublicRpcFallback('QuickNode RPC is selected but no QuickNode endpoint is configured.')
   }
-  if (settings.rpcProvider === 'custom' && settings.customRpcUrl) {
-    return settings.customRpcUrl
+  if (settings.rpcProvider === 'custom') {
+    if (settings.customRpcUrl) return settings.customRpcUrl
+    warnPublicRpcFallback('Custom RPC is selected but no custom endpoint is configured.')
   }
 
   if (settings.rpcProvider === 'helius') {
     const key = getHeliusApiKey()
     if (key) return `https://mainnet.helius-rpc.com/?api-key=${key}`
+    warnPublicRpcFallback('Helius RPC is selected but HELIUS_API_KEY is not configured.')
   }
 
-  return 'https://api.mainnet-beta.solana.com'
+  if (settings.rpcProvider === 'public') {
+    warnPublicRpcFallback('Public Solana RPC is selected.')
+  }
+
+  return PUBLIC_RPC_ENDPOINT
 }
 
 export function getConnection(): Connection {
@@ -53,11 +76,119 @@ export function getTransactionSubmissionSettings() {
   }
 }
 
-export type TransactionTransport = ReturnType<typeof getTransactionSubmissionSettings>['mode']
+export type TransactionTransport = ReturnType<typeof getTransactionSubmissionSettings>['mode'] | 'jupiter'
 
 export interface TransactionExecutionResult {
   signature: string
   transport: TransactionTransport
+}
+
+function warnPublicRpcFallback(reason: string): void {
+  if (publicRpcFallbackWarned) return
+  publicRpcFallbackWarned = true
+  const message = 'Using public Solana mainnet RPC fallback. Public RPC is aggressively rate limited; configure Helius, QuickNode, or a custom RPC for wallet execution.'
+  LogService.warn('SolanaService', message, { reason, endpoint: PUBLIC_RPC_ENDPOINT })
+}
+
+function getComputeBudgetOpcode(ix: TransactionInstruction): number | null {
+  if (!ix.programId.equals(ComputeBudgetProgram.programId)) return null
+  return ix.data[0] ?? null
+}
+
+function getDefaultComputeUnitLimit(instructions: TransactionInstruction[]): number {
+  const nonBudgetInstructions = instructions.filter((ix) => !ix.programId.equals(ComputeBudgetProgram.programId))
+  if (
+    nonBudgetInstructions.length === 1
+    && nonBudgetInstructions[0].programId.equals(SystemProgram.programId)
+  ) {
+    return 20_000
+  }
+  if (nonBudgetInstructions.length <= 2) return 120_000
+  return Math.min(1_000_000, Math.max(DEFAULT_COMPUTE_UNIT_LIMIT, nonBudgetInstructions.length * 80_000))
+}
+
+export async function getPriorityFeeMicroLamports(connection: Connection): Promise<number> {
+  const now = Date.now()
+  if (priorityFeeCache?.endpoint === connection.rpcEndpoint && priorityFeeCache.expiresAt > now) {
+    return priorityFeeCache.value
+  }
+
+  let value = DEFAULT_COMPUTE_UNIT_PRICE_MICRO_LAMPORTS
+  try {
+    const response = await fetch(connection.rpcEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'getPriorityFeeEstimate',
+        params: [{
+          accountKeys: [SystemProgram.programId.toBase58()],
+          options: { priorityLevel: 'High' },
+        }],
+      }),
+    })
+    const data = await response.json().catch(() => null) as { result?: { priorityFeeEstimate?: number } } | null
+    const estimate = data?.result?.priorityFeeEstimate
+    if (typeof estimate === 'number' && Number.isFinite(estimate) && estimate > 0) {
+      value = Math.max(estimate, 10_000)
+    }
+  } catch {
+    try {
+      const recentFees = await connection.getRecentPrioritizationFees()
+      const fees = recentFees
+        .map((entry) => entry.prioritizationFee)
+        .filter((fee) => Number.isFinite(fee) && fee > 0)
+        .sort((a, b) => a - b)
+      if (fees.length > 0) {
+        value = Math.max(fees[Math.floor(fees.length * 0.75)], 10_000)
+      }
+    } catch {
+      value = DEFAULT_COMPUTE_UNIT_PRICE_MICRO_LAMPORTS
+    }
+  }
+
+  priorityFeeCache = {
+    endpoint: connection.rpcEndpoint,
+    value,
+    expiresAt: now + PRIORITY_FEE_CACHE_MS,
+  }
+  return value
+}
+
+export async function getPriorityFeeLamports(connection: Connection, computeUnitLimit = DEFAULT_COMPUTE_UNIT_LIMIT): Promise<number> {
+  const microLamports = await getPriorityFeeMicroLamports(connection)
+  return Math.ceil((computeUnitLimit * microLamports) / 1_000_000)
+}
+
+async function withComputeBudgetInstructions(
+  connection: Connection,
+  instructions: TransactionInstruction[],
+  options?: {
+    addComputeBudget?: boolean
+    computeUnitLimit?: number
+    computeUnitPriceMicroLamports?: number
+  },
+): Promise<TransactionInstruction[]> {
+  if (options?.addComputeBudget === false) return instructions
+
+  const hasUnitLimit = instructions.some((ix) => getComputeBudgetOpcode(ix) === COMPUTE_BUDGET_SET_UNIT_LIMIT)
+  const hasUnitPrice = instructions.some((ix) => getComputeBudgetOpcode(ix) === COMPUTE_BUDGET_SET_UNIT_PRICE)
+  if (hasUnitLimit && hasUnitPrice) return instructions
+
+  const budgetInstructions: TransactionInstruction[] = []
+  if (!hasUnitLimit) {
+    budgetInstructions.push(ComputeBudgetProgram.setComputeUnitLimit({
+      units: options?.computeUnitLimit ?? getDefaultComputeUnitLimit(instructions),
+    }))
+  }
+  if (!hasUnitPrice) {
+    budgetInstructions.push(ComputeBudgetProgram.setComputeUnitPrice({
+      microLamports: options?.computeUnitPriceMicroLamports ?? await getPriorityFeeMicroLamports(connection),
+    }))
+  }
+
+  return [...budgetInstructions, ...instructions]
 }
 
 export async function submitRawTransaction(
@@ -96,17 +227,26 @@ export async function submitRawTransaction(
   return payload.result
 }
 
-export async function confirmSignature(connection: Connection, signature: string, timeoutMs = 60_000): Promise<void> {
+export async function confirmSignature(
+  connection: Connection,
+  signature: string,
+  timeoutMs = 60_000,
+  confirmationStrategy?: BlockheightConfirmationStrategy,
+): Promise<void> {
+  const strategy = confirmationStrategy ?? await connection.getLatestBlockhash('confirmed')
   let timer: ReturnType<typeof setTimeout> | undefined
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error('Transaction confirmation timed out (60s). It may still confirm — check Solscan.')), timeoutMs)
+    timer = setTimeout(() => reject(new Error(`Transaction confirmation timed out (${Math.round(timeoutMs / 1000)}s). It may still confirm - check Solscan.`)), timeoutMs)
   })
 
   try {
-    await Promise.race([
-      connection.confirmTransaction(signature, 'confirmed'),
+    const result = await Promise.race([
+      connection.confirmTransaction({ signature, ...strategy }, 'confirmed'),
       timeoutPromise,
     ])
+    if (result.value.err) {
+      throw new Error(`Transaction failed: ${JSON.stringify(result.value.err)}`)
+    }
   } finally {
     if (timer) clearTimeout(timer)
   }
@@ -120,19 +260,37 @@ export async function executeTransaction(
     timeoutMs?: number
     feePayer?: PublicKey
     sendOptions?: SendOptions
+    addComputeBudget?: boolean
+    computeUnitLimit?: number
+    computeUnitPriceMicroLamports?: number
+    confirmationStrategy?: BlockheightConfirmationStrategy
   },
 ): Promise<TransactionExecutionResult> {
   const { mode } = getTransactionSubmissionSettings()
+  let confirmationStrategy = options?.confirmationStrategy
 
   if (transaction instanceof Transaction) {
     const latest = await connection.getLatestBlockhash('confirmed')
+    transaction.instructions = await withComputeBudgetInstructions(connection, transaction.instructions, options)
     transaction.feePayer = options?.feePayer ?? transaction.feePayer ?? signers[0]?.publicKey
     transaction.recentBlockhash = latest.blockhash
+    confirmationStrategy = latest
     if (signers.length > 0) {
       transaction.sign(...signers)
     }
   } else if (signers.length > 0) {
+    const latest = await connection.getLatestBlockhash('confirmed')
+    confirmationStrategy ??= {
+      blockhash: transaction.message.recentBlockhash,
+      lastValidBlockHeight: latest.lastValidBlockHeight,
+    }
     transaction.sign(signers)
+  } else {
+    const latest = await connection.getLatestBlockhash('confirmed')
+    confirmationStrategy ??= {
+      blockhash: transaction.message.recentBlockhash,
+      lastValidBlockHeight: latest.lastValidBlockHeight,
+    }
   }
 
   const signature = await submitRawTransaction(connection, transaction.serialize(), {
@@ -140,7 +298,7 @@ export async function executeTransaction(
     maxRetries: mode === 'jito' ? 0 : 3,
     ...options?.sendOptions,
   })
-  await confirmSignature(connection, signature, options?.timeoutMs)
+  await confirmSignature(connection, signature, options?.timeoutMs, confirmationStrategy)
 
   return {
     signature,
@@ -155,6 +313,9 @@ export async function executeInstructions(
   options?: {
     timeoutMs?: number
     payer?: PublicKey
+    addComputeBudget?: boolean
+    computeUnitLimit?: number
+    computeUnitPriceMicroLamports?: number
   },
 ): Promise<TransactionExecutionResult> {
   if (instructions.length === 0) {
@@ -166,16 +327,19 @@ export async function executeInstructions(
     throw new Error('A fee payer is required to execute instructions')
   }
 
-  const { blockhash } = await connection.getLatestBlockhash('confirmed')
+  const latest = await connection.getLatestBlockhash('confirmed')
+  const budgetedInstructions = await withComputeBudgetInstructions(connection, instructions, options)
   const message = new TransactionMessage({
     payerKey: payer,
-    recentBlockhash: blockhash,
-    instructions,
+    recentBlockhash: latest.blockhash,
+    instructions: budgetedInstructions,
   }).compileToV0Message()
 
   return executeTransaction(connection, new VersionedTransaction(message), signers, {
     timeoutMs: options?.timeoutMs,
     feePayer: payer,
+    addComputeBudget: false,
+    confirmationStrategy: latest,
   })
 }
 

--- a/electron/services/WalletService.ts
+++ b/electron/services/WalletService.ts
@@ -1,10 +1,10 @@
 import * as SecureKey from './SecureKeyService'
 import { getDb } from '../db/db'
 import { API_ENDPOINTS, RETRY_CONFIG } from '../config/constants'
-import { Keypair, Connection, PublicKey, Transaction, SystemProgram, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import { Keypair, Connection, PublicKey, Transaction, SystemProgram, LAMPORTS_PER_SOL, type ParsedAccountData } from '@solana/web3.js'
 import { getAssociatedTokenAddress, createTransferInstruction, createAssociatedTokenAccountInstruction, getAccount } from '@solana/spl-token'
 import bs58 from 'bs58'
-import { executeTransaction, getConnection, getHeliusApiKey, getJupiterApiKey, getTransactionSubmissionSettings, withKeypair, type TransactionExecutionResult } from './SolanaService'
+import { executeTransaction, getConnection, getHeliusApiKey, getJupiterApiKey, getPriorityFeeLamports, withKeypair, type TransactionExecutionResult } from './SolanaService'
 
 async function fetchWithRetry(url: string, retries = RETRY_CONFIG.MAX_RETRIES): Promise<Response> {
   for (let attempt = 0; attempt < retries; attempt++) {
@@ -52,6 +52,42 @@ interface HeliusBalancesResponse {
   pagination?: { page: number; limit: number; hasMore: boolean }
 }
 
+interface HeliusDasAsset {
+  id?: string
+  content?: {
+    metadata?: {
+      name?: string
+      symbol?: string
+    }
+    links?: {
+      image?: string
+    }
+  }
+  token_info?: {
+    symbol?: string
+    balance?: number | string
+    decimals?: number
+    price_info?: {
+      price_per_token?: number
+      total_price?: number
+    }
+  }
+}
+
+interface HeliusDasResponse {
+  result?: {
+    items?: HeliusDasAsset[]
+    nativeBalance?: {
+      lamports?: number
+      price_per_sol?: number
+      total_price?: number
+    }
+  }
+  error?: {
+    message?: string
+  }
+}
+
 interface HeliusHistoryEvent {
   signature: string
   timestamp?: number
@@ -88,6 +124,11 @@ interface PortfolioFeedEntry {
 
 const lastWalletTotals = new Map<string, number>()
 const exportCooldowns = new Map<string, number>()
+const SOL_MINT = 'So11111111111111111111111111111111111111112'
+const BASE_SIGNATURE_FEE_LAMPORTS = 5_000
+const SOL_TRANSFER_COMPUTE_UNITS = 20_000
+const TOKEN_TRANSFER_COMPUTE_UNITS = 80_000
+const TOKEN_TRANSFER_WITH_ATA_COMPUTE_UNITS = 140_000
 
 // In-memory balance cache with 30-second TTL
 const balanceCache = new Map<string, { data: HeliusBalancesResponse; timestamp: number }>()
@@ -354,7 +395,7 @@ export async function storeJupiterKey(value: string) {
   const trimmed = value.trim()
   if (!trimmed) throw new Error('Jupiter API key is required')
 
-  const res = await fetch('https://api.jup.ag/swap/v1/program-id-to-label', {
+  const res = await fetch('https://api.jup.ag/tokens/v2/search?query=SOL', {
     headers: { 'x-api-key': trimmed },
   })
   if (!res.ok) throw new Error('Invalid Jupiter API key — connection failed')
@@ -396,6 +437,86 @@ async function getWalletBalances(address: string, apiKey: string): Promise<Heliu
     return cached.data
   }
 
+  const data = await getWalletBalancesViaDas(address, apiKey).catch(() => getWalletBalancesViaEnhancedApi(address, apiKey))
+  balanceCache.set(address, { data, timestamp: Date.now() })
+  return data
+}
+
+async function getWalletBalancesViaDas(address: string, apiKey: string): Promise<HeliusBalancesResponse> {
+  const response = await fetch(`https://mainnet.helius-rpc.com/?api-key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getAssetsByOwner',
+      params: {
+        ownerAddress: address,
+        page: 1,
+        limit: 1000,
+        displayOptions: {
+          showFungible: true,
+          showNativeBalance: true,
+          showZeroBalance: false,
+        },
+      },
+    }),
+  })
+
+  if (!response.ok) throw new Error(`DAS balances failed (${response.status})`)
+  const payload = await response.json() as HeliusDasResponse
+  if (payload.error) throw new Error(payload.error.message ?? 'DAS balances failed')
+
+  const result = payload.result
+  if (!result) throw new Error('DAS balances response missing result')
+
+  const balances: HeliusBalance[] = []
+  const nativeLamports = result.nativeBalance?.lamports ?? 0
+  if (nativeLamports > 0) {
+    const solAmount = nativeLamports / LAMPORTS_PER_SOL
+    const solPrice = result.nativeBalance?.price_per_sol ?? lastSolPrice
+    balances.push({
+      mint: SOL_MINT,
+      balance: solAmount,
+      decimals: LAMPORTS_DECIMALS,
+      symbol: 'SOL',
+      name: 'Solana',
+      pricePerToken: solPrice,
+      usdValue: result.nativeBalance?.total_price ?? solAmount * solPrice,
+      logoUri: undefined,
+    })
+  }
+
+  for (const asset of result.items ?? []) {
+    const tokenInfo = asset.token_info
+    if (!asset.id || !tokenInfo) continue
+
+    const decimals = Number.isInteger(tokenInfo.decimals) ? tokenInfo.decimals as number : 0
+    const rawBalance = parseNumericTokenBalance(tokenInfo.balance)
+    if (rawBalance <= 0) continue
+
+    const balance = rawBalance / Math.pow(10, decimals)
+    if (balance <= 0) continue
+
+    balances.push({
+      mint: asset.id,
+      balance,
+      decimals,
+      symbol: normalizeTokenLabel(tokenInfo.symbol) ?? normalizeTokenLabel(asset.content?.metadata?.symbol),
+      name: normalizeTokenLabel(asset.content?.metadata?.name),
+      pricePerToken: tokenInfo.price_info?.price_per_token ?? 0,
+      usdValue: tokenInfo.price_info?.total_price ?? 0,
+      logoUri: asset.content?.links?.image,
+    })
+  }
+
+  return {
+    balances,
+    totalUsdValue: balances.reduce((sum, balance) => sum + (balance.usdValue ?? 0), 0),
+  }
+}
+
+async function getWalletBalancesViaEnhancedApi(address: string, apiKey: string): Promise<HeliusBalancesResponse> {
   const url = new URL(`${API_ENDPOINTS.HELIUS_BASE}/wallet/${address}/balances`)
   url.searchParams.set('api-key', apiKey)
   url.searchParams.set('showNative', 'true')
@@ -413,9 +534,9 @@ async function getWalletBalances(address: string, apiKey: string): Promise<Heliu
     const solPrice = lastSolPrice
     raw.balances = [
       {
-        mint: 'So11111111111111111111111111111111111111112',
+        mint: SOL_MINT,
         balance: solAmount,
-        decimals: 9,
+        decimals: LAMPORTS_DECIMALS,
         symbol: 'SOL',
         name: 'Solana',
         pricePerToken: solPrice,
@@ -426,8 +547,21 @@ async function getWalletBalances(address: string, apiKey: string): Promise<Heliu
     ]
   }
 
-  balanceCache.set(address, { data: raw, timestamp: Date.now() })
   return raw
+}
+
+function parseNumericTokenBalance(value: number | string | undefined): number {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+function normalizeTokenLabel(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed || undefined
 }
 
 async function getWalletHistory(address: string, apiKey: string): Promise<HeliusHistoryEvent[]> {
@@ -534,6 +668,45 @@ function isValidSolanaAddress(value: string): boolean {
   try { new PublicKey(value); return true } catch { return false }
 }
 
+interface ParsedMintAccount {
+  type: 'mint'
+  info: {
+    decimals: number
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isParsedMintAccount(value: unknown): value is ParsedMintAccount {
+  if (!isRecord(value) || value.type !== 'mint' || !isRecord(value.info)) return false
+  return Number.isInteger(value.info.decimals)
+}
+
+function readTokenMintDecimals(accountInfo: Awaited<ReturnType<Connection['getParsedAccountInfo']>>['value']): number {
+  if (!accountInfo) throw new Error('Token mint account not found')
+
+  const data = accountInfo.data
+  if (Buffer.isBuffer(data) || !isRecord(data) || !('parsed' in data)) {
+    throw new Error('Token mint account is not parsed token metadata')
+  }
+
+  const parsedData = data as ParsedAccountData
+  if (parsedData.program !== 'spl-token' && parsedData.program !== 'spl-token-2022') {
+    throw new Error('Account is not an SPL Token mint')
+  }
+  if (!isParsedMintAccount(parsedData.parsed)) {
+    throw new Error('Account is not an SPL Token mint')
+  }
+
+  const decimals = parsedData.parsed.info.decimals
+  if (decimals < 0 || decimals > 255) {
+    throw new Error('Token mint decimals are invalid')
+  }
+  return decimals
+}
+
 function toRawTokenAmount(amount: number, decimals: number): bigint {
   if (!Number.isFinite(amount) || amount <= 0) {
     throw new Error('Amount must be greater than 0')
@@ -597,7 +770,8 @@ export async function transferSOL(
     const fromAddress = keypair.publicKey.toBase58()
 
     const balance = await connection.getBalance(keypair.publicKey)
-    const feeBufferLamports = 10_000
+    const priorityFeeLamports = await getPriorityFeeLamports(connection, SOL_TRANSFER_COMPUTE_UNITS)
+    const feeBufferLamports = Math.max(10_000, BASE_SIGNATURE_FEE_LAMPORTS + priorityFeeLamports)
     const lamportsToSend = sendMax
       ? Math.max(0, balance - feeBufferLamports)
       : Math.round((amountSol ?? 0) * LAMPORTS_PER_SOL)
@@ -634,7 +808,9 @@ export async function transferSOL(
         })
       )
 
-      const { signature, transport } = await executeTransaction(connection, transaction, [keypair])
+      const { signature, transport } = await executeTransaction(connection, transaction, [keypair], {
+        computeUnitLimit: SOL_TRANSFER_COMPUTE_UNITS,
+      })
 
       db.prepare('UPDATE transaction_history SET signature = ?, status = ? WHERE id = ?').run(signature, 'confirmed', txId)
       return { id: txId, signature, status: 'confirmed', transport }
@@ -671,7 +847,7 @@ export async function transferToken(
     // Fetch the source token account balance and validate before building the transaction.
     const fromAta = await getAssociatedTokenAddress(mintPubkey, keypair.publicKey)
     const mintInfo = await connection.getParsedAccountInfo(mintPubkey)
-    const decimals = (mintInfo.value?.data as any)?.parsed?.info?.decimals ?? 9
+    const decimals = readTokenMintDecimals(mintInfo.value)
     let rawAmount: bigint
     let amountToRecord: number
     try {
@@ -705,10 +881,12 @@ export async function transferToken(
 
       const transaction = new Transaction()
 
+      let needsDestinationAta = false
       // Create destination ATA if it doesn't exist
       try {
         await getAccount(connection, toAta)
       } catch {
+        needsDestinationAta = true
         transaction.add(
           createAssociatedTokenAccountInstruction(
             keypair.publicKey,
@@ -728,7 +906,9 @@ export async function transferToken(
         )
       )
 
-      const { signature, transport } = await executeTransaction(connection, transaction, [keypair])
+      const { signature, transport } = await executeTransaction(connection, transaction, [keypair], {
+        computeUnitLimit: needsDestinationAta ? TOKEN_TRANSFER_WITH_ATA_COMPUTE_UNITS : TOKEN_TRANSFER_COMPUTE_UNITS,
+      })
 
       db.prepare('UPDATE transaction_history SET signature = ?, status = ? WHERE id = ?').run(signature, 'confirmed', txId)
       return { id: txId, signature, status: 'confirmed', transport }
@@ -744,17 +924,46 @@ export async function transferToken(
 // Jupiter Swap Integration
 // ---------------------------------------------------------------------------
 
-const JUPITER_QUOTE_API = 'https://api.jup.ag/swap/v1/quote'
-const JUPITER_SWAP_API = 'https://api.jup.ag/swap/v1/swap'
+const JUPITER_SWAP_ORDER_API = 'https://api.jup.ag/swap/v2/order'
+const JUPITER_SWAP_EXECUTE_API = 'https://api.jup.ag/swap/v2/execute'
 const LAMPORTS_DECIMALS = 9
 
-interface JupiterQuoteResponse {
+interface JupiterRoutePlanItem {
+  swapInfo?: {
+    label?: string
+    ammKey?: string
+    inputMint?: string
+    outputMint?: string
+    inAmount?: string
+    outAmount?: string
+  }
+  percent?: number
+  bps?: number
+  usdValue?: number
+}
+
+interface JupiterSwapOrderResponse {
   inputMint: string
   outputMint: string
   inAmount: string
   outAmount: string
-  priceImpactPct: string
-  routePlan: Array<{ swapInfo: { label: string; ammKey: string }; percent: number }>
+  priceImpact?: number
+  priceImpactPct?: string
+  routePlan: JupiterRoutePlanItem[]
+  transaction: string
+  requestId: string
+  lastValidBlockHeight?: string
+  taker?: string | null
+  errorCode?: number
+  errorMessage?: string
+  error?: string
+}
+
+interface JupiterSwapExecuteResponse {
+  status: 'Success' | 'Failed'
+  signature?: string
+  error?: string
+  code?: number
 }
 
 interface SwapQuoteResult {
@@ -769,7 +978,146 @@ interface SwapQuoteResult {
 
 export type { TransactionExecutionResult } from './SolanaService'
 
+function getWalletAddressOrThrow(walletId: string): string {
+  const db = getDb()
+  const row = db.prepare('SELECT address FROM wallets WHERE id = ?').get(walletId) as { address: string } | undefined
+  if (!row) throw new Error('Wallet not found')
+  if (!isValidSolanaAddress(row.address)) throw new Error('Wallet address is invalid')
+  return row.address
+}
+
+function parseJupiterSwapOrder(value: unknown): JupiterSwapOrderResponse {
+  if (!isRecord(value)) throw new Error('Jupiter order response is not an object')
+
+  const inputMint = value.inputMint
+  const outputMint = value.outputMint
+  const inAmount = value.inAmount
+  const outAmount = value.outAmount
+  const transaction = value.transaction
+  const requestId = value.requestId
+
+  if (typeof inputMint !== 'string' || !isValidSolanaAddress(inputMint)) {
+    throw new Error('Jupiter order has an invalid input mint')
+  }
+  if (typeof outputMint !== 'string' || !isValidSolanaAddress(outputMint)) {
+    throw new Error('Jupiter order has an invalid output mint')
+  }
+  if (typeof inAmount !== 'string' || !/^\d+$/.test(inAmount) || BigInt(inAmount) <= 0n) {
+    throw new Error('Jupiter order has an invalid input amount')
+  }
+  if (typeof outAmount !== 'string' || !/^\d+$/.test(outAmount) || BigInt(outAmount) <= 0n) {
+    throw new Error('Jupiter order has an invalid output amount')
+  }
+  if (typeof transaction !== 'string' || !isValidBase64Payload(transaction)) {
+    const detail = typeof value.errorMessage === 'string' ? `: ${value.errorMessage}` : ''
+    throw new Error(`Jupiter order did not include an executable transaction${detail}`)
+  }
+  if (typeof requestId !== 'string' || requestId.length === 0) {
+    throw new Error('Jupiter order is missing requestId')
+  }
+  if (value.priceImpact !== undefined && typeof value.priceImpact !== 'number') {
+    throw new Error('Jupiter order has an invalid price impact')
+  }
+  if (value.priceImpactPct !== undefined && typeof value.priceImpactPct !== 'string') {
+    throw new Error('Jupiter order has an invalid price impact percentage')
+  }
+  if (!Array.isArray(value.routePlan)) {
+    throw new Error('Jupiter order has an invalid route plan')
+  }
+  for (const route of value.routePlan) {
+    if (!isRecord(route)) throw new Error('Jupiter order has an invalid route plan')
+    if (route.swapInfo !== undefined && !isRecord(route.swapInfo)) {
+      throw new Error('Jupiter order has an invalid route plan')
+    }
+    if (route.percent !== undefined && typeof route.percent !== 'number') {
+      throw new Error('Jupiter order has an invalid route plan')
+    }
+    if (route.bps !== undefined && typeof route.bps !== 'number') {
+      throw new Error('Jupiter order has an invalid route plan')
+    }
+  }
+  if (value.lastValidBlockHeight !== undefined && typeof value.lastValidBlockHeight !== 'string') {
+    throw new Error('Jupiter order has an invalid lastValidBlockHeight')
+  }
+  if (value.taker !== undefined && value.taker !== null && typeof value.taker !== 'string') {
+    throw new Error('Jupiter order has an invalid taker')
+  }
+
+  return {
+    inputMint,
+    outputMint,
+    inAmount,
+    outAmount,
+    priceImpact: value.priceImpact,
+    priceImpactPct: value.priceImpactPct,
+    routePlan: value.routePlan as JupiterRoutePlanItem[],
+    transaction,
+    requestId,
+    lastValidBlockHeight: value.lastValidBlockHeight,
+    taker: value.taker,
+    errorCode: typeof value.errorCode === 'number' ? value.errorCode : undefined,
+    errorMessage: typeof value.errorMessage === 'string' ? value.errorMessage : undefined,
+    error: typeof value.error === 'string' ? value.error : undefined,
+  }
+}
+
+function isValidBase64Payload(value: string): boolean {
+  if (value.length === 0) return false
+  try {
+    const decoded = Buffer.from(value, 'base64')
+    if (decoded.length === 0) return false
+    return decoded.toString('base64').replace(/=+$/, '') === value.replace(/=+$/, '')
+  } catch {
+    return false
+  }
+}
+
+function normalizeJupiterPriceImpactPct(order: JupiterSwapOrderResponse): string {
+  if (order.priceImpactPct !== undefined) return order.priceImpactPct
+  if (order.priceImpact !== undefined) return String(Math.abs(order.priceImpact) * 100)
+  return '0'
+}
+
+function normalizeJupiterRoutePlan(routePlan: JupiterRoutePlanItem[]): Array<{ label: string; percent: number }> {
+  return routePlan.map((route) => ({
+    label: route.swapInfo?.label ?? 'Unknown',
+    percent: typeof route.percent === 'number'
+      ? route.percent
+      : typeof route.bps === 'number'
+        ? route.bps / 100
+        : 0,
+  }))
+}
+
+async function requestJupiterSwapOrder(
+  inputMint: string,
+  outputMint: string,
+  rawAmount: bigint,
+  slippageBps: number,
+  taker: string,
+  jupiterApiKey: string,
+): Promise<JupiterSwapOrderResponse> {
+  const url = new URL(JUPITER_SWAP_ORDER_API)
+  url.searchParams.set('inputMint', inputMint)
+  url.searchParams.set('outputMint', outputMint)
+  url.searchParams.set('amount', rawAmount.toString())
+  url.searchParams.set('taker', taker)
+  url.searchParams.set('swapMode', 'ExactIn')
+  url.searchParams.set('slippageBps', String(slippageBps))
+
+  const response = await fetch(url.toString(), {
+    headers: { 'x-api-key': jupiterApiKey },
+  })
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Jupiter order failed (${response.status}): ${body}`)
+  }
+
+  return parseJupiterSwapOrder(await response.json())
+}
+
 export async function getSwapQuote(
+  walletId: string,
   inputMint: string,
   outputMint: string,
   amount: number,
@@ -783,25 +1131,12 @@ export async function getSwapQuote(
   const jupiterApiKey = getJupiterApiKey()
   if (!jupiterApiKey) throw new Error('JUPITER_API_KEY not configured. Add it in Wallet settings to enable swaps.')
 
+  const taker = getWalletAddressOrThrow(walletId)
+
   // Resolve decimals for the input mint to convert human amount to raw
   const decimals = await getMintDecimals(inputMint)
   const rawAmount = BigInt(Math.round(amount * Math.pow(10, decimals)))
-
-  const url = new URL(JUPITER_QUOTE_API)
-  url.searchParams.set('inputMint', inputMint)
-  url.searchParams.set('outputMint', outputMint)
-  url.searchParams.set('amount', rawAmount.toString())
-  url.searchParams.set('slippageBps', String(slippageBps))
-
-  const response = await fetch(url.toString(), {
-    headers: { 'x-api-key': jupiterApiKey },
-  })
-  if (!response.ok) {
-    const body = await response.text()
-    throw new Error(`Jupiter quote failed (${response.status}): ${body}`)
-  }
-
-  const data = await response.json() as JupiterQuoteResponse
+  const data = await requestJupiterSwapOrder(inputMint, outputMint, rawAmount, slippageBps, taker, jupiterApiKey)
 
   // Convert raw amounts to human-readable
   const outputDecimals = await getMintDecimals(outputMint)
@@ -813,13 +1148,10 @@ export async function getSwapQuote(
     outputMint: data.outputMint,
     inAmount: humanInAmount,
     outAmount: humanOutAmount,
-    priceImpactPct: data.priceImpactPct,
-    routePlan: (data.routePlan ?? []).map((r) => ({
-      label: r.swapInfo?.label ?? 'Unknown',
-      percent: r.percent,
-    })),
+    priceImpactPct: normalizeJupiterPriceImpactPct(data),
+    routePlan: normalizeJupiterRoutePlan(data.routePlan),
     // The raw Jupiter response is passed back to executeSwap so it can use the
-    // exact quote the user reviewed rather than fetching at a potentially different price.
+    // exact executable order the user reviewed rather than fetching at a different price.
     rawQuoteResponse: data,
   }
 }
@@ -847,8 +1179,7 @@ export async function executeSwap(
 
     // Balance check: verify the wallet holds enough of the input token before
     // building the transaction. This prevents sending a doomed tx to the network.
-    const decimals = await getMintDecimals(inputMint)
-    const SOL_MINT = 'So11111111111111111111111111111111111111112'
+    const decimals = await getMintDecimals(inputMint, connection)
     if (inputMint === SOL_MINT) {
       const lamports = await connection.getBalance(keypair.publicKey)
       const requiredLamports = Math.round(amount * Math.pow(10, decimals)) + 10_000 // fee buffer
@@ -874,76 +1205,44 @@ export async function executeSwap(
       }
     }
 
-    // Use the quote the user reviewed when provided. Fall back to fetching a fresh
-    // quote only if no rawQuoteResponse was supplied (e.g. programmatic calls).
-    let quoteData: unknown
+    // Use the executable order the user reviewed when provided. Fall back to
+    // fetching a fresh order only if no rawQuoteResponse was supplied.
+    let orderData: JupiterSwapOrderResponse
+    const rawRequested = BigInt(Math.round(amount * Math.pow(10, decimals)))
     if (rawQuoteResponse) {
-      // H2: validate that the quote matches the parameters the user approved
-      const q = rawQuoteResponse as Record<string, unknown>
-
-      if (typeof q.inputMint !== 'string' || q.inputMint !== inputMint) {
-        throw new Error(`Quote inputMint mismatch: expected ${inputMint}, got ${String(q.inputMint)}`)
+      const q = parseJupiterSwapOrder(rawQuoteResponse)
+      if (q.inputMint !== inputMint) {
+        throw new Error(`Jupiter order inputMint mismatch: expected ${inputMint}, got ${q.inputMint}`)
       }
-      if (typeof q.outputMint !== 'string' || q.outputMint !== outputMint) {
-        throw new Error(`Quote outputMint mismatch: expected ${outputMint}, got ${String(q.outputMint)}`)
+      if (q.outputMint !== outputMint) {
+        throw new Error(`Jupiter order outputMint mismatch: expected ${outputMint}, got ${q.outputMint}`)
+      }
+      if (q.taker && q.taker !== userPublicKey) {
+        throw new Error(`Jupiter order taker mismatch: expected ${userPublicKey}, got ${q.taker}`)
       }
 
       // inAmount in the raw Jupiter quote is in lamports/raw units — compare against
       // the raw amount derived from the same decimals used when the quote was fetched.
-      const rawRequested = Math.round(amount * Math.pow(10, decimals))
-      const quoteInAmount = parseInt(String(q.inAmount ?? '0'), 10)
-      if (isNaN(quoteInAmount) || quoteInAmount <= 0) {
-        throw new Error('Quote inAmount is invalid')
-      }
-      const drift = Math.abs(quoteInAmount - rawRequested) / rawRequested
-      if (drift > 0.01) {
+      const quoteInAmount = BigInt(q.inAmount)
+      const driftRaw = quoteInAmount > rawRequested ? quoteInAmount - rawRequested : rawRequested - quoteInAmount
+      if (driftRaw * 100n > rawRequested) {
         throw new Error(
           `Quote inAmount ${quoteInAmount} deviates more than 1% from requested ${rawRequested}`
         )
       }
 
-      quoteData = rawQuoteResponse
+      orderData = q
     } else {
-      const rawAmount = BigInt(Math.round(amount * Math.pow(10, decimals)))
-      const quoteUrl = new URL(JUPITER_QUOTE_API)
-      quoteUrl.searchParams.set('inputMint', inputMint)
-      quoteUrl.searchParams.set('outputMint', outputMint)
-      quoteUrl.searchParams.set('amount', rawAmount.toString())
-      quoteUrl.searchParams.set('slippageBps', String(slippageBps))
-
-      const quoteRes = await fetch(quoteUrl.toString(), {
-        headers: { 'x-api-key': jupiterApiKey },
-      })
-      if (!quoteRes.ok) throw new Error(`Jupiter quote failed: ${quoteRes.status}`)
-      quoteData = await quoteRes.json()
+      orderData = await requestJupiterSwapOrder(inputMint, outputMint, rawRequested, slippageBps, userPublicKey, jupiterApiKey)
     }
 
-    // Get the swap transaction from Jupiter
-    const swapRes = await fetch(JUPITER_SWAP_API, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': jupiterApiKey,
-      },
-      body: JSON.stringify({
-        quoteResponse: quoteData,
-        userPublicKey,
-        wrapAndUnwrapSol: true,
-      }),
-    })
-
-    if (!swapRes.ok) {
-      const body = await swapRes.text()
-      throw new Error(`Jupiter swap failed (${swapRes.status}): ${body}`)
-    }
-
-    const { swapTransaction } = await swapRes.json() as { swapTransaction: string }
-
-    // Deserialize, sign, and send the versioned transaction
+    // Deserialize and sign Jupiter's assembled V2 order transaction, then hand it
+    // back to Jupiter's managed execution endpoint for landing.
     const { VersionedTransaction: VTx } = await import('@solana/web3.js')
-    const txBuf = Buffer.from(swapTransaction, 'base64')
+    const txBuf = Buffer.from(orderData.transaction, 'base64')
     const transaction = VTx.deserialize(txBuf)
     transaction.sign([keypair])
+    const signedTransaction = Buffer.from(transaction.serialize()).toString('base64')
 
     const txId = crypto.randomUUID()
     db.prepare(
@@ -951,10 +1250,32 @@ export async function executeSwap(
     ).run(txId, walletId, 'swap', userPublicKey, '', amount, `${inputMint}→${outputMint}`, 'pending', Date.now())
 
     try {
-      const { signature, transport } = await executeTransaction(connection, transaction, [])
+      const executeRes = await fetch(JUPITER_SWAP_EXECUTE_API, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': jupiterApiKey,
+        },
+        body: JSON.stringify({
+          signedTransaction,
+          requestId: orderData.requestId,
+          lastValidBlockHeight: orderData.lastValidBlockHeight,
+        }),
+      })
 
-      db.prepare('UPDATE transaction_history SET signature = ?, status = ? WHERE id = ?').run(signature, 'confirmed', txId)
-      return { signature, transport }
+      if (!executeRes.ok) {
+        const body = await executeRes.text()
+        throw new Error(`Jupiter execute failed (${executeRes.status}): ${body}`)
+      }
+
+      const executeData = await executeRes.json() as JupiterSwapExecuteResponse
+      if (executeData.status !== 'Success' || !executeData.signature) {
+        const detail = executeData.error ?? `code ${String(executeData.code ?? 'unknown')}`
+        throw new Error(`Jupiter execute failed: ${detail}`)
+      }
+
+      db.prepare('UPDATE transaction_history SET signature = ?, status = ? WHERE id = ?').run(executeData.signature, 'confirmed', txId)
+      return { signature: executeData.signature, transport: 'jupiter' }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err)
       db.prepare('UPDATE transaction_history SET status = ?, error = ? WHERE id = ?').run('failed', errorMsg, txId)
@@ -963,18 +1284,13 @@ export async function executeSwap(
   })
 }
 
-async function getMintDecimals(mint: string): Promise<number> {
+async function getMintDecimals(mint: string, connection = getConnection()): Promise<number> {
   // SOL native mint
-  if (mint === 'So11111111111111111111111111111111111111112') return LAMPORTS_DECIMALS
+  if (mint === SOL_MINT) return LAMPORTS_DECIMALS
 
-  try {
-    const connection = getConnection()
-    const mintPubkey = new PublicKey(mint)
-    const mintInfo = await connection.getParsedAccountInfo(mintPubkey)
-    return (mintInfo.value?.data as any)?.parsed?.info?.decimals ?? 9
-  } catch {
-    return 9
-  }
+  const mintPubkey = new PublicKey(mint)
+  const mintInfo = await connection.getParsedAccountInfo(mintPubkey)
+  return readTokenMintDecimals(mintInfo.value)
 }
 
 export async function getBalance(walletId: string) {

--- a/electron/services/token-launch/adapters/MeteoraDbcLaunchAdapter.ts
+++ b/electron/services/token-launch/adapters/MeteoraDbcLaunchAdapter.ts
@@ -12,7 +12,7 @@ const DEFAULT_BASE_SUPPLY = '1000000000000000'
 interface MeteoraDeps {
   env?: NodeJS.ProcessEnv
   settings?: MeteoraLaunchpadConfig
-  loadSdk?: () => unknown
+  loadSdk?: () => unknown | Promise<unknown>
   uploadMetadata?: typeof uploadTokenMetadata
 }
 
@@ -50,8 +50,32 @@ function resolveConfig(env: NodeJS.ProcessEnv, settings?: MeteoraLaunchpadConfig
   }
 }
 
-function defaultLoadSdk() {
-  return require('@meteora-ag/dynamic-bonding-curve-sdk') as Record<string, unknown>
+async function importOptionalSdk(packageName: string): Promise<unknown> {
+  const dynamicImport = new Function('specifier', 'return import(specifier)') as (specifier: string) => Promise<unknown>
+  return dynamicImport(packageName)
+}
+
+async function defaultLoadSdk() {
+  try {
+    return require('@meteora-ag/dynamic-bonding-curve-sdk') as Record<string, unknown>
+  } catch (requireError) {
+    try {
+      return await importOptionalSdk('@meteora-ag/dynamic-bonding-curve-sdk') as Record<string, unknown>
+    } catch (importError) {
+      const requireMessage = requireError instanceof Error ? requireError.message : String(requireError)
+      const importMessage = importError instanceof Error ? importError.message : String(importError)
+      throw new Error(`Unable to load Meteora DBC SDK. require() failed: ${requireMessage}. dynamic import failed: ${importMessage}`)
+    }
+  }
+}
+
+async function assertOnChainAccount(
+  connection: ReturnType<typeof getConnectionStrict>,
+  key: PublicKey,
+  label: string,
+): Promise<void> {
+  const accountInfo = await connection.getAccountInfo(key)
+  if (!accountInfo) throw new Error(`${label} ${key.toBase58()} was not found on-chain`)
 }
 
 export function createMeteoraDbcLaunchAdapter(deps: MeteoraDeps = {}): TokenLaunchAdapter {
@@ -159,18 +183,23 @@ export function createMeteoraDbcLaunchAdapter(deps: MeteoraDeps = {}): TokenLaun
 
       return withKeypair(input.walletId, async (keypair) => {
         const connection = getConnectionStrict()
+        const mintKeypair = Keypair.generate()
+        const quoteMint = new PublicKey(config.quoteMint)
+        const configKey = new PublicKey(config.configId)
+        const baseAmount = new BN(config.baseSupply)
+        await Promise.all([
+          assertOnChainAccount(connection, configKey, 'Meteora DBC config'),
+          assertOnChainAccount(connection, quoteMint, 'Meteora quote mint'),
+        ])
+
         const metadata = await uploadMetadata(input)
-        const sdk = loadSdk() as Record<string, any>
+        const sdk = await loadSdk() as Record<string, any>
         const DynamicBondingCurve = sdk.DynamicBondingCurve ?? sdk.default?.DynamicBondingCurve
         if (!DynamicBondingCurve) {
           throw new Error('Installed Meteora DBC SDK does not expose DynamicBondingCurve')
         }
 
         const dbc = new DynamicBondingCurve(connection, 'confirmed')
-        const mintKeypair = Keypair.generate()
-        const quoteMint = new PublicKey(config.quoteMint)
-        const configKey = new PublicKey(config.configId)
-        const baseAmount = new BN(config.baseSupply)
 
         const createResult = await dbc.createPool({
           creator: keypair.publicKey,

--- a/electron/services/token-launch/adapters/RaydiumLaunchLabAdapter.ts
+++ b/electron/services/token-launch/adapters/RaydiumLaunchLabAdapter.ts
@@ -11,7 +11,7 @@ const DEFAULT_SOL_MINT = 'So11111111111111111111111111111111111111112'
 interface RaydiumDeps {
   env?: NodeJS.ProcessEnv
   settings?: RaydiumLaunchpadConfig
-  loadSdk?: () => unknown
+  loadSdk?: () => unknown | Promise<unknown>
   uploadMetadata?: typeof uploadTokenMetadata
 }
 
@@ -48,8 +48,32 @@ function resolveConfig(env: NodeJS.ProcessEnv, settings?: RaydiumLaunchpadConfig
   }
 }
 
-function defaultLoadSdk() {
-  return require('@raydium-io/raydium-sdk-v2') as Record<string, unknown>
+async function importOptionalSdk(packageName: string): Promise<unknown> {
+  const dynamicImport = new Function('specifier', 'return import(specifier)') as (specifier: string) => Promise<unknown>
+  return dynamicImport(packageName)
+}
+
+async function defaultLoadSdk() {
+  try {
+    return require('@raydium-io/raydium-sdk-v2') as Record<string, unknown>
+  } catch (requireError) {
+    try {
+      return await importOptionalSdk('@raydium-io/raydium-sdk-v2') as Record<string, unknown>
+    } catch (importError) {
+      const requireMessage = requireError instanceof Error ? requireError.message : String(requireError)
+      const importMessage = importError instanceof Error ? importError.message : String(importError)
+      throw new Error(`Unable to load Raydium SDK. require() failed: ${requireMessage}. dynamic import failed: ${importMessage}`)
+    }
+  }
+}
+
+async function assertOnChainAccount(
+  connection: ReturnType<typeof getConnectionStrict>,
+  key: PublicKey,
+  label: string,
+): Promise<void> {
+  const accountInfo = await connection.getAccountInfo(key)
+  if (!accountInfo) throw new Error(`${label} ${key.toBase58()} was not found on-chain`)
 }
 
 export function createRaydiumLaunchLabAdapter(deps: RaydiumDeps = {}): TokenLaunchAdapter {
@@ -144,11 +168,16 @@ export function createRaydiumLaunchLabAdapter(deps: RaydiumDeps = {}): TokenLaun
 
       return withKeypair(input.walletId, async (keypair) => {
         const connection = getConnectionStrict()
-        const metadata = await uploadMetadata(input)
-        const sdk = loadSdk() as Record<string, any>
         const mintKeypair = Keypair.generate()
         const quoteMint = new PublicKey(config.quoteMint)
         const configId = new PublicKey(config.configId)
+        await Promise.all([
+          assertOnChainAccount(connection, configId, 'Raydium LaunchLab config'),
+          assertOnChainAccount(connection, quoteMint, 'Raydium quote mint'),
+        ])
+
+        const metadata = await uploadMetadata(input)
+        const sdk = await loadSdk() as Record<string, any>
 
         const raydium = sdk.Raydium?.load
           ? await sdk.Raydium.load({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "main": "dist-electron/main/index.js",
   "description": "Custom Electron IDE for AI-native development",
   "author": "nullxnothing",

--- a/src/components/QuickView/WalletQuickView.tsx
+++ b/src/components/QuickView/WalletQuickView.tsx
@@ -312,6 +312,7 @@ function SwapView({ walletId, holdings, onBack, executionLabel, signerLabel }: {
     setQuoteLoading(true)
     try {
       const res = await window.daemon.wallet.swapQuote({
+        walletId,
         inputMint,
         outputMint,
         amount: parsedAmount,

--- a/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
+++ b/src/panels/IntegrationCommandCenter/IntegrationCommandCenter.tsx
@@ -1621,6 +1621,7 @@ export function IntegrationCommandCenter() {
 
     try {
       const quoteRes = await daemon.wallet.swapQuote({
+        walletId: defaultWallet.id,
         inputMint: SOL_MINT,
         outputMint: USDC_MINT,
         amount: 0.1,

--- a/src/panels/WalletPanel/WalletSwapForm.tsx
+++ b/src/panels/WalletPanel/WalletSwapForm.tsx
@@ -109,6 +109,7 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
     setQuoteLoading(true)
     try {
       const res = await window.daemon.wallet.swapQuote({
+        walletId,
         inputMint,
         outputMint,
         amount: parsedAmount,
@@ -461,7 +462,7 @@ export function WalletSwapForm({ walletId, walletName, holdings, executionMode, 
         {swapError && <div className="wallet-empty">{swapError}</div>}
         {swapResult && (
           <div className="wallet-success-msg">
-            Swap confirmed via {swapResult.transport === 'jito' ? 'Jito' : 'RPC'}! Sig: {swapResult.signature.slice(0, 8)}...{swapResult.signature.slice(-8)}
+            Swap confirmed via {swapResult.transport === 'jupiter' ? 'Jupiter' : swapResult.transport === 'jito' ? 'Jito' : 'RPC'}! Sig: {swapResult.signature.slice(0, 8)}...{swapResult.signature.slice(-8)}
           </div>
         )}
       </div>

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -235,7 +235,7 @@ declare global {
 
   type WalletExecutionResult = {
     signature: string
-    transport: 'rpc' | 'jito'
+    transport: 'rpc' | 'jito' | 'jupiter'
   }
 
   type SolanaTransactionPreviewInput = import('../../electron/shared/types').SolanaTransactionPreviewInput
@@ -462,7 +462,7 @@ declare global {
     sendToken: (input: { fromWalletId: string; toAddress: string; mint: string; amount?: number; sendMax?: boolean }) => Promise<IpcResponse<WalletExecutionResult>>
     balance: (walletId: string) => Promise<IpcResponse<{ sol: number; lamports: number }>>
     holdings: (walletId: string) => Promise<IpcResponse<Array<{ mint: string; symbol: string; name: string; amount: number; priceUsd: number; valueUsd: number; logoUri: string | null }>>>
-    swapQuote: (input: { inputMint: string; outputMint: string; amount: number; slippageBps: number }) => Promise<IpcResponse<{ inputMint: string; outputMint: string; inAmount: string; outAmount: string; priceImpactPct: string; routePlan: Array<{ label: string; percent: number }>; rawQuoteResponse: unknown }>>
+    swapQuote: (input: { walletId: string; inputMint: string; outputMint: string; amount: number; slippageBps: number }) => Promise<IpcResponse<{ inputMint: string; outputMint: string; inAmount: string; outAmount: string; priceImpactPct: string; routePlan: Array<{ label: string; percent: number }>; rawQuoteResponse: unknown }>>
     transactionPreview: (input: SolanaTransactionPreviewInput) => Promise<IpcResponse<SolanaTransactionPreview>>
     swapExecute: (input: { walletId: string; inputMint: string; outputMint: string; amount: number; slippageBps: number; rawQuoteResponse?: unknown; confirmedAt: number; acknowledgedImpact: boolean }) => Promise<IpcResponse<WalletExecutionResult>>
     agentWallets: (agentId?: string) => Promise<IpcResponse<Array<{ id: string; name: string; address: string; is_default: number; agent_id: string; wallet_type: string; created_at: number; assigned_project_ids: string[] }>>>

--- a/test/panels/AppSurfaces.dom.test.tsx
+++ b/test/panels/AppSurfaces.dom.test.tsx
@@ -450,6 +450,7 @@ describe('App surface DOM coverage', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Preview Jupiter quote' }))
     expect(await screen.findByText('Jupiter quote ready')).toBeInTheDocument()
     expect(window.daemon.wallet.swapQuote).toHaveBeenCalledWith({
+      walletId: 'wallet-1',
       inputMint: 'So11111111111111111111111111111111111111112',
       outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
       amount: 0.1,

--- a/test/services/MeteoraDbcLaunchAdapter.test.ts
+++ b/test/services/MeteoraDbcLaunchAdapter.test.ts
@@ -163,4 +163,41 @@ describe('MeteoraDbcLaunchAdapter', () => {
     expect(result.signature).toBe('meteora-sig-123')
     expect(result.poolAddress).toContain('meteora-pool')
   })
+
+  it('blocks direct launch when the configured DBC config is not on-chain', async () => {
+    const getAccountInfo = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ lamports: 1 })
+    getConnectionStrictMock.mockReturnValue({
+      getLatestBlockhash: vi.fn(),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getAccountInfo,
+    })
+    const uploadMetadata = vi.fn(async () => ({ metadataUri: 'https://meta.example/meteora.json' }))
+    const loadSdk = vi.fn(() => ({}))
+
+    const adapter = createMeteoraDbcLaunchAdapter({
+      env: {
+        METEORA_DBC_CONFIG: '11111111111111111111111111111111',
+      } as NodeJS.ProcessEnv,
+      loadSdk,
+      uploadMetadata,
+    })
+
+    await expect(adapter.createLaunch({
+      launchpad: 'meteora',
+      walletId: 'wallet-1',
+      name: 'Meteora Token',
+      symbol: 'METX',
+      description: 'DBC token',
+      imagePath: null,
+      initialBuySol: 0.2,
+      slippageBps: 900,
+      priorityFeeSol: 0.005,
+    })).rejects.toThrow(/DBC config .*not found on-chain/i)
+
+    expect(uploadMetadata).not.toHaveBeenCalled()
+    expect(loadSdk).not.toHaveBeenCalled()
+  })
 })

--- a/test/services/PumpFunService.test.ts
+++ b/test/services/PumpFunService.test.ts
@@ -6,6 +6,9 @@ const {
   mockFetchGlobal,
   mockFetchBondingCurve,
   mockFetchFeeConfig,
+  mockCreateV2AndBuyInstructions,
+  mockExecuteInstructions,
+  mockKeypairGenerate,
   mockFetch,
 } = vi.hoisted(() => ({
   mockWithKeypair: vi.fn(),
@@ -13,6 +16,9 @@ const {
   mockFetchGlobal: vi.fn(),
   mockFetchBondingCurve: vi.fn(),
   mockFetchFeeConfig: vi.fn(),
+  mockCreateV2AndBuyInstructions: vi.fn(),
+  mockExecuteInstructions: vi.fn(),
+  mockKeypairGenerate: vi.fn(),
   mockFetch: vi.fn(),
 }))
 
@@ -24,9 +30,11 @@ const mockSdkModule = vi.hoisted(() => ({
     buyInstructions: vi.fn(),
     sellInstructions: vi.fn(),
   })),
-  PumpSdk: vi.fn(() => ({})),
+  PumpSdk: vi.fn(() => ({
+    createV2AndBuyInstructions: mockCreateV2AndBuyInstructions,
+  })),
   bondingCurvePda: vi.fn(() => ({ toBase58: () => 'curve-1' })),
-  getBuyTokenAmountFromSolAmount: vi.fn(),
+  getBuyTokenAmountFromSolAmount: vi.fn(() => ({ toString: () => '1000' })),
   getSellSolAmountFromTokenAmount: vi.fn(),
 }))
 
@@ -37,7 +45,7 @@ vi.mock('node:module', () => ({
 vi.mock('../../electron/services/SolanaService', () => ({
   withKeypair: mockWithKeypair,
   getConnectionStrict: mockGetConnectionStrict,
-  executeInstructions: vi.fn(),
+  executeInstructions: mockExecuteInstructions,
   loadKeypair: vi.fn(),
 }))
 
@@ -65,7 +73,7 @@ vi.mock('@solana/spl-token', () => ({
 vi.mock('@solana/web3.js', () => ({
   PublicKey: vi.fn((value: string) => ({ toBase58: () => value })),
   Keypair: {
-    generate: vi.fn(),
+    generate: mockKeypairGenerate,
   },
 }))
 
@@ -86,6 +94,12 @@ describe('PumpFunService', () => {
     mockFetchGlobal.mockResolvedValue({ tokenTotalSupply: {} })
     mockFetchBondingCurve.mockResolvedValue({ complete: false })
     mockFetchFeeConfig.mockResolvedValue({})
+    mockCreateV2AndBuyInstructions.mockResolvedValue([{}])
+    mockExecuteInstructions.mockResolvedValue({ signature: 'create-sig', transport: 'rpc' })
+    mockKeypairGenerate.mockReturnValue({
+      publicKey: { toBase58: () => 'Mint111111111111111111111111111111111111111' },
+      secretKey: new Uint8Array(64),
+    })
   })
 
   it('rejects zero-value buys before building instructions', async () => {
@@ -122,5 +136,81 @@ describe('PumpFunService', () => {
       initialBuyAmountSol: 0.1,
       mayhemMode: false,
     })).rejects.toThrow('Token metadata upload timed out after 30s')
+  })
+
+  it('retries transient metadata upload failures before creating the token', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'temporary outage',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ metadataUri: 'ipfs://metadata' }),
+      })
+
+    const result = await createToken({
+      walletId: 'wallet-1',
+      name: 'Daemon',
+      symbol: 'DMN',
+      description: 'Daemon token',
+      imagePath: null,
+      initialBuyAmountSol: 0.1,
+      mayhemMode: false,
+    })
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({
+      signature: 'create-sig',
+      mint: 'Mint111111111111111111111111111111111111111',
+      metadataUri: 'ipfs://metadata',
+      bondingCurveAddress: 'curve-1',
+    })
+  })
+
+  it('adds an explicit 500K CU limit to pump create+buy transactions', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ metadataUri: 'ipfs://metadata' }),
+    })
+
+    await createToken({
+      walletId: 'wallet-1',
+      name: 'Daemon',
+      symbol: 'DMN',
+      description: 'Daemon token',
+      imagePath: null,
+      initialBuyAmountSol: 0.1,
+      mayhemMode: false,
+    })
+
+    expect(mockExecuteInstructions).toHaveBeenCalledWith(
+      expect.anything(),
+      [{}],
+      [expect.anything(), expect.objectContaining({ publicKey: expect.anything() })],
+      {
+        payer: expect.anything(),
+        computeUnitLimit: 500_000,
+      },
+    )
+  })
+
+  it('adds mint context when create+buy submission fails ambiguously', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ metadataUri: 'ipfs://metadata' }),
+    })
+    mockExecuteInstructions.mockRejectedValueOnce(new Error('Transaction confirmation timed out (60s)'))
+
+    await expect(createToken({
+      walletId: 'wallet-1',
+      name: 'Daemon',
+      symbol: 'DMN',
+      description: 'Daemon token',
+      imagePath: null,
+      initialBuyAmountSol: 0.1,
+      mayhemMode: false,
+    })).rejects.toThrow(/verify the mint on-chain before retrying/i)
   })
 })

--- a/test/services/RaydiumLaunchLabAdapter.test.ts
+++ b/test/services/RaydiumLaunchLabAdapter.test.ts
@@ -162,4 +162,41 @@ describe('RaydiumLaunchLabAdapter', () => {
     expect(result.signature).toBe('raydium-sig-123')
     expect(result.poolAddress).toContain('raydium-pool')
   })
+
+  it('blocks direct launch when the configured LaunchLab config is not on-chain', async () => {
+    const getAccountInfo = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ lamports: 1 })
+    getConnectionStrictMock.mockReturnValue({
+      getLatestBlockhash: vi.fn(),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getAccountInfo,
+    })
+    const uploadMetadata = vi.fn(async () => ({ metadataUri: 'https://meta.example/raydium.json' }))
+    const loadSdk = vi.fn(() => ({}))
+
+    const adapter = createRaydiumLaunchLabAdapter({
+      env: {
+        RAYDIUM_LAUNCHLAB_CONFIG: '11111111111111111111111111111111',
+      } as NodeJS.ProcessEnv,
+      loadSdk,
+      uploadMetadata,
+    })
+
+    await expect(adapter.createLaunch({
+      launchpad: 'raydium',
+      walletId: 'wallet-1',
+      name: 'Ray Token',
+      symbol: 'RAYX',
+      description: 'LaunchLab token',
+      imagePath: null,
+      initialBuySol: 0.25,
+      slippageBps: 800,
+      priorityFeeSol: 0.005,
+    })).rejects.toThrow(/LaunchLab config .*not found on-chain/i)
+
+    expect(uploadMetadata).not.toHaveBeenCalled()
+    expect(loadSdk).not.toHaveBeenCalled()
+  })
 })

--- a/test/services/RecoveryService.test.ts
+++ b/test/services/RecoveryService.test.ts
@@ -3,9 +3,12 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import bs58 from 'bs58'
-import { Keypair } from '@solana/web3.js'
+import { Connection, Keypair } from '@solana/web3.js'
 
 vi.mock('electron', () => ({
+  app: {
+    getPath: () => os.tmpdir(),
+  },
   BrowserWindow: {
     getAllWindows: () => [],
   },
@@ -70,5 +73,49 @@ describe('RecoveryService', () => {
     loadCsvFile(csvPath)
 
     await expect(executeRecovery('So11111111111111111111111111111111111111112', null)).rejects.toThrow('Master wallet keypair not found in loaded wallets')
+  })
+
+  it('estimates SOL sweep priority fees against the source wallet account', async () => {
+    const master = Keypair.generate()
+    const source = Keypair.generate()
+    const csvPath = path.join(tempDir, 'wallets.csv')
+    fs.writeFileSync(
+      csvPath,
+      `privateKey\n${bs58.encode(master.secretKey)}\n${bs58.encode(source.secretKey)}\n`,
+      'utf8',
+    )
+    loadCsvFile(csvPath)
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        json: async () => ({ result: { priorityFeeEstimate: 111_000 } }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ result: { priorityFeeEstimate: 222_000 } }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const tokenAccountsSpy = vi.spyOn(Connection.prototype, 'getParsedTokenAccountsByOwner')
+      .mockResolvedValue({ context: { slot: 1 }, value: [] })
+    const balanceSpy = vi.spyOn(Connection.prototype, 'getBalance')
+      .mockResolvedValue(1_000_000)
+    const blockhashSpy = vi.spyOn(Connection.prototype, 'getLatestBlockhash')
+      .mockResolvedValue({
+        blockhash: '11111111111111111111111111111111',
+        lastValidBlockHeight: 123,
+      })
+
+    try {
+      await executeRecovery(master.publicKey.toBase58(), null)
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      const solFeeBody = JSON.parse(fetchMock.mock.calls[1][1].body)
+      expect(solFeeBody.params[0].accountKeys).toEqual([source.publicKey.toBase58()])
+    } finally {
+      tokenAccountsSpy.mockRestore()
+      balanceSpy.mockRestore()
+      blockhashSpy.mockRestore()
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/test/services/SolanaService.test.ts
+++ b/test/services/SolanaService.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  SystemProgram,
+  VersionedTransaction,
+} from '@solana/web3.js'
+
+const { mockGetWalletInfrastructureSettings, mockLogWarn } = vi.hoisted(() => ({
+  mockGetWalletInfrastructureSettings: vi.fn(),
+  mockLogWarn: vi.fn(),
+}))
+
+vi.mock('../../electron/services/SettingsService', () => ({
+  getWalletInfrastructureSettings: mockGetWalletInfrastructureSettings,
+}))
+
+vi.mock('../../electron/services/LogService', () => ({
+  LogService: {
+    warn: mockLogWarn,
+  },
+}))
+
+vi.mock('../../electron/services/SecureKeyService', () => ({
+  getKey: vi.fn(() => null),
+  storeKey: vi.fn(),
+  deleteKey: vi.fn(),
+}))
+
+vi.mock('../../electron/db/db', () => ({
+  getDb: vi.fn(),
+}))
+
+import {
+  confirmSignature,
+  executeInstructions,
+  getRpcEndpoint,
+} from '../../electron/services/SolanaService'
+
+function mockInfrastructureSettings(overrides: Record<string, unknown> = {}) {
+  mockGetWalletInfrastructureSettings.mockReturnValue({
+    rpcProvider: 'helius',
+    quicknodeRpcUrl: '',
+    customRpcUrl: '',
+    swapProvider: 'jupiter',
+    preferredWallet: 'phantom',
+    executionMode: 'rpc',
+    jitoBlockEngineUrl: 'https://mainnet.block-engine.jito.wtf/api/v1/transactions',
+    ...overrides,
+  })
+}
+
+describe('SolanaService transaction execution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInfrastructureSettings()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { priorityFeeEstimate: 42_000 } }),
+    }))
+  })
+
+  it('adds compute budget instructions when executing raw instructions', async () => {
+    const payer = Keypair.generate()
+    let submittedTx: VersionedTransaction | null = null
+    const connection = {
+      rpcEndpoint: 'https://unit.test',
+      getLatestBlockhash: vi.fn().mockResolvedValue({
+        blockhash: '11111111111111111111111111111111',
+        lastValidBlockHeight: 123,
+      }),
+      sendRawTransaction: vi.fn((rawTx: Uint8Array) => {
+        submittedTx = VersionedTransaction.deserialize(rawTx)
+        return Promise.resolve('test-signature')
+      }),
+      confirmTransaction: vi.fn().mockResolvedValue({ value: { err: null } }),
+      getRecentPrioritizationFees: vi.fn(),
+    } as any
+
+    await executeInstructions(
+      connection,
+      [
+        SystemProgram.transfer({
+          fromPubkey: payer.publicKey,
+          toPubkey: Keypair.generate().publicKey,
+          lamports: 1,
+        }),
+      ],
+      [payer],
+      { payer: payer.publicKey },
+    )
+
+    expect(submittedTx).not.toBeNull()
+    const message = submittedTx!.message
+    const [limitIx, priceIx] = message.compiledInstructions
+    expect(message.staticAccountKeys[limitIx.programIdIndex].equals(ComputeBudgetProgram.programId)).toBe(true)
+    expect(message.staticAccountKeys[priceIx.programIdIndex].equals(ComputeBudgetProgram.programId)).toBe(true)
+    expect(limitIx.data[0]).toBe(2)
+    expect(priceIx.data[0]).toBe(3)
+  })
+
+  it('confirms signatures with blockhash and lastValidBlockHeight strategy', async () => {
+    const connection = {
+      confirmTransaction: vi.fn().mockResolvedValue({ value: { err: null } }),
+    } as any
+
+    await confirmSignature(connection, 'test-signature', 1_000, {
+      blockhash: '11111111111111111111111111111111',
+      lastValidBlockHeight: 456,
+    })
+
+    expect(connection.confirmTransaction).toHaveBeenCalledWith({
+      signature: 'test-signature',
+      blockhash: '11111111111111111111111111111111',
+      lastValidBlockHeight: 456,
+    }, 'confirmed')
+  })
+
+  it('logs when falling back to public mainnet RPC', () => {
+    mockInfrastructureSettings({ rpcProvider: 'public' })
+
+    expect(getRpcEndpoint()).toBe('https://api.mainnet-beta.solana.com')
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      'SolanaService',
+      expect.stringContaining('Using public Solana mainnet RPC fallback'),
+      expect.objectContaining({ reason: 'Public Solana RPC is selected.' }),
+    )
+  })
+})

--- a/test/services/WalletService.swap.test.ts
+++ b/test/services/WalletService.swap.test.ts
@@ -1,9 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { mockPrepare, mockGetBalance, mockWithKeypair } = vi.hoisted(() => ({
+const {
+  mockPrepare,
+  mockGetBalance,
+  mockWithKeypair,
+  mockExecuteTransaction,
+  mockGetPriorityFeeLamports,
+  mockSecureGetKey,
+  mockFetch,
+  mockVersionedDeserialize,
+  mockVersionedSign,
+  mockVersionedSerialize,
+} = vi.hoisted(() => ({
   mockPrepare: vi.fn(),
   mockGetBalance: vi.fn(),
   mockWithKeypair: vi.fn(),
+  mockExecuteTransaction: vi.fn(),
+  mockGetPriorityFeeLamports: vi.fn(),
+  mockSecureGetKey: vi.fn(),
+  mockFetch: vi.fn(),
+  mockVersionedDeserialize: vi.fn(),
+  mockVersionedSign: vi.fn(),
+  mockVersionedSerialize: vi.fn(),
 }))
 
 const {
@@ -37,13 +55,13 @@ vi.mock('../../electron/db/db', () => ({
 }))
 
 vi.mock('../../electron/services/SecureKeyService', () => ({
-  getKey: vi.fn(() => null),
+  getKey: mockSecureGetKey,
   storeKey: vi.fn(),
   deleteKey: vi.fn(),
   isEncryptionAvailable: vi.fn(() => true),
 }))
 
-vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+vi.stubGlobal('fetch', mockFetch.mockResolvedValue({
   ok: false,
   status: 503,
   json: async () => ({}),
@@ -75,7 +93,10 @@ vi.mock('../../electron/services/SolanaService', () => {
       sendRawTransaction: vi.fn().mockResolvedValue('sig'),
     })),
     confirmSignature: vi.fn().mockResolvedValue({ err: null }),
-    executeTransaction: vi.fn().mockResolvedValue({ signature: 'sig', transport: 'rpc' }),
+    executeTransaction: mockExecuteTransaction,
+    getPriorityFeeLamports: mockGetPriorityFeeLamports,
+    getHeliusApiKey: vi.fn(() => mockSecureGetKey('HELIUS_API_KEY')),
+    getJupiterApiKey: vi.fn(() => mockSecureGetKey('JUPITER_API_KEY')),
     getTransactionSubmissionSettings: vi.fn(() => ({ mode: 'rpc' })),
     submitRawTransaction: vi.fn().mockResolvedValue('sig'),
     loadKeypair: vi.fn(() => fakeKeypair),
@@ -98,6 +119,9 @@ vi.mock('@solana/web3.js', () => ({
   LAMPORTS_PER_SOL: 1_000_000_000,
   sendAndConfirmTransaction: vi.fn().mockResolvedValue('fake-sig'),
   TOKEN_PROGRAM_ID: { toBase58: () => 'TokenProgram' },
+  VersionedTransaction: {
+    deserialize: mockVersionedDeserialize,
+  },
 }))
 
 vi.mock('@solana/spl-token', () => ({
@@ -107,7 +131,7 @@ vi.mock('@solana/spl-token', () => ({
   getAccount: mockGetAccount,
 }))
 
-import { getDashboard, transferSOL, transferToken } from '../../electron/services/WalletService'
+import { executeSwap, getDashboard, getSwapQuote, transferSOL, transferToken } from '../../electron/services/WalletService'
 
 function makeWalletDbChain(overrides: { walletRow?: object | null; dailySpendTotal?: number } = {}) {
   const walletRow = overrides.walletRow !== undefined
@@ -129,8 +153,22 @@ function makeWalletDbChain(overrides: { walletRow?: object | null; dailySpendTot
   }
 }
 
+function installVersionedTransactionMock() {
+  mockVersionedSerialize.mockReturnValue(Buffer.from('signed-jupiter-transaction'))
+  mockVersionedDeserialize.mockReturnValue({
+    sign: mockVersionedSign,
+    serialize: mockVersionedSerialize,
+  })
+}
+
 describe('transferSOL — validation', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSecureGetKey.mockReturnValue(null)
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({}), text: async () => 'unavailable' })
+    mockExecuteTransaction.mockResolvedValue({ signature: 'sig', transport: 'rpc' })
+    mockGetPriorityFeeLamports.mockResolvedValue(7_000)
+  })
 
   it('throws for amount of 0', async () => {
     await expect(transferSOL('w1', 'So11111111111111111111111111111111111111112', 0)).rejects.toThrow(/greater than 0/i)
@@ -157,10 +195,37 @@ describe('transferSOL — validation', () => {
       transferSOL('w1', 'So11111111111111111111111111111111111111112', 0.1)
     ).rejects.toThrow(/watch-only/i)
   })
+
+  it('reserves priority fees and passes an explicit compute limit for SOL sends', async () => {
+    mockPrepare.mockImplementation(makeWalletDbChain())
+    mockGetBalance.mockResolvedValue(1_000_000_000)
+    const fakeKeypair = {
+      publicKey: { toBase58: () => 'FakeKey', toBuffer: () => Buffer.alloc(32) },
+      secretKey: new Uint8Array(64),
+      fill: vi.fn(),
+    }
+    mockWithKeypair.mockImplementation((_walletId: string, fn: Function) => fn(fakeKeypair))
+
+    await transferSOL('w1', 'So11111111111111111111111111111111111111112', 0.1)
+
+    expect(mockGetPriorityFeeLamports).toHaveBeenCalledWith(expect.anything(), 20_000)
+    expect(mockExecuteTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      [fakeKeypair],
+      { computeUnitLimit: 20_000 },
+    )
+  })
 })
 
 describe('getDashboard — fallback active wallet', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSecureGetKey.mockReturnValue(null)
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({}), text: async () => 'unavailable' })
+    mockExecuteTransaction.mockResolvedValue({ signature: 'sig', transport: 'rpc' })
+    mockGetPriorityFeeLamports.mockResolvedValue(7_000)
+  })
 
   it('returns the default wallet as active even when Helius is not configured', async () => {
     mockPrepare.mockImplementation((sql: string) => {
@@ -248,10 +313,87 @@ describe('getDashboard — fallback active wallet', () => {
       holdings: [],
     })
   })
+
+  it('uses DAS metadata for wallet holdings when Helius is configured', async () => {
+    mockSecureGetKey.mockImplementation((key: string) => key === 'HELIUS_API_KEY' ? 'helius-key' : null)
+    mockPrepare.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id, name, address, is_default, agent_id, wallet_type, created_at FROM wallets')) {
+        return {
+          all: vi.fn().mockReturnValue([
+            {
+              id: 'wallet-1',
+              name: 'Primary Wallet',
+              address: 'Wallet111111111111111111111111111111111111',
+              is_default: 1,
+              agent_id: null,
+              wallet_type: 'user',
+              created_at: 123,
+            },
+          ]),
+        }
+      }
+      if (sql.includes('SELECT id, wallet_id FROM projects WHERE wallet_id IS NOT NULL')) {
+        return { all: vi.fn().mockReturnValue([]) }
+      }
+      if (sql.includes('SELECT wallet_id FROM projects WHERE id')) {
+        return { get: vi.fn().mockReturnValue(undefined) }
+      }
+      if (sql.includes('SELECT snapshot_at FROM portfolio_snapshots')) {
+        return { get: vi.fn().mockReturnValue(undefined) }
+      }
+      if (sql.includes('SELECT total_usd FROM')) {
+        return { all: vi.fn().mockReturnValue([]) }
+      }
+      return { run: vi.fn(), get: vi.fn().mockReturnValue(undefined), all: vi.fn().mockReturnValue([]) }
+    })
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ solana: { usd: 100, usd_24h_change: 1 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            nativeBalance: { lamports: 1_000_000_000, price_per_sol: 100, total_price: 100 },
+            items: [
+              {
+                id: 'Mint11111111111111111111111111111111111111',
+                content: { metadata: { name: 'Example Token', symbol: 'EXM' }, links: { image: 'https://img.test/token.png' } },
+                token_info: { balance: 1_500_000, decimals: 6, price_info: { price_per_token: 2, total_price: 3 } },
+              },
+            ],
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ events: [] }),
+      })
+
+    const dashboard = await getDashboard()
+
+    expect(dashboard.activeWallet?.holdings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        mint: 'Mint11111111111111111111111111111111111111',
+        symbol: 'EXM',
+        name: 'Example Token',
+        amount: 1.5,
+        valueUsd: 3,
+      }),
+    ]))
+  })
 })
 
 describe('transferSOL — insufficient balance', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSecureGetKey.mockReturnValue(null)
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({}), text: async () => 'unavailable' })
+    mockExecuteTransaction.mockResolvedValue({ signature: 'sig', transport: 'rpc' })
+    mockGetPriorityFeeLamports.mockResolvedValue(7_000)
+  })
 
   it('throws insufficient balance error when SOL balance is too low', async () => {
     mockPrepare.mockImplementation(makeWalletDbChain())
@@ -272,7 +414,13 @@ describe('transferSOL — insufficient balance', () => {
 })
 
 describe('transferSOL — agent spend limit', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSecureGetKey.mockReturnValue(null)
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({}), text: async () => 'unavailable' })
+    mockExecuteTransaction.mockResolvedValue({ signature: 'sig', transport: 'rpc' })
+    mockGetPriorityFeeLamports.mockResolvedValue(7_000)
+  })
 
   it('counts pending transfers toward the daily spend limit', async () => {
     mockPrepare.mockImplementation(makeWalletDbChain({
@@ -296,7 +444,13 @@ describe('transferSOL — agent spend limit', () => {
 })
 
 describe('transferToken — validation', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSecureGetKey.mockReturnValue(null)
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({}), text: async () => 'unavailable' })
+    mockExecuteTransaction.mockResolvedValue({ signature: 'sig', transport: 'rpc' })
+    mockGetPriorityFeeLamports.mockResolvedValue(7_000)
+  })
 
   it('throws when token amount is 0', async () => {
     await expect(
@@ -318,9 +472,39 @@ describe('transferToken — validation', () => {
     ).rejects.toThrow(/watch-only/i)
   })
 
+  it('rejects token sends when the mint account is not a parsed SPL mint', async () => {
+    mockPrepare.mockImplementation(makeWalletDbChain())
+    mockGetParsedAccountInfo.mockResolvedValue({
+      value: {
+        data: {
+          program: 'system',
+          parsed: { type: 'account', info: {} },
+        },
+      },
+    })
+    mockGetAssociatedTokenAddress.mockResolvedValue('from-ata')
+    const fakeKeypair = {
+      publicKey: { toBase58: () => 'FakeKey', toBuffer: () => Buffer.alloc(32) },
+      secretKey: new Uint8Array(64),
+      fill: vi.fn(),
+    }
+    mockWithKeypair.mockImplementation((_walletId: string, fn: Function) => fn(fakeKeypair))
+
+    await expect(
+      transferToken('w1', 'So11111111111111111111111111111111111111112', 'So11111111111111111111111111111111111111112', 10)
+    ).rejects.toThrow(/SPL Token mint/i)
+  })
+
   it('uses the full bigint token balance for sendMax without Number coercion', async () => {
     mockPrepare.mockImplementation(makeWalletDbChain())
-    mockGetParsedAccountInfo.mockResolvedValue({ value: { data: { parsed: { info: { decimals: 6 } } } } })
+    mockGetParsedAccountInfo.mockResolvedValue({
+      value: {
+        data: {
+          program: 'spl-token',
+          parsed: { type: 'mint', info: { decimals: 6 } },
+        },
+      },
+    })
     mockGetAssociatedTokenAddress
       .mockResolvedValueOnce('from-ata')
       .mockResolvedValueOnce('to-ata')
@@ -352,5 +536,195 @@ describe('transferToken — validation', () => {
       fakeKeypair.publicKey,
       9007199254740993123456789n,
     )
+    expect(mockExecuteTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      [fakeKeypair],
+      { computeUnitLimit: 80_000 },
+    )
+  })
+
+  it('uses a higher compute limit when creating the destination ATA', async () => {
+    mockPrepare.mockImplementation(makeWalletDbChain())
+    mockGetParsedAccountInfo.mockResolvedValue({
+      value: {
+        data: {
+          program: 'spl-token',
+          parsed: { type: 'mint', info: { decimals: 6 } },
+        },
+      },
+    })
+    mockGetAssociatedTokenAddress
+      .mockResolvedValueOnce('from-ata')
+      .mockResolvedValueOnce('to-ata')
+    mockGetAccount
+      .mockResolvedValueOnce({ amount: 2_000n })
+      .mockRejectedValueOnce(new Error('missing destination ATA'))
+    mockCreateTransferInstruction.mockReturnValue({})
+    mockCreateAssociatedTokenAccountInstruction.mockReturnValue({})
+
+    const fakeKeypair = {
+      publicKey: { toBase58: () => 'FakeKey', toBuffer: () => Buffer.alloc(32) },
+      secretKey: new Uint8Array(64),
+      fill: vi.fn(),
+    }
+
+    mockWithKeypair.mockImplementation((_walletId: string, fn: Function) => fn(fakeKeypair))
+
+    await transferToken(
+      'w1',
+      'So11111111111111111111111111111111111111112',
+      'So11111111111111111111111111111111111111112',
+      0.001,
+    )
+
+    expect(mockCreateAssociatedTokenAccountInstruction).toHaveBeenCalled()
+    expect(mockExecuteTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      [fakeKeypair],
+      { computeUnitLimit: 140_000 },
+    )
+  })
+})
+
+describe('Jupiter swap — Swap API V2', () => {
+  const inputMint = 'So11111111111111111111111111111111111111112'
+  const outputMint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+  const walletAddress = 'FakePublicKey111111111111111111111111111111'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSecureGetKey.mockImplementation((key: string) => key === 'JUPITER_API_KEY' ? 'jup-key' : null)
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({}), text: async () => 'unavailable' })
+    mockExecuteTransaction.mockResolvedValue({ signature: 'sig', transport: 'rpc' })
+    mockGetPriorityFeeLamports.mockResolvedValue(7_000)
+    mockPrepare.mockImplementation(makeWalletDbChain({
+      walletRow: {
+        id: 'w1',
+        name: 'Test',
+        address: walletAddress,
+        is_default: 1,
+        wallet_type: 'user',
+        keypair_path: null,
+      },
+    }))
+  })
+
+  it('requests an executable V2 order with the wallet taker and validates the response shape', async () => {
+    mockGetParsedAccountInfo.mockResolvedValue({
+      value: {
+        data: {
+          program: 'spl-token',
+          parsed: { type: 'mint', info: { decimals: 6 } },
+        },
+      },
+    })
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        inputMint,
+        outputMint,
+        inAmount: '100000000',
+        outAmount: '25000000',
+        priceImpact: -0.0025,
+        routePlan: [{ swapInfo: { label: 'Orca' }, bps: 10_000 }],
+        transaction: Buffer.from('unsigned').toString('base64'),
+        requestId: 'request-1',
+        lastValidBlockHeight: '123',
+        taker: walletAddress,
+      }),
+    })
+
+    const quote = await getSwapQuote('w1', inputMint, outputMint, 0.1, 50)
+
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(String(url)).toContain('https://api.jup.ag/swap/v2/order')
+    expect(String(url)).toContain(`taker=${walletAddress}`)
+    expect(String(url)).toContain('swapMode=ExactIn')
+    expect(init).toEqual({ headers: { 'x-api-key': 'jup-key' } })
+    expect(quote).toMatchObject({
+      inputMint,
+      outputMint,
+      inAmount: '0.1',
+      outAmount: '25',
+      priceImpactPct: '0.25',
+      routePlan: [{ label: 'Orca', percent: 100 }],
+    })
+    expect(quote.rawQuoteResponse).toMatchObject({ requestId: 'request-1', transaction: expect.any(String) })
+  })
+
+  it('rejects corrupted raw Jupiter orders before signing or submitting', async () => {
+    mockGetBalance.mockResolvedValue(1_000_000_000)
+    const fakeKeypair = {
+      publicKey: { toBase58: () => walletAddress, toBuffer: () => Buffer.alloc(32) },
+      secretKey: new Uint8Array(64),
+      fill: vi.fn(),
+    }
+    mockWithKeypair.mockImplementation((_walletId: string, fn: Function) => fn(fakeKeypair))
+
+    await expect(
+      executeSwap('w1', inputMint, outputMint, 0.1, 50, {
+        inputMint,
+        outputMint,
+        inAmount: '100000000',
+        outAmount: '25000000',
+        priceImpact: -0.0025,
+        routePlan: [],
+        requestId: 'request-1',
+      })
+    ).rejects.toThrow(/executable transaction/i)
+
+    expect(mockVersionedDeserialize).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('executes reviewed V2 orders through Jupiter managed execution', async () => {
+    installVersionedTransactionMock()
+    mockGetBalance.mockResolvedValue(1_000_000_000)
+    const fakeKeypair = {
+      publicKey: { toBase58: () => walletAddress, toBuffer: () => Buffer.alloc(32) },
+      secretKey: new Uint8Array(64),
+      fill: vi.fn(),
+    }
+    mockWithKeypair.mockImplementation((_walletId: string, fn: Function) => fn(fakeKeypair))
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'Success', signature: 'swap-sig' }),
+    })
+
+    const result = await executeSwap('w1', inputMint, outputMint, 0.1, 50, {
+      inputMint,
+      outputMint,
+      inAmount: '100000000',
+      outAmount: '25000000',
+      priceImpact: -0.0025,
+      routePlan: [],
+      transaction: Buffer.from('unsigned').toString('base64'),
+      requestId: 'request-1',
+      lastValidBlockHeight: '123',
+      taker: walletAddress,
+    })
+
+    expect(mockVersionedDeserialize).toHaveBeenCalledWith(Buffer.from('unsigned'))
+    expect(mockVersionedSign).toHaveBeenCalledWith([fakeKeypair])
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.jup.ag/swap/v2/execute',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': 'jup-key',
+        },
+      }),
+    )
+    const executeBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(executeBody).toEqual({
+      signedTransaction: Buffer.from('signed-jupiter-transaction').toString('base64'),
+      requestId: 'request-1',
+      lastValidBlockHeight: '123',
+    })
+    expect(mockExecuteTransaction).not.toHaveBeenCalled()
+    expect(result).toEqual({ signature: 'swap-sig', transport: 'jupiter' })
   })
 })


### PR DESCRIPTION
## Summary
- harden Solana transaction confirmation, compute budget, and RPC fallback behavior
- migrate Jupiter swaps to Swap API V2 with raw order validation
- add priority fees/CU limits to wallet and Pump.fun flows
- verify launch adapter config accounts and target recovery priority fees correctly

## Verification
- GitHub Release workflow passed for v3.0.9: https://github.com/nullxnothing/daemon/actions/runs/25447264234
- v3.0.9 release assets published: https://github.com/nullxnothing/daemon/releases/tag/v3.0.9