### PR TITLE
chore: release v3.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- bump DAEMON version to v3.0.10 for the latest downloadable build

## Validation
- version-only change; prior PR #156 CI passed before this bump