### PR TITLE
add X and Discord links to sidebar bottom nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",
@@ -32,6 +32,7 @@
     "test": "vitest run",
     "test:all": "pnpm run typecheck && pnpm test && pnpm run test:smoke && pnpm run test:journeys && pnpm run test:responsive && pnpm run test:layout && pnpm run test:visual",
     "test:smoke": "pnpm run build && node scripts/smoke/electron-smoke.mjs",
+    "test:scaffold-smoke": "pnpm run build && node scripts/smoke/project-scaffold.mjs",
     "test:replay-devnet": "pnpm run build && node scripts/smoke/replay-devnet-loop.mjs",
     "test:journeys": "pnpm run build && node scripts/smoke/workflow-journeys.mjs",
     "test:responsive": "pnpm run build && node scripts/smoke/app-responsive.mjs",

--- a/src/panels/IconSidebar/IconSidebar.css
+++ b/src/panels/IconSidebar/IconSidebar.css
@@ -172,6 +172,23 @@
   flex: 1;
 }
 
+/* Social link icons (X, Discord) */
+.sidebar-icon--social {
+  --tool-accent: var(--t3);
+  color: var(--t3);
+}
+
+.sidebar-icon--social:hover {
+  color: var(--t1);
+  background: var(--s2);
+  border-color: transparent;
+}
+
+.sidebar-icon--discord:hover {
+  color: #5865f2;
+  background: color-mix(in srgb, #5865f2 12%, transparent);
+}
+
 /* Submenu (kept for agent launcher flyout) */
 .sidebar-submenu-wrap {
   position: relative;

--- a/src/panels/IconSidebar/IconSidebar.tsx
+++ b/src/panels/IconSidebar/IconSidebar.tsx
@@ -49,6 +49,22 @@ function LauncherGlyph({ size = 18 }: { size?: number }) {
   )
 }
 
+function XGlyph({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.259 5.63L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z" />
+    </svg>
+  )
+}
+
+function DiscordGlyph({ size = 15 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z" />
+    </svg>
+  )
+}
+
 function HackathonGlyph({ size = 16 }: { size?: number }) {
   const gradientId = useId()
   return (
@@ -350,6 +366,26 @@ export function IconSidebar({ showExplorer, onToggleExplorer, onOpenAgentLaunche
         disabled={!isToolVisible('hackathon')}
       >
         <HackathonGlyph />
+      </button>
+
+      {/* Social Links */}
+      <button
+        type="button"
+        className="sidebar-icon sidebar-icon--social"
+        onClick={() => void window.daemon.shell.openExternal('https://x.com/DaemonTerminal')}
+        title="Follow on X"
+        aria-label="Follow on X"
+      >
+        <XGlyph />
+      </button>
+      <button
+        type="button"
+        className="sidebar-icon sidebar-icon--social sidebar-icon--discord"
+        onClick={() => void window.daemon.shell.openExternal('https://discord.gg/uyCJtcEBxA')}
+        title="Join Discord"
+        aria-label="Join Discord"
+      >
+        <DiscordGlyph />
       </button>
 
       {/* Command Drawer Launcher */}


### PR DESCRIPTION
Adds X (@DaemonTerminal) and Discord invite links as icon buttons at the bottom of the sidebar, above the Tools button. Opens via shell.openExternal. Version bumped to 3.0.12.