### PR TITLE
security(p0): safeStorage backend hardening + IPC sender validation + CI install lockdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,15 @@ jobs:
           cache: pnpm
       - name: Install Linux UI test dependencies
         run: sudo apt-get update && sudo apt-get install -y xvfb
-      - run: pnpm install --frozen-lockfile
+      # Disable lifecycle scripts on install (Shai-Hulud-class supply-chain
+      # defense); native modules are rebuilt explicitly afterward.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - run: pnpm run rebuild:native
+      - name: OSV supply-chain scan (lockfile)
+        uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
+        with:
+          scan-args: |-
+            --lockfile=pnpm-lock.yaml
       - run: pnpm run typecheck
       - run: pnpm run lint:styles
       - run: pnpm run security:audit
@@ -62,7 +70,8 @@ jobs:
           key: electron-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             electron-cache-${{ runner.os }}-
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - run: pnpm run rebuild:native
       - run: pnpm run build
       - run: pnpm run test:visual
       - run: pnpm exec electron-builder --publish never
@@ -89,7 +98,8 @@ jobs:
           key: electron-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             electron-cache-${{ runner.os }}-
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - run: pnpm run rebuild:native
       - run: pnpm run build
       - name: Pre-cache Electron binary
         shell: bash

--- a/docs/security/SECURITY_AUDIT.md
+++ b/docs/security/SECURITY_AUDIT.md
@@ -1,0 +1,138 @@
+# DAEMON Security Audit & Remediation
+
+Audit of the Electron hot-wallet / agent-workbench. Findings are recorded per
+priority stage with `file:line` evidence and a status of **CONFIRMED+FIXED**,
+**ALREADY MITIGATED** (with proof), or **N/A**.
+
+One branch + PR per stage:
+- P0 → `fix/security-p0`
+- P1 → `fix/security-p1`
+- P2 → `fix/security-p2`
+- P3 → `fix/security-p3`
+
+---
+
+## Transaction flow call graph (signer reachability)
+
+The single signing primitive is `withKeypair` / `loadKeypair` in
+`electron/services/SolanaService.ts:385-409`. It loads a decrypted `Keypair`
+from `SecureKeyService`, passes it to a callback, and zeroes the secret in a
+`finally`. All on-chain signing funnels through `executeTransaction`
+(`SolanaService.ts:273`) / `executeInstructions` (`:348`), which call
+`transaction.sign(...)` then `submitRawTransaction`.
+
+Callers of the signing primitive (`Grep withKeypair|executeTransaction|loadKeypair|.sign(`):
+- `services/WalletService.ts` — `transferSOL`, `transferToken`, `executeSwap`, external-transfer prepare/submit
+- `services/PumpFunService.ts`, `services/token-launch/adapters/*` — launch flows
+- `services/ProofPoolService.ts`, `services/MetaplexOperatorService.ts`, `services/KeycardService.ts`, `services/MeterflowService.ts`, `services/ProService.ts`, `services/RecoveryService.ts`
+- `services/AgentWorkService.ts` (`loadKeypair`, `:178`) and `services/SpawnAgentsService.ts` — **agent-adjacent**, analyzed in P1.
+
+Renderer → signer entry points are the `wallet:*` IPC channels in
+`electron/ipc/wallet.ts` (`wallet:send-sol :106`, `wallet:send-token :122`,
+`wallet:swap-execute :138`). These are exposed to the renderer via
+`electron/preload/index.ts:297-335`. **The signing IPC channels assume the
+renderer UI is the approval gate** — there is no main-process binding between an
+approved proposal and the signed bytes. This is the P1 confused-deputy surface.
+
+---
+
+## PRIORITY 0 — Stop-the-bleeding (`fix/security-p0`)
+
+### 1. Supply chain: `@solana/web3.js` backdoor + `bigint-buffer` overflow — ALREADY MITIGATED
+- **web3.js pinned to 1.98.4** everywhere in `pnpm-lock.yaml` (e.g. `:2515`,
+  `:9396`); `package.json:91` declares `^1.98.4`. No lockfile entry references the
+  backdoored **1.95.6 / 1.95.7** (CVE-2024-54134). 1.98.4 is above the 1.98.1
+  fix line, so no key rotation is indicated from this vector.
+- **`bigint-buffer` (CVE-2025-3194)** is neutralized via a pnpm override mapping
+  it to a local pure-JS workspace stub: `package.json:158`
+  (`"bigint-buffer": "workspace:*"`), resolved to `link:packages/bigint-buffer`
+  in `pnpm-lock.yaml:8835`. The stub (`packages/bigint-buffer/index.cjs`) is a
+  DataView/BigInt reimplementation with no native overflow path; covered by
+  `test/security/BigIntBufferShim.test.ts`. `pnpm why bigint-buffer` is wired
+  into `package.json:50` (`test:deps:solana`).
+
+### 2. Install hygiene — PARTIALLY MITIGATED → FIXED
+- Lockfile committed and excluded from gitignore (`.gitignore:28-30`).
+- `test:ci` already used `--frozen-lockfile --ignore-scripts` (`package.json:55`),
+  but the **CI workflow** ran `pnpm install --frozen-lockfile` *without*
+  `--ignore-scripts` (lifecycle scripts execute on install — the Shai-Hulud
+  vector).
+- **FIX** (`.github/workflows/ci.yml`): all three jobs now install with
+  `--ignore-scripts` and rebuild native modules explicitly via
+  `pnpm run rebuild:native`. Added an **OSV lockfile scan** step
+  (`google/osv-scanner-action`) to the validate job. (Socket/Snyk were not added
+  because they require an org token; OSV is free and token-less. Swap in
+  Socket/Snyk if a token is provisioned.)
+
+### 3. `safeStorage` degradation — CONFIRMED + FIXED
+- **Before**: `SecureKeyService.getKey` returned `null` whenever
+  `isEncryptionAvailable()` was false and never inspected
+  `getSelectedStorageBackend()`. On Linux a degraded `basic_text` backend
+  reports `isEncryptionAvailable() === true` while storing plaintext, and a
+  missing key silently returned `null` — the exact "silent-null and proceed"
+  anti-pattern (old `electron/services/SecureKeyService.ts:22-31`).
+- **FIX** (`electron/services/SecureKeyService.ts`):
+  - `isKeyEncryptionTrustworthy()` / `getKeyEncryptionWarning()` /
+    `getStorageBackend()` added; degraded backends `basic_text` / `unknown` are
+    treated as untrusted. macOS/Windows (no backend selector) trust
+    `isEncryptionAvailable()`.
+  - Private-key names (`WALLET_KEYPAIR_*`, `AGENT_STATION_KEY_*`,
+    `PROOF_POOL_KEY_*`, `PROOF_CREATOR_KEY_*`, `PROOF_VANITY_MINT_*`,
+    `PROOF_POOL_PLATFORM_ESCROW`) are **refused on store** and **throw on read**
+    under a degraded/unavailable backend — they no longer return `null` and let a
+    caller proceed. API keys keep lenient (null) behavior.
+  - `setUsePlainTextEncryption` is never called (verified by grep — absent).
+  - Startup health check in `electron/main/index.ts` (`app.whenReady`): logs +
+    records a `key-encryption-degraded` diagnostic and emits `secure-key:degraded`
+    to the renderer (channel allow-listed in `preload/index.ts`).
+- **Tests**: `test/services/SecureKeyService.test.ts` — 8 new cases (store/read
+  refusal on `basic_text` and unavailable keyring, lenient API-key behavior,
+  healthy-backend round-trip). Fail-before: the new functions did not exist and
+  `getKey` returned null instead of throwing.
+
+### 4. Electron baseline — MOSTLY MITIGATED → IPC sender gap FIXED
+- `BrowserWindow` `webPreferences` (`electron/main/index.ts:467-473`):
+  `contextIsolation:true`, `nodeIntegration:false`, `sandbox:true`. ✅
+  (`webviewTag:true`, but webviews are gated — see below.)
+- `setWindowOpenHandler` denies and routes through `isSafeExternalUrl`
+  (`main/index.ts:513-516`). ✅
+- `will-attach-webview` forces `nodeIntegration:false`, `contextIsolation:true`,
+  `sandbox:true`, `webSecurity:true`, strips `preload` (`:519-532`). ✅
+- `will-navigate` blocks cross-origin (`:535-543`). ✅
+- Strict CSP in production (`script-src 'self'`, `object-src 'none'`) (`:385`);
+  `webSecurity` not disabled, `allowRunningInsecureContent` not set. ✅
+- **GAP (CONFIRMED + FIXED): no `senderFrame` validation.** `ipcHandler`
+  (`electron/services/IpcHandlerFactory.ts`) never inspected the event, and the
+  raw `ipcMain.on` PTY channels (`electron/ipc/terminal.ts` `terminal:write` etc.)
+  and window-control channels (`main/index.ts`) had no sender check. A
+  compromised/embedded webview or sub-frame could `ipcRenderer.invoke` any
+  channel — including `wallet:send-sol`.
+  - **FIX**: new `electron/security/ipcSender.ts` (`isTrustedSender` requires the
+    event's **top frame** at the configured app origin). Wired into:
+    - `IpcHandlerFactory.ipcHandler` — guards every `.handle` channel (the bulk).
+    - `ipc/terminal.ts` — `terminal:write` / `terminal:resize` / `terminal:ready`.
+    - `main/index.ts` — window controls, `agentops:*`, `shell:open-external`;
+      `setTrustedIpcOrigin(...)` set at `createWindow`.
+  - **Tests**: `test/security/IpcSender.test.ts` (8 cases: top-frame accept,
+    sub-frame reject, cross-origin reject, file:// app, missing/unparseable frame)
+    and `test/services/IpcHandlerFactory.test.ts` (2 new cases: missing frame and
+    sub-frame rejected). Fail-before: the factory previously ran the handler for
+    any event.
+- **Note**: the renderer still reaches signing IPC directly. Restricting that to
+  the approval gate is **P1** (architectural), not a baseline flag.
+
+### 5. Auto-update — ALREADY MITIGATED (documented)
+- `electron-updater ^6.8.3` (`package.json:100`) — current; the
+  GHSA-9jxc-qjr9-vjxq Windows signature-bypass was fixed long before 6.8.
+- `main/index.ts:625-637`: auto-update only runs when `app.isPackaged`, uses
+  `checkForUpdatesAndNotify` (signature verification on by default in v6; install
+  is blocked on failed verification), and has a kill switch
+  (`DAEMON_DISABLE_AUTO_UPDATE`). Artifacts are served over HTTPS by the release
+  channel. No `setUsePlainTextEncryption` / unsafe-update flags present.
+
+### P0 residual / follow-ups
+- `electron/security/externalNavigation.ts:34-45` — `isAllowedWebviewUrl` permits
+  arbitrary `http:` for dev previews. `openSafeExternalUrl` is strict
+  (https+localhost only), so `shell.openExternal` is safe; the loose http rule
+  only affects webview embedding. Tighten in P2.
+- Consider a real Socket/Snyk token in CI to complement OSV.

--- a/electron/ipc/terminal.ts
+++ b/electron/ipc/terminal.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/db'
 import { buildCommand, cleanupContextFile } from '../services/ClaudeRouter'
 import { registerPort } from '../services/PortService'
 import { ipcHandler } from '../services/IpcHandlerFactory'
+import { isTrustedSender } from '../security/ipcSender'
 import { LogService } from '../services/LogService'
 import * as SessionTracker from '../services/SessionTracker'
 import * as ShiplineService from '../services/ShiplineService'
@@ -375,6 +376,8 @@ export function registerTerminalHandlers() {
   }))
 
   ipcMain.on('terminal:write', (_event, id: string, data: string) => {
+    // PTY input is a privileged channel — only the trusted top frame may drive it.
+    if (!isTrustedSender(_event)) return
     const session = sessions.get(id)
     session?.pty.write(data)
     if (session) {
@@ -394,12 +397,14 @@ export function registerTerminalHandlers() {
   })
 
   ipcMain.on('terminal:resize', (_event, id: string, cols: number, rows: number) => {
+    if (!isTrustedSender(_event)) return
     try { sessions.get(id)?.pty.resize(cols, rows) } catch (err) {
       LogService.warn('Terminal', `Failed to resize terminal ${id}`, { error: (err as Error).message })
     }
   })
 
   ipcMain.on('terminal:ready', (_event, id: string, cols?: number, rows?: number) => {
+    if (!isTrustedSender(_event)) return
     const session = sessions.get(id)
     if (!session) return
     if (Number.isFinite(cols) && Number.isFinite(rows) && cols! > 1 && rows! > 0) {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -60,8 +60,10 @@ import { flushRemoteTelemetry } from '../services/RemoteTelemetryService'
 import { flushQueue as flushVoightQueue } from '../services/VoightService'
 import { clearLoadedWallets } from '../services/RecoveryService'
 import { maybeRecoverUnstableUiState, type UiRecoveryResult } from '../services/SettingsService'
+import { getKeyEncryptionWarning, getStorageBackend } from '../services/SecureKeyService'
 import { shutdownAllLspSessions } from '../services/LspService'
 import { isAllowedWebviewUrl, isSafeExternalUrl, openSafeExternalUrl } from '../security/externalNavigation'
+import { isTrustedSender, setTrustedIpcOrigin } from '../security/ipcSender'
 import pkg from 'electron-updater'
 const { autoUpdater } = pkg
 
@@ -337,17 +339,20 @@ function registerAllIpc() {
   registerLspHandlers()
   registerVoightHandlers()
 
-  // Window controls
-  ipcMain.on('window:minimize', () => win?.minimize())
-  ipcMain.on('window:maximize', () => {
+  // Window controls — raw channels (not wrapped by ipcHandler), so guard the
+  // sender frame inline. Embedded/cross-origin frames must not drive the window.
+  ipcMain.on('window:minimize', (event) => { if (isTrustedSender(event)) win?.minimize() })
+  ipcMain.on('window:maximize', (event) => {
+    if (!isTrustedSender(event)) return
     if (win?.isMaximized()) {
       win.unmaximize()
     } else {
       win?.maximize()
     }
   })
-  ipcMain.on('window:close', () => shutdownApp())
-  ipcMain.on('window:reload', () => {
+  ipcMain.on('window:close', (event) => { if (isTrustedSender(event)) shutdownApp() })
+  ipcMain.on('window:reload', (event) => {
+    if (!isTrustedSender(event)) return
     if (!win) return
     if (VITE_DEV_SERVER_URL) {
       win.webContents.reloadIgnoringCache()
@@ -355,10 +360,11 @@ function registerAllIpc() {
       win.reload()
     }
   })
-  ipcMain.handle('window:isMaximized', () => win?.isMaximized() ?? false)
+  ipcMain.handle('window:isMaximized', (event) => (isTrustedSender(event) ? (win?.isMaximized() ?? false) : false))
 
-  ipcMain.handle('agentops:get-pending-open-request', () => pendingAgentOpsOpenRequest)
-  ipcMain.handle('agentops:ack-open-request', (_event, receivedAt: string) => {
+  ipcMain.handle('agentops:get-pending-open-request', (event) => (isTrustedSender(event) ? pendingAgentOpsOpenRequest : null))
+  ipcMain.handle('agentops:ack-open-request', (event, receivedAt: string) => {
+    if (!isTrustedSender(event)) return false
     if (pendingAgentOpsOpenRequest?.receivedAt === receivedAt) {
       pendingAgentOpsOpenRequest = null
     }
@@ -366,13 +372,17 @@ function registerAllIpc() {
   })
 
   // Shell utilities
-  ipcMain.handle('shell:open-external', async (_event, url: string) => {
+  ipcMain.handle('shell:open-external', async (event, url: string) => {
+    if (!isTrustedSender(event)) return
     await openSafeExternalUrl(url)
   })
 }
 
 async function createWindow() {
   if (SMOKE_TEST_MODE) console.log('[smoke] createWindow:start')
+  // Trusted IPC origin: the Vite dev server in development, the file:// bundle in
+  // production. IPC handlers reject senders whose top frame is not this origin.
+  setTrustedIpcOrigin(VITE_DEV_SERVER_URL ? new URL(VITE_DEV_SERVER_URL).origin : 'file://')
   registerAllIpc()
 
   // CSP headers only in production — in dev, Vite serves /@react-refresh and
@@ -609,8 +619,24 @@ app.whenReady().then(() => {
     }
   }
   initTelemetry(app.getVersion() || '3.0.8')
+
+  // Key-encryption health: if the OS keyring is unavailable or degraded to a
+  // plaintext-equivalent backend, surface a blocking warning. SecureKeyService
+  // independently refuses to store/decrypt private keys in this state.
+  const keyEncryptionWarning = getKeyEncryptionWarning()
+  if (keyEncryptionWarning) {
+    console.warn('[secure-key]', keyEncryptionWarning, '(backend:', getStorageBackend(), ')')
+    recordAppCrash('key-encryption-degraded', keyEncryptionWarning, `backend=${getStorageBackend() ?? 'n/a'}`)
+  }
+
   createWindow().catch((err) => {
     console.error('[smoke] createWindow:error', err)
+  }).then(() => {
+    if (keyEncryptionWarning && win && !win.isDestroyed()) {
+      win.webContents.once('did-finish-load', () => {
+        win?.webContents.send('secure-key:degraded', keyEncryptionWarning)
+      })
+    }
   })
   dispatchInitialAgentOpsOpenRequest()
   setTimeout(() => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -233,6 +233,7 @@ contextBridge.exposeInMainWorld('daemon', {
         'process:changed',
         'port:changed',
         'wallet:changed',
+        'secure-key:degraded',
       ])
       if (!allowed.has(channel)) {
         console.warn(`[preload] events.on rejected unknown channel: ${channel}`)

--- a/electron/security/ipcSender.ts
+++ b/electron/security/ipcSender.ts
@@ -1,0 +1,68 @@
+import type { IpcMainEvent, IpcMainInvokeEvent, WebFrameMain } from 'electron'
+
+/**
+ * IPC sender validation.
+ *
+ * DAEMON exposes high-privilege IPC channels (wallet signing, fs, shell, env).
+ * `<webview>` tags and any cross-origin iframe get their own WebFrameMain and
+ * can call `ipcRenderer.invoke` — so a compromised/embedded page could otherwise
+ * reach a privileged channel. We require that the caller be the TOP frame of the
+ * trusted application origin: the main renderer, never an embedded frame.
+ *
+ * The trusted origin is the Vite dev server in development and the file:// app
+ * bundle in production (custom protocols used for assets are not IPC senders).
+ */
+
+let trustedOrigin: string | null = null
+
+/** Set once at window creation. `null`/`'file://'` covers the packaged app. */
+export function setTrustedIpcOrigin(origin: string | null): void {
+  trustedOrigin = origin
+}
+
+function frameOrigin(frame: WebFrameMain | null): string | null {
+  if (!frame) return null
+  try {
+    // Packaged app loads from a file:// URL whose origin serializes to 'null';
+    // fall back to the scheme so we can still distinguish app vs remote frames.
+    const url = new URL(frame.url)
+    if (url.protocol === 'file:') return 'file://'
+    return url.origin
+  } catch {
+    return null
+  }
+}
+
+function isTopFrame(frame: WebFrameMain | null): boolean {
+  if (!frame) return false
+  // WebFrameMain.parent is null only for the top frame of a webContents.
+  // A <webview> hosts its content in a separate webContents whose top frame
+  // is the webview's document — which will not match the trusted origin.
+  return frame.parent === null
+}
+
+/**
+ * True when an IPC event originated from the trusted top-level app frame.
+ * Defaults to permissive only in the unexpected case where no origin was ever
+ * configured (e.g. a unit-test harness that imports a handler directly) so we
+ * never hard-break tests, but production always sets the origin at startup.
+ */
+export function isTrustedSender(event: IpcMainInvokeEvent | IpcMainEvent): boolean {
+  const frame = event.senderFrame
+  if (!frame) return false
+  if (!isTopFrame(frame)) return false
+
+  const origin = frameOrigin(frame)
+  if (origin === null) return false
+
+  // No configured origin (test/headless): accept top-frame senders only.
+  if (trustedOrigin === null) return true
+
+  return origin === trustedOrigin
+}
+
+export function assertTrustedSender(event: IpcMainInvokeEvent | IpcMainEvent): void {
+  if (!isTrustedSender(event)) {
+    throw new Error('IPC request rejected: untrusted sender frame')
+  }
+}

--- a/electron/services/IpcHandlerFactory.ts
+++ b/electron/services/IpcHandlerFactory.ts
@@ -1,5 +1,6 @@
 import { IpcMainInvokeEvent } from 'electron'
 import { sanitizeErrorMessage } from '../security/PrivacyGuard'
+import { isTrustedSender } from '../security/ipcSender'
 import * as Voight from './VoightService'
 
 export type IpcResponse<T = unknown> = 
@@ -37,6 +38,11 @@ export function ipcHandler<R = unknown>(
   onError?: (err: unknown) => string | null | undefined
 ): (event: IpcMainInvokeEvent, ...args: any[]) => Promise<IpcResponse<R>> {
   return async (event: IpcMainInvokeEvent, ...args: any[]) => {
+    if (!isTrustedSender(event)) {
+      const message = 'IPC request rejected: untrusted sender frame'
+      trackIpcError(message)
+      return { ok: false, error: message }
+    }
     try {
       const result = await handler(event, ...args)
       return { ok: true, data: result }

--- a/electron/services/SecureKeyService.ts
+++ b/electron/services/SecureKeyService.ts
@@ -1,6 +1,78 @@
 import { safeStorage } from 'electron'
 import { getDb } from '../db/db'
 
+/**
+ * Backends that mean the OS keyring is unavailable and safeStorage has silently
+ * fallen back to a hardcoded-password cipher (Linux) or an unknown state.
+ * In these modes the at-rest blob is effectively plaintext, so we refuse to
+ * hold private keys. See Electron docs: getSelectedStorageBackend() === 'basic_text'.
+ */
+const DEGRADED_STORAGE_BACKENDS = new Set(['basic_text', 'unknown'])
+
+/**
+ * Key-name prefixes/names for on-chain private keys — the high-value secrets we
+ * never store or decrypt under a degraded backend. These mirror the names used
+ * by WalletService, PumpFunService, AgentStationService, and ProofPoolService.
+ */
+const PRIVATE_KEY_NAME_PREFIXES = [
+  'WALLET_KEYPAIR_',
+  'AGENT_STATION_KEY_',
+  'PROOF_POOL_KEY_',
+  'PROOF_CREATOR_KEY_',
+  'PROOF_VANITY_MINT_',
+]
+const PRIVATE_KEY_NAMES = new Set(['PROOF_POOL_PLATFORM_ESCROW'])
+
+function isPrivateKeyName(keyName: string): boolean {
+  return PRIVATE_KEY_NAMES.has(keyName) || PRIVATE_KEY_NAME_PREFIXES.some((prefix) => keyName.startsWith(prefix))
+}
+
+/**
+ * safeStorage.getSelectedStorageBackend() only exists on Linux. On macOS
+ * (Keychain) and Windows (DPAPI) the call is absent, and isEncryptionAvailable()
+ * is the authoritative signal. Returns null when the API is unavailable.
+ */
+function getSelectedStorageBackend(): string | null {
+  const fn = (safeStorage as { getSelectedStorageBackend?: () => string }).getSelectedStorageBackend
+  if (typeof fn !== 'function') return null
+  try {
+    return fn.call(safeStorage)
+  } catch {
+    return 'unknown'
+  }
+}
+
+/**
+ * True when the OS keyring is available AND, where the platform reports a
+ * backend, that backend is not a plaintext-equivalent fallback.
+ */
+export function isKeyEncryptionTrustworthy(): boolean {
+  if (!safeStorage.isEncryptionAvailable()) return false
+  const backend = getSelectedStorageBackend()
+  if (backend === null) return true // macOS/Windows: no backend selector, trust isEncryptionAvailable
+  return !DEGRADED_STORAGE_BACKENDS.has(backend)
+}
+
+export function getStorageBackend(): string | null {
+  return getSelectedStorageBackend()
+}
+
+/**
+ * Startup health check. Returns a blocking warning string when private-key
+ * storage must be disabled, or null when the keyring is healthy. Callers should
+ * surface a non-dismissible warning and avoid signing flows when this is set.
+ */
+export function getKeyEncryptionWarning(): string | null {
+  if (!safeStorage.isEncryptionAvailable()) {
+    return 'Your OS keyring is unavailable. DAEMON cannot encrypt wallet keys and will not hold private keys until a secure keyring is configured.'
+  }
+  const backend = getSelectedStorageBackend()
+  if (backend !== null && DEGRADED_STORAGE_BACKENDS.has(backend)) {
+    return `Your OS keyring fell back to degraded encryption (${backend}). Stored secrets would be effectively plaintext, so DAEMON will not hold private keys. Configure a system secret service (gnome-keyring / KWallet) and restart.`
+  }
+  return null
+}
+
 export function isEncryptionAvailable(): boolean {
   return safeStorage.isEncryptionAvailable()
 }
@@ -8,6 +80,10 @@ export function isEncryptionAvailable(): boolean {
 export function storeKey(keyName: string, value: string): void {
   if (!safeStorage.isEncryptionAvailable()) {
     throw new Error('OS encryption not available — cannot store keys securely')
+  }
+  // High-value private keys are never written under a degraded (plaintext-equivalent) backend.
+  if (isPrivateKeyName(keyName) && !isKeyEncryptionTrustworthy()) {
+    throw new Error(getKeyEncryptionWarning() ?? 'OS keyring is in a degraded encryption mode — refusing to store private key')
   }
 
   const db = getDb()
@@ -20,7 +96,16 @@ export function storeKey(keyName: string, value: string): void {
 }
 
 export function getKey(keyName: string): string | null {
-  if (!safeStorage.isEncryptionAvailable()) return null
+  // Private keys must fail loud, never silently return null and let a caller
+  // proceed as if there were simply no wallet. A degraded backend here means
+  // the decrypted bytes cannot be trusted as confidentially stored.
+  if (isPrivateKeyName(keyName)) {
+    if (!isKeyEncryptionTrustworthy()) {
+      throw new Error(getKeyEncryptionWarning() ?? 'OS keyring is unavailable or degraded — refusing to decrypt private key')
+    }
+  } else if (!safeStorage.isEncryptionAvailable()) {
+    return null
+  }
 
   const db = getDb()
   const row = db.prepare('SELECT encrypted_value FROM secure_keys WHERE key_name = ?').get(keyName) as

--- a/test/security/IpcSender.test.ts
+++ b/test/security/IpcSender.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { isTrustedSender, setTrustedIpcOrigin } from '../../electron/security/ipcSender'
+
+type FakeFrame = { url: string; parent: FakeFrame | null }
+
+function event(frame: FakeFrame | null) {
+  return { senderFrame: frame } as unknown as Parameters<typeof isTrustedSender>[0]
+}
+
+function frame(url: string, parent: FakeFrame | null = null): FakeFrame {
+  return { url, parent }
+}
+
+describe('isTrustedSender', () => {
+  beforeEach(() => setTrustedIpcOrigin(null))
+
+  it('accepts the top frame at the configured dev origin', () => {
+    setTrustedIpcOrigin('http://127.0.0.1:7777')
+    expect(isTrustedSender(event(frame('http://127.0.0.1:7777/index.html')))).toBe(true)
+  })
+
+  it('accepts the top frame for the packaged file:// app', () => {
+    setTrustedIpcOrigin('file://')
+    expect(isTrustedSender(event(frame('file:///C:/app/dist/index.html')))).toBe(true)
+  })
+
+  it('rejects a different origin (e.g. a navigated/remote page)', () => {
+    setTrustedIpcOrigin('http://127.0.0.1:7777')
+    expect(isTrustedSender(event(frame('https://evil.example.com/')))).toBe(false)
+  })
+
+  it('rejects a sub-frame even at the trusted origin (iframe/webview document)', () => {
+    setTrustedIpcOrigin('http://127.0.0.1:7777')
+    const top = frame('http://127.0.0.1:7777/index.html')
+    const child = frame('http://127.0.0.1:7777/embedded', top)
+    expect(isTrustedSender(event(child))).toBe(false)
+  })
+
+  it('rejects a webview top frame whose origin differs from the app', () => {
+    setTrustedIpcOrigin('file://')
+    // A <webview> hosts a separate webContents; its top frame is a remote page.
+    expect(isTrustedSender(event(frame('https://some-embedded-site.com/')))).toBe(false)
+  })
+
+  it('rejects when there is no sender frame', () => {
+    setTrustedIpcOrigin('file://')
+    expect(isTrustedSender(event(null))).toBe(false)
+  })
+
+  it('rejects an unparseable frame url', () => {
+    setTrustedIpcOrigin('file://')
+    expect(isTrustedSender(event(frame('::::not-a-url')))).toBe(false)
+  })
+
+  it('with no configured origin, accepts a top frame but still rejects sub-frames', () => {
+    setTrustedIpcOrigin(null)
+    expect(isTrustedSender(event(frame('http://127.0.0.1:7777/')))).toBe(true)
+    const top = frame('http://127.0.0.1:7777/')
+    expect(isTrustedSender(event(frame('http://127.0.0.1:7777/child', top)))).toBe(false)
+  })
+})

--- a/test/services/IpcHandlerFactory.test.ts
+++ b/test/services/IpcHandlerFactory.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi } from 'vitest'
 import { ipcHandler, withValidation, unwrapResponse } from '../../electron/services/IpcHandlerFactory'
 import type { IpcMainInvokeEvent } from 'electron'
 
-// Minimal fake event — ipcHandler passes it through but never inspects it in tests
-const fakeEvent = {} as IpcMainInvokeEvent
+// Trusted top-frame sender. ipcHandler now rejects untrusted sender frames, so
+// tests of the success/error/validation paths must present a valid top frame.
+// No trusted origin is configured in this suite, so any top frame is accepted.
+const fakeEvent = { senderFrame: { url: 'file:///app/index.html', parent: null } } as unknown as IpcMainInvokeEvent
 
 describe('ipcHandler — success path', () => {
   it('wraps synchronous return value in { ok: true, data }', async () => {
@@ -94,6 +96,26 @@ describe('withValidation', () => {
     const handler = ipcHandler(wrapped)
     await handler(fakeEvent, 'a', 'b')
     expect(validator).toHaveBeenCalledWith('a', 'b')
+  })
+})
+
+describe('ipcHandler — sender frame validation', () => {
+  it('rejects an event with no sender frame', async () => {
+    const innerFn = vi.fn().mockResolvedValue('ok')
+    const handler = ipcHandler(innerFn)
+    const result = await handler({} as IpcMainInvokeEvent)
+    expect(result).toEqual({ ok: false, error: 'IPC request rejected: untrusted sender frame' })
+    expect(innerFn).not.toHaveBeenCalled()
+  })
+
+  it('rejects a sub-frame sender (iframe/webview document)', async () => {
+    const innerFn = vi.fn().mockResolvedValue('ok')
+    const handler = ipcHandler(innerFn)
+    const top = { url: 'file:///app/index.html', parent: null }
+    const subFrameEvent = { senderFrame: { url: 'https://embedded.example.com/', parent: top } } as unknown as IpcMainInvokeEvent
+    const result = await handler(subFrameEvent)
+    expect(result).toEqual({ ok: false, error: 'IPC request rejected: untrusted sender frame' })
+    expect(innerFn).not.toHaveBeenCalled()
   })
 })
 

--- a/test/services/SecureKeyService.test.ts
+++ b/test/services/SecureKeyService.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { mockEncryptString, mockDecryptString, mockIsEncryptionAvailable } = vi.hoisted(() => ({
+const { mockEncryptString, mockDecryptString, mockIsEncryptionAvailable, mockGetSelectedStorageBackend } = vi.hoisted(() => ({
   mockEncryptString: vi.fn((s: string) => Buffer.from(s)),
   mockDecryptString: vi.fn((b: Buffer) => b.toString()),
   mockIsEncryptionAvailable: vi.fn(() => true),
+  // Returns null to emulate macOS/Windows (no backend selector); a string emulates Linux.
+  mockGetSelectedStorageBackend: vi.fn<() => string | null>(() => null),
 }))
 
 vi.mock('electron', () => ({
@@ -11,6 +13,12 @@ vi.mock('electron', () => ({
     encryptString: mockEncryptString,
     decryptString: mockDecryptString,
     isEncryptionAvailable: mockIsEncryptionAvailable,
+    getSelectedStorageBackend: () => {
+      const value = mockGetSelectedStorageBackend()
+      // Emulate platforms without the selector by throwing the "not a function"
+      // condition: the service guards typeof, so returning null is enough here.
+      return value as string
+    },
   },
 }))
 
@@ -23,7 +31,15 @@ vi.mock('../../electron/db/db', () => ({
   getDb: () => ({ prepare: mockPrepare }),
 }))
 
-import { storeKey, getKey, deleteKey, listKeys, isEncryptionAvailable } from '../../electron/services/SecureKeyService'
+import {
+  storeKey,
+  getKey,
+  deleteKey,
+  listKeys,
+  isEncryptionAvailable,
+  isKeyEncryptionTrustworthy,
+  getKeyEncryptionWarning,
+} from '../../electron/services/SecureKeyService'
 
 describe('isEncryptionAvailable', () => {
   beforeEach(() => vi.clearAllMocks())
@@ -173,5 +189,71 @@ describe('listKeys', () => {
   it('returns empty array when no keys are stored', () => {
     mockPrepare.mockReturnValue({ all: vi.fn().mockReturnValue([]) })
     expect(listKeys()).toEqual([])
+  })
+})
+
+describe('safeStorage backend degradation (CVE-class: silent plaintext fallback)', () => {
+  const WALLET_KEY = 'WALLET_KEYPAIR_abc'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsEncryptionAvailable.mockReturnValue(true)
+    mockGetSelectedStorageBackend.mockReturnValue(null)
+  })
+
+  it('treats macOS/Windows (null backend) as trustworthy', () => {
+    mockGetSelectedStorageBackend.mockReturnValue(null)
+    expect(isKeyEncryptionTrustworthy()).toBe(true)
+    expect(getKeyEncryptionWarning()).toBeNull()
+  })
+
+  it('treats Linux gnome_libsecret as trustworthy', () => {
+    mockGetSelectedStorageBackend.mockReturnValue('gnome_libsecret')
+    expect(isKeyEncryptionTrustworthy()).toBe(true)
+    expect(getKeyEncryptionWarning()).toBeNull()
+  })
+
+  it('flags basic_text as degraded', () => {
+    mockGetSelectedStorageBackend.mockReturnValue('basic_text')
+    expect(isKeyEncryptionTrustworthy()).toBe(false)
+    expect(getKeyEncryptionWarning()).toMatch(/degraded/i)
+  })
+
+  it('flags an unavailable keyring', () => {
+    mockIsEncryptionAvailable.mockReturnValue(false)
+    expect(isKeyEncryptionTrustworthy()).toBe(false)
+    expect(getKeyEncryptionWarning()).toMatch(/unavailable/i)
+  })
+
+  it('refuses to STORE a wallet key on basic_text instead of writing plaintext', () => {
+    mockPrepare.mockReturnValue({ run: mockRun, get: mockGet, all: mockAll })
+    mockGetSelectedStorageBackend.mockReturnValue('basic_text')
+    expect(() => storeKey(WALLET_KEY, 'secret-bytes')).toThrow(/degraded/i)
+    expect(mockRun).not.toHaveBeenCalled()
+  })
+
+  it('still stores API keys on basic_text (lenient, non-private)', () => {
+    mockPrepare.mockReturnValue({ run: mockRun, get: mockGet, all: mockAll })
+    mockGetSelectedStorageBackend.mockReturnValue('basic_text')
+    expect(() => storeKey('HELIUS_API_KEY', 'helius-xyz')).not.toThrow()
+    expect(mockRun).toHaveBeenCalled()
+  })
+
+  it('THROWS (does not return null) reading a wallet key on a degraded backend', () => {
+    mockGetSelectedStorageBackend.mockReturnValue('basic_text')
+    mockPrepare.mockReturnValue({ get: vi.fn().mockReturnValue({ encrypted_value: Buffer.from('x') }) })
+    expect(() => getKey(WALLET_KEY)).toThrow(/degraded/i)
+  })
+
+  it('THROWS reading a wallet key with no keyring available', () => {
+    mockIsEncryptionAvailable.mockReturnValue(false)
+    expect(() => getKey(WALLET_KEY)).toThrow(/unavailable/i)
+  })
+
+  it('reads a wallet key normally on a healthy backend', () => {
+    mockGetSelectedStorageBackend.mockReturnValue('gnome_libsecret')
+    mockDecryptString.mockReturnValue('secret-bytes')
+    mockPrepare.mockReturnValue({ get: vi.fn().mockReturnValue({ encrypted_value: Buffer.from('x') }) })
+    expect(getKey(WALLET_KEY)).toBe('secret-bytes')
   })
 })


### PR DESCRIPTION
## Priority 0 — Stop-the-bleeding

First of four security-hardening PRs (P0–P3). Full findings in `docs/security/SECURITY_AUDIT.md`.

### Fixed (net-new)
- **safeStorage degradation** (`SecureKeyService`): detect degraded backend (`basic_text`/`unknown`) via `getSelectedStorageBackend()`; **refuse to store** and **throw on read** for wallet/keypair secrets under a degraded or unavailable keyring instead of silently returning `null`. macOS/Windows (no backend selector) keep trusting `isEncryptionAvailable()`. Startup warning logged + emitted to renderer (`secure-key:degraded`).
- **IPC sender validation**: new `security/ipcSender.ts` `isTrustedSender()` requires the event's **top frame** at the trusted app origin. Wired into the `ipcHandler` factory (all `.handle` channels) plus raw `terminal:write/resize/ready` and window-control channels. Blocks a compromised/embedded webview or sub-frame from reaching `wallet:send-sol`/PTY input.
- **CI install hygiene**: all jobs now `pnpm install --frozen-lockfile --ignore-scripts` + explicit `rebuild:native`; added an **OSV lockfile scan** step.

### Already mitigated (documented with evidence)
- `@solana/web3.js` pinned **1.98.4** (no 1.95.6/1.95.7 backdoor); `bigint-buffer` overridden to a local pure-JS stub (CVE-2025-3194 neutralized).
- Electron baseline: `contextIsolation/sandbox:true`, `nodeIntegration:false`, `setWindowOpenHandler`, `will-attach-webview`, `will-navigate`, strict prod CSP.
- `electron-updater ^6.8.3`, packaged-only, signature-verify blocks install.

### Tests
- `test/services/SecureKeyService.test.ts` (+8): store/read refusal on degraded backend, lenient API-key behavior, healthy round-trip.
- `test/security/IpcSender.test.ts` (8) + `test/services/IpcHandlerFactory.test.ts` (+2): top-frame accept, sub-frame/cross-origin reject.
- Full suite green; `tsc --noEmit` clean; `pnpm audit` clean.

> Note: renderer still reaches signing IPC directly — restricting that to a non-bypassable approval gate is **P1** (architectural), tracked in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)