### PR TITLE
security(p2): authenticate Seeker relay + restrict webview http

### DIFF
--- a/apps/seeker-mobile/App.tsx
+++ b/apps/seeker-mobile/App.tsx
@@ -17,6 +17,7 @@ import { demoProject } from './src/data/demo'
 import { useApprovalQueue } from './src/hooks/useApprovalQueue'
 import { useDesktopRelay } from './src/hooks/useDesktopRelay'
 import { usePairingSession } from './src/hooks/usePairingSession'
+import { postRelayEvent } from './src/services/desktopRelay'
 import { useSeekerNotifications } from './src/hooks/useSeekerNotifications'
 import { useSeekerWallet } from './src/hooks/useSeekerWallet'
 import type { ApprovalRequest, ApprovalRisk, PairingSession } from './src/types'
@@ -46,33 +47,23 @@ function shortAddress(address: string | null) {
   return `${address.slice(0, 4)}...${address.slice(-4)}`
 }
 
-function relayBaseUrl(relayUrl: string) {
-  return relayUrl.trim().replace(/\/$/, '')
-}
-
 async function sendPairEvent(nextSession: PairingSession) {
-  const base = relayBaseUrl(nextSession.relayUrl)
-  if (!base) return { ok: false, error: 'Missing relay URL' }
-
-  try {
-    const res = await fetch(`${base}/api/seeker/events`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        type: 'pair',
-        sessionCode: nextSession.pairingCode,
-        payload: {
-          platform: 'seeker-mobile',
-          project: nextSession.projectName,
-          device: 'Daemon Seeker app',
-        },
-      }),
-    })
-    if (!res.ok) return { ok: false, error: `Relay returned ${res.status}` }
-    return { ok: true }
-  } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : 'Pair event failed' }
-  }
+  // Delegate to the shared relay client so the per-session bearer token is sent.
+  return postRelayEvent(
+    {
+      relayUrl: nextSession.relayUrl,
+      sessionCode: nextSession.pairingCode,
+      accessToken: nextSession.accessToken,
+    },
+    {
+      type: 'pair',
+      payload: {
+        platform: 'seeker-mobile',
+        project: nextSession.projectName,
+        device: 'Daemon Seeker app',
+      },
+    },
+  )
 }
 
 function StatusPill({ label, tone = 'green' }: { label: string; tone?: 'green' | 'blue' | 'yellow' | 'red' | 'gray' }) {
@@ -170,7 +161,7 @@ export default function App() {
   const [codeInput, setCodeInput] = useState('')
   const [pairingMessage, setPairingMessage] = useState<string | null>(null)
   const { session, deepLink, pairManually, resetPairing } = usePairingSession()
-  const relay = useDesktopRelay(session.relayUrl, session.pairingCode)
+  const relay = useDesktopRelay(session.relayUrl, session.pairingCode, session.accessToken)
   const approvals = useApprovalQueue(relay.sendRelayEvent)
   const wallet = useSeekerWallet()
   const notifications = useSeekerNotifications()
@@ -196,7 +187,21 @@ export default function App() {
   }, [approvals, relay, session.status])
 
   const handlePair = async () => {
-    const nextSession = pairManually(codeInput || session.pairingCode, relayInput || session.relayUrl)
+    // The secured relay requires the per-session token. Accept a pasted
+    // `daemonseeker://pair?...` link (carrying code+relay+token) in the code
+    // field; otherwise fall back to the typed short code (token unknown).
+    let pairCode = codeInput || session.pairingCode
+    let pairRelay = relayInput || session.relayUrl
+    let pairToken: string | undefined
+    if (codeInput.trim().startsWith('daemonseeker://')) {
+      try {
+        const params = new URL(codeInput.trim()).searchParams
+        pairCode = params.get('code') ?? pairCode
+        pairRelay = params.get('relay') ?? pairRelay
+        pairToken = params.get('token') ?? undefined
+      } catch { /* not a valid link — use typed values */ }
+    }
+    const nextSession = pairManually(pairCode, pairRelay, pairToken)
     setPairingMessage('Pairing with Daemon desktop...')
     const result = await sendPairEvent(nextSession)
     if (!result.ok) {

--- a/apps/seeker-mobile/src/hooks/useDesktopRelay.ts
+++ b/apps/seeker-mobile/src/hooks/useDesktopRelay.ts
@@ -2,20 +2,20 @@ import { useCallback, useState } from 'react'
 import type { RelayEvent } from '../types'
 import { fetchRelaySnapshot, postRelayEvent, type RelaySnapshot } from '../services/desktopRelay'
 
-export function useDesktopRelay(relayUrl: string, sessionCode: string) {
+export function useDesktopRelay(relayUrl: string, sessionCode: string, accessToken?: string | null) {
   const [lastSyncAt, setLastSyncAt] = useState<number | null>(null)
   const [lastError, setLastError] = useState<string | null>(null)
   const [snapshot, setSnapshot] = useState<RelaySnapshot | null>(null)
 
   const sendRelayEvent = useCallback(async (event: Omit<RelayEvent, 'sessionCode'>) => {
-    const result = await postRelayEvent({ relayUrl, sessionCode }, event)
+    const result = await postRelayEvent({ relayUrl, sessionCode, accessToken }, event)
     if (!result.ok) setLastError(result.error ?? 'Relay event failed')
     else setLastError(null)
     return result
-  }, [relayUrl, sessionCode])
+  }, [relayUrl, sessionCode, accessToken])
 
   const syncRelaySnapshot = useCallback(async () => {
-    const result = await fetchRelaySnapshot({ relayUrl, sessionCode })
+    const result = await fetchRelaySnapshot({ relayUrl, sessionCode, accessToken })
     if (result.ok) {
       setSnapshot(result.data)
       setLastError(null)
@@ -24,7 +24,7 @@ export function useDesktopRelay(relayUrl: string, sessionCode: string) {
       setLastError(result.error)
     }
     return result
-  }, [relayUrl, sessionCode])
+  }, [relayUrl, sessionCode, accessToken])
 
   return {
     snapshot,

--- a/apps/seeker-mobile/src/hooks/usePairingSession.ts
+++ b/apps/seeker-mobile/src/hooks/usePairingSession.ts
@@ -16,6 +16,7 @@ function parsePairingUrl(url: string | null) {
   try {
     const parsed = new URL(url)
     const pairingCode = parsed.searchParams.get('code') ?? parsed.searchParams.get('pair')
+    const accessToken = parsed.searchParams.get('token')
     const relayUrl = parsed.searchParams.get('relay') ?? parsed.searchParams.get('relayUrl')
     const desktopId = parsed.searchParams.get('desktopId') ?? parsed.searchParams.get('desktop')
     const projectName = parsed.searchParams.get('project') ?? parsed.searchParams.get('projectName')
@@ -24,6 +25,7 @@ function parsePairingUrl(url: string | null) {
 
     return {
       pairingCode: pairingCode ?? createPairingCode(),
+      accessToken: accessToken ?? null,
       relayUrl: relayUrl ?? '',
       desktopId: desktopId ?? null,
       projectName: projectName ?? 'Daemon Project',
@@ -38,6 +40,7 @@ export function usePairingSession(initialRelayUrl = '') {
   const [session, setSession] = useState<PairingSession>(() => ({
     status: 'idle',
     pairingCode: createPairingCode(),
+    accessToken: null,
     relayUrl: initialRelayUrl,
     desktopId: null,
     projectName: 'Daemon Project',
@@ -60,10 +63,11 @@ export function usePairingSession(initialRelayUrl = '') {
     return nextSession
   }, [])
 
-  const pairManually = useCallback((pairingCode: string, relayUrl: string) => {
+  const pairManually = useCallback((pairingCode: string, relayUrl: string, accessToken?: string) => {
     const next = {
       status: 'paired' as const,
       pairingCode: pairingCode.trim() || createPairingCode(),
+      accessToken: accessToken?.trim() || null,
       relayUrl: relayUrl.trim(),
       desktopId: 'manual-desktop',
     }
@@ -86,6 +90,7 @@ export function usePairingSession(initialRelayUrl = '') {
     updateSession({
       status: 'idle',
       pairingCode: createPairingCode(),
+      accessToken: null,
       relayUrl: initialRelayUrl,
       desktopId: null,
       projectName: 'Daemon Project',

--- a/apps/seeker-mobile/src/services/desktopRelay.ts
+++ b/apps/seeker-mobile/src/services/desktopRelay.ts
@@ -9,6 +9,8 @@ export interface RelaySnapshot {
 export interface RelayClientOptions {
   relayUrl: string
   sessionCode: string
+  /** Per-session bearer token from the pairing deep link. Required by the relay. */
+  accessToken?: string | null
 }
 
 function normalizeRelayUrl(relayUrl: string) {
@@ -16,14 +18,20 @@ function normalizeRelayUrl(relayUrl: string) {
   return trimmed.length > 0 ? trimmed : null
 }
 
-export async function postRelayEvent({ relayUrl, sessionCode }: RelayClientOptions, event: Omit<RelayEvent, 'sessionCode'>) {
+function authHeaders(accessToken?: string | null): Record<string, string> {
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (accessToken) headers['authorization'] = `Bearer ${accessToken}`
+  return headers
+}
+
+export async function postRelayEvent({ relayUrl, sessionCode, accessToken }: RelayClientOptions, event: Omit<RelayEvent, 'sessionCode'>) {
   const base = normalizeRelayUrl(relayUrl)
   if (!base) return { ok: false, error: 'Missing relay URL' }
 
   try {
     const res = await fetch(`${base}/api/seeker/events`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: authHeaders(accessToken),
       body: JSON.stringify({ ...event, sessionCode }),
     })
 
@@ -34,12 +42,14 @@ export async function postRelayEvent({ relayUrl, sessionCode }: RelayClientOptio
   }
 }
 
-export async function fetchRelaySnapshot({ relayUrl, sessionCode }: RelayClientOptions) {
+export async function fetchRelaySnapshot({ relayUrl, sessionCode, accessToken }: RelayClientOptions) {
   const base = normalizeRelayUrl(relayUrl)
   if (!base) return { ok: false, error: 'Missing relay URL', data: null as RelaySnapshot | null }
 
   try {
-    const res = await fetch(`${base}/api/seeker/session/${encodeURIComponent(sessionCode)}`)
+    const res = await fetch(`${base}/api/seeker/session/${encodeURIComponent(sessionCode)}`, {
+      headers: authHeaders(accessToken),
+    })
     if (!res.ok) return { ok: false, error: `Relay returned ${res.status}`, data: null }
     const data = await res.json() as RelaySnapshot
     return { ok: true, data, error: null }

--- a/apps/seeker-mobile/src/types.ts
+++ b/apps/seeker-mobile/src/types.ts
@@ -3,6 +3,8 @@ export type SessionStatus = 'idle' | 'pairing' | 'paired' | 'error'
 export interface PairingSession {
   status: SessionStatus
   pairingCode: string
+  /** Per-session bearer secret from the pairing deep link; required by the relay. */
+  accessToken: string | null
   relayUrl: string
   desktopId: string | null
   projectName: string

--- a/docs/security/SECURITY_AUDIT.md
+++ b/docs/security/SECURITY_AUDIT.md
@@ -76,8 +76,12 @@ method-scoped and origin-checked. ✅
   - `/sessions` list restricted to loopback.
   - Tests: `test/services/SeekerRelayService.test.ts` — no-token/wrong-token/
     browser-origin/unauth-approval rejected, correct token accepted.
-- **Follow-up (mobile app)**: `apps/seeker-mobile` must read the deep-link `token`
-  and send `Authorization: Bearer <token>` (out of scope for the desktop audit).
+- **Mobile app (done in this PR)**: `apps/seeker-mobile` now parses the deep-link
+  `token`, threads it through `PairingSession` → `useDesktopRelay` →
+  `desktopRelay` client, and sends `Authorization: Bearer <token>` on all relay
+  requests (snapshot, events, pair). Manual pairing accepts a pasted
+  `daemonseeker://` link to carry the token. Verified by `tsc` (the mobile package
+  has no test runner).
 - `daemon-ai-cloud/server.ts` is a separately-deployed cloud component gated by
   x402/SubscriptionGateway — not the desktop app's local surface; unchanged.
 

--- a/docs/security/SECURITY_AUDIT.md
+++ b/docs/security/SECURITY_AUDIT.md
@@ -1,0 +1,92 @@
+# DAEMON Security Audit & Remediation
+
+Audit of the Electron hot-wallet / agent-workbench. Findings are recorded per
+priority stage with `file:line` evidence and a status of **CONFIRMED+FIXED**,
+**ALREADY MITIGATED** (with proof), or **N/A**.
+
+One branch + PR per stage:
+- P0 → `fix/security-p0`
+- P1 → `fix/security-p1`
+- P2 → `fix/security-p2`
+- P3 → `fix/security-p3`
+
+---
+
+## Transaction flow call graph (signer reachability)
+
+The single signing primitive is `withKeypair` / `loadKeypair` in
+`electron/services/SolanaService.ts:385-409`. It loads a decrypted `Keypair`
+from `SecureKeyService`, passes it to a callback, and zeroes the secret in a
+`finally`. All on-chain signing funnels through `executeTransaction`
+(`SolanaService.ts:273`) / `executeInstructions` (`:348`), which call
+`transaction.sign(...)` then `submitRawTransaction`.
+
+Callers of the signing primitive (`Grep withKeypair|executeTransaction|loadKeypair|.sign(`):
+- `services/WalletService.ts` — `transferSOL`, `transferToken`, `executeSwap`, external-transfer prepare/submit
+- `services/PumpFunService.ts`, `services/token-launch/adapters/*` — launch flows
+- `services/ProofPoolService.ts`, `services/MetaplexOperatorService.ts`, `services/KeycardService.ts`, `services/MeterflowService.ts`, `services/ProService.ts`, `services/RecoveryService.ts`
+- `services/AgentWorkService.ts` (`loadKeypair`, `:178`) and `services/SpawnAgentsService.ts` — **agent-adjacent**, analyzed in P1.
+
+Renderer → signer entry points are the `wallet:*` IPC channels in
+`electron/ipc/wallet.ts` (`wallet:send-sol :106`, `wallet:send-token :122`,
+`wallet:swap-execute :138`). These are exposed to the renderer via
+`electron/preload/index.ts:297-335`. **The signing IPC channels assume the
+renderer UI is the approval gate** — there is no main-process binding between an
+approved proposal and the signed bytes. This is the P1 confused-deputy surface.
+
+---
+
+## PRIORITY 2 — Electron RCE surface (`fix/security-p2`)
+
+### 12. Minimal preload bridge — ALREADY MITIGATED
+`electron/preload/index.ts` exposes one explicit method per channel; there is no
+generic `ipcRenderer.invoke(channel, ...args)` passthrough. Event subscriptions
+are channel-allow-listed (`:231`). With the P0 sender-frame guard, the bridge is
+method-scoped and origin-checked. ✅
+
+### 13. shell.openExternal + CSP + webview scheme — MOSTLY MITIGATED → http tightened
+- `shell:open-external` routes through `openSafeExternalUrl`
+  (`security/externalNavigation.ts:28`): only `https:` and loopback `http:`,
+  credentials rejected. ✅
+- Strict prod CSP (`script-src 'self'`, `object-src 'none'`), `webSecurity` never
+  disabled, `allowRunningInsecureContent` never set (`main/index.ts:385`). ✅
+- **FIX**: `isAllowedWebviewUrl` previously allowed arbitrary remote `http:`. Now
+  restricted to `https:` + loopback `http:` so a cleartext remote page can't be
+  embedded as a `<webview>` (`externalNavigation.ts`; test updated in
+  `test/security/ExternalNavigation.test.ts`).
+- **Residual**: local pages are served from `file://` rather than a custom
+  privileged-isolated protocol. The `will-navigate` + `setWindowOpenHandler`
+  origin locks contain this; a custom app protocol is a larger follow-up.
+
+### 14. Embedded local server (Seeker relay) — CONFIRMED + FIXED
+`electron/services/SeekerRelayService.ts` runs an HTTP server bound to `0.0.0.0`
+(intentional — the phone reaches it over LAN) exposing pairing/approval endpoints.
+- **Weak pairing secret**: `makePairingCode` produced ~6 chars
+  (`randomBytes(3)` → 4 hex + 2 digits ≈ 5.9M combos) — brute-forceable on an
+  unauthenticated, LAN-exposed server with no rate limit; a LAN attacker could
+  enumerate codes and POST `approved` to approval endpoints.
+- **CORS `*`**: any web page could reach the LAN endpoints.
+- **FIX**:
+  - 32-byte per-session **bearer access token** (`randomBytes(32)`), delivered to
+    the phone via the deep link/QR (`token=` param) and required (constant-time
+    `timingSafeEqual`) on every session-scoped endpoint. Unauthorized → generic
+    404 (doesn't confirm code existence).
+  - Removed `access-control-allow-origin: *`; any request with a browser `Origin`
+    is rejected (`403`).
+  - `/sessions` list restricted to loopback.
+  - Tests: `test/services/SeekerRelayService.test.ts` — no-token/wrong-token/
+    browser-origin/unauth-approval rejected, correct token accepted.
+- **Follow-up (mobile app)**: `apps/seeker-mobile` must read the deep-link `token`
+  and send `Authorization: Bearer <token>` (out of scope for the desktop audit).
+- `daemon-ai-cloud/server.ts` is a separately-deployed cloud component gated by
+  x402/SubscriptionGateway — not the desktop app's local surface; unchanged.
+
+### 15. Untrusted repos + email injection — REVIEWED (residual)
+- Repo build/run happens in the user-driven `node-pty` terminal, not an automatic
+  main-process exec. `ProjectSafetyService.ts:103` flags
+  `--dangerously-skip-permissions` in scanned commands. A fully **key-free,
+  network-restricted repo worker** (so a malicious `postinstall` can't share the
+  signer's process) is an architectural follow-up.
+- `imapflow`/`nodemailer`/`BrowserService` send paths use structured library
+  APIs (no shell concatenation); no concrete injection found. Deeper fuzzing
+  recommended.

--- a/electron/security/externalNavigation.ts
+++ b/electron/security/externalNavigation.ts
@@ -36,10 +36,8 @@ export function isAllowedWebviewUrl(input: unknown): boolean {
   if (!url) return false
   if (url.username || url.password) return false
 
-  if (url.protocol === 'https:') return true
-  if (isLocalHttpUrl(url)) return true
-
-  // Browser and tool preview webviews may need plain HTTP during local
-  // development, but only after rejecting credentialed and non-network schemes.
-  return url.protocol === 'http:'
+  // Only https, or plain http to loopback (local dev/tool previews). Remote
+  // http is rejected — an embedded cleartext page is both downgradeable and a
+  // needless RCE/credential-leak surface.
+  return url.protocol === 'https:' || isLocalHttpUrl(url)
 }

--- a/electron/services/SeekerRelayService.ts
+++ b/electron/services/SeekerRelayService.ts
@@ -38,6 +38,8 @@ export interface SeekerRelayEvent {
 export interface SeekerSession {
   id: string
   pairingCode: string
+  /** High-entropy bearer secret delivered to the paired device via the deep link/QR. */
+  accessToken: string
   relayUrl: string
   deepLink: string
   projectId: string | null
@@ -73,12 +75,12 @@ let externalRelayStatus: SeekerRelayStatus | null = null
 const sessions = new Map<string, SeekerSession>()
 
 function json(res: ServerResponse, statusCode: number, payload: unknown) {
+  // No CORS allow-origin: the relay serves the native app, not browsers. Browser
+  // preflight will fail by design (see hasBrowserOrigin guard).
   res.writeHead(statusCode, {
     'content-type': 'application/json; charset=utf-8',
-    'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,POST,PATCH,OPTIONS',
-    'access-control-allow-headers': 'content-type',
     'cache-control': 'no-store',
+    'x-content-type-options': 'nosniff',
   })
   res.end(JSON.stringify(payload))
 }
@@ -150,9 +152,37 @@ function makePairingCode() {
   return `DMN-${segment}-${suffix}`
 }
 
-function makeDeepLink(pairingCode: string, relayUrl: string, projectName: string) {
-  const params = new URLSearchParams({ code: pairingCode, relay: relayUrl, project: projectName })
+function makeAccessToken() {
+  return crypto.randomBytes(32).toString('hex')
+}
+
+function makeDeepLink(pairingCode: string, accessToken: string, relayUrl: string, projectName: string) {
+  const params = new URLSearchParams({ code: pairingCode, token: accessToken, relay: relayUrl, project: projectName })
   return `daemonseeker://pair?${params.toString()}`
+}
+
+/** Constant-time bearer check against the session token. */
+function isAuthorizedForSession(req: IncomingMessage, session: SeekerSession): boolean {
+  const header = req.headers['authorization']
+  const presented = typeof header === 'string' && header.startsWith('Bearer ')
+    ? header.slice('Bearer '.length).trim()
+    : ''
+  if (!presented || presented.length !== session.accessToken.length) return false
+  try {
+    return crypto.timingSafeEqual(Buffer.from(presented), Buffer.from(session.accessToken))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Reject requests that carry a browser Origin header. The relay is for the
+ * native Seeker app (which sends no Origin); a web page must not reach it even
+ * if it learns the LAN address.
+ */
+function hasBrowserOrigin(req: IncomingMessage): boolean {
+  const origin = req.headers['origin']
+  return typeof origin === 'string' && origin.length > 0
 }
 
 function defaultProjectSnapshot(projectName: string): SeekerProjectSnapshot {
@@ -283,6 +313,8 @@ function recordMobileEvent(event: SeekerRelayEvent) {
 }
 
 async function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  // Block web pages outright — the native app sends no Origin.
+  if (hasBrowserOrigin(req)) return json(res, 403, { ok: false, error: 'Forbidden' })
   if (req.method === 'OPTIONS') return json(res, 204, {})
   const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
 
@@ -290,7 +322,10 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse) {
     return json(res, 200, { ok: true, data: getRelayStatus() })
   }
 
+  // The session LIST exposes every session's snapshot — keep it to the desktop
+  // (loopback) only; the LAN-reachable phone uses the token-scoped endpoints.
   if (req.method === 'GET' && url.pathname === '/api/seeker/sessions') {
+    if (!isLoopbackRequest(req)) return json(res, 403, { ok: false, error: 'Forbidden' })
     return json(res, 200, { ok: true, data: listSessions() })
   }
 
@@ -308,7 +343,11 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse) {
   if (req.method === 'GET' && sessionMatch) {
     const pairingCode = decodeURIComponent(sessionMatch[1])
     const session = getSessionOrNull(pairingCode)
-    if (!session) return json(res, 404, { ok: false, error: 'Pairing session not found or expired' })
+    // Generic 404 (not 401/403) so the token-gated endpoints don't reveal which
+    // pairing codes exist to a brute-forcing LAN client.
+    if (!session || !isAuthorizedForSession(req, session)) {
+      return json(res, 404, { ok: false, error: 'Pairing session not found or expired' })
+    }
     return json(res, 200, snapshotForMobile(session))
   }
 
@@ -316,6 +355,10 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse) {
   if (req.method === 'POST' && approvalAddMatch) {
     try {
       const pairingCode = decodeURIComponent(approvalAddMatch[1])
+      const session = getSessionOrNull(pairingCode)
+      if (!session || !isAuthorizedForSession(req, session)) {
+        return json(res, 404, { ok: false, error: 'Pairing session not found or expired' })
+      }
       const body = await readBody(req) as Omit<SeekerApprovalRequest, 'id' | 'status' | 'createdAt'> & Partial<Pick<SeekerApprovalRequest, 'id' | 'status' | 'createdAt'>>
       return json(res, 200, { ok: true, data: addApproval(pairingCode, body) })
     } catch (error) {
@@ -327,6 +370,10 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse) {
   if ((req.method === 'POST' || req.method === 'PATCH') && approvalStatusMatch) {
     try {
       const pairingCode = decodeURIComponent(approvalStatusMatch[1])
+      const session = getSessionOrNull(pairingCode)
+      if (!session || !isAuthorizedForSession(req, session)) {
+        return json(res, 404, { ok: false, error: 'Pairing session not found or expired' })
+      }
       const approvalId = decodeURIComponent(approvalStatusMatch[2])
       const body = await readBody(req) as { status?: unknown }
       if (!isApprovalStatus(body.status)) return json(res, 400, { ok: false, error: 'Invalid approval status' })
@@ -340,15 +387,24 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse) {
     try {
       const body = await readBody(req) as Partial<SeekerRelayEvent>
       if (!body.type || !body.sessionCode) return json(res, 400, { ok: false, error: 'Missing event type or sessionCode' })
-      const session = recordMobileEvent(body as SeekerRelayEvent)
-      if (!session) return json(res, 404, { ok: false, error: 'Pairing session not found or expired' })
-      return json(res, 200, { ok: true, data: snapshotForMobile(session) })
+      const session = getSessionOrNull(body.sessionCode)
+      if (!session || !isAuthorizedForSession(req, session)) {
+        return json(res, 404, { ok: false, error: 'Pairing session not found or expired' })
+      }
+      const updated = recordMobileEvent(body as SeekerRelayEvent)
+      if (!updated) return json(res, 404, { ok: false, error: 'Pairing session not found or expired' })
+      return json(res, 200, { ok: true, data: snapshotForMobile(updated) })
     } catch (error) {
       return json(res, 400, { ok: false, error: error instanceof Error ? error.message : 'Invalid request' })
     }
   }
 
   return notFound(res)
+}
+
+function isLoopbackRequest(req: IncomingMessage): boolean {
+  const addr = req.socket.remoteAddress ?? ''
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1'
 }
 
 export async function startRelayServer(port = DEFAULT_PORT): Promise<SeekerRelayStatus> {
@@ -427,13 +483,15 @@ export async function createPairingSession(input: {
   const status = await startRelayServer()
   const projectName = input.projectName?.trim() || input.project?.name || 'Daemon Project'
   const pairingCode = makePairingCode()
+  const accessToken = makeAccessToken()
   const relayUrl = status.lanUrl
   const now = Date.now()
   const session: SeekerSession = {
     id: crypto.randomUUID(),
     pairingCode,
+    accessToken,
     relayUrl,
-    deepLink: makeDeepLink(pairingCode, relayUrl, projectName),
+    deepLink: makeDeepLink(pairingCode, accessToken, relayUrl, projectName),
     projectId: input.projectId ?? null,
     projectPath: input.projectPath ?? null,
     projectName,

--- a/test/security/ExternalNavigation.test.ts
+++ b/test/security/ExternalNavigation.test.ts
@@ -21,12 +21,14 @@ describe('external navigation security policy', () => {
     await expect(openSafeExternalUrl('javascript:alert(1)')).resolves.toBe(false)
   })
 
-  it('keeps webviews on network URLs and rejects privileged schemes or credentials', async () => {
+  it('allows https and loopback http webviews, rejects remote http, credentials, and privileged schemes', async () => {
     const { isAllowedWebviewUrl } = await import('../../electron/security/externalNavigation')
 
     expect(isAllowedWebviewUrl('https://docs.daemon.test')).toBe(true)
     expect(isAllowedWebviewUrl('http://localhost:5173')).toBe(true)
-    expect(isAllowedWebviewUrl('http://example.com')).toBe(true)
+    expect(isAllowedWebviewUrl('http://127.0.0.1:5173')).toBe(true)
+    // Remote cleartext http is no longer embeddable.
+    expect(isAllowedWebviewUrl('http://example.com')).toBe(false)
     expect(isAllowedWebviewUrl('https://user:pass@example.com')).toBe(false)
     expect(isAllowedWebviewUrl('javascript:alert(1)')).toBe(false)
     expect(isAllowedWebviewUrl('file:///C:/secret.txt')).toBe(false)

--- a/test/services/SeekerRelayService.test.ts
+++ b/test/services/SeekerRelayService.test.ts
@@ -1,6 +1,31 @@
 import http, { type Server } from 'node:http'
 import { afterEach, describe, expect, it } from 'vitest'
-import { startRelayServer, stopRelayServer } from '../../electron/services/SeekerRelayService'
+import {
+  startRelayServer,
+  stopRelayServer,
+  createPairingSession,
+  getRelayStatus,
+} from '../../electron/services/SeekerRelayService'
+
+async function request(
+  port: number,
+  path: string,
+  init: { method?: string; token?: string; origin?: string; body?: unknown } = {},
+) {
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (init.token) headers['authorization'] = `Bearer ${init.token}`
+  if (init.origin) headers['origin'] = init.origin
+  const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+    method: init.method ?? 'GET',
+    headers,
+    body: init.body != null ? JSON.stringify(init.body) : undefined,
+  })
+  return { status: res.status, json: await res.json().catch(() => null) as { ok?: boolean } | null }
+}
+
+function tokenFromDeepLink(deepLink: string): string {
+  return new URL(deepLink).searchParams.get('token') ?? ''
+}
 
 describe('SeekerRelayService', () => {
   let external: Server | null = null
@@ -40,5 +65,40 @@ describe('SeekerRelayService', () => {
     expect(status.running).toBe(true)
     expect(status.port).toBe(address.port)
     expect(status.sessionCount).toBe(2)
+  })
+
+  describe('session authorization', () => {
+    it('requires a bearer token on session-scoped endpoints and rejects browser origins', async () => {
+      const snapshot = await createPairingSession({ projectName: 'Sec Test', seedDemoApprovals: false })
+      const code = snapshot.session.pairingCode
+      const token = tokenFromDeepLink(snapshot.session.deepLink)
+      const port = getRelayStatus().port
+
+      expect(token).toMatch(/^[0-9a-f]{64}$/)
+
+      // No token → 404 (does not confirm the code exists).
+      const noToken = await request(port, `/api/seeker/session/${encodeURIComponent(code)}`)
+      expect(noToken.status).toBe(404)
+
+      // Wrong token → 404.
+      const wrongToken = await request(port, `/api/seeker/session/${encodeURIComponent(code)}`, { token: 'deadbeef'.repeat(8) })
+      expect(wrongToken.status).toBe(404)
+
+      // Correct token → 200 with the mobile snapshot shape.
+      const ok = await request(port, `/api/seeker/session/${encodeURIComponent(code)}`, { token })
+      expect(ok.status).toBe(200)
+      expect((ok.json as { session?: unknown } | null)?.session).toBeTruthy()
+
+      // A browser Origin is forbidden even with the right token.
+      const browser = await request(port, `/api/seeker/session/${encodeURIComponent(code)}`, { token, origin: 'https://evil.example.com' })
+      expect(browser.status).toBe(403)
+
+      // Approving an approval without the token is rejected.
+      const unauth = await request(port, `/api/seeker/session/${encodeURIComponent(code)}/approvals`, {
+        method: 'POST',
+        body: { title: 'x', description: 'y', risk: 'low', source: 'agent' },
+      })
+      expect(unauth.status).toBe(404)
+    })
   })
 })


### PR DESCRIPTION
## Priority 2 — Electron RCE surface

Stacked on #178. Full analysis in `docs/security/SECURITY_AUDIT.md`.

### Fixed
- **Seeker relay auth (CONFIRMED vuln)** — `SeekerRelayService` binds `0.0.0.0` (phone reaches it over LAN) but the pairing code was only ~6 chars (≈5.9M combos) on an unauthenticated, rate-limit-free server with `CORS: *`. A LAN attacker could brute-force a code and POST `approved` to approval endpoints. Fix: 32-byte per-session **bearer token** (delivered via the pairing deep link, constant-time compared) required on every session-scoped endpoint; unauthorized → generic 404; dropped `CORS: *` and reject any browser `Origin`; `/sessions` list is loopback-only.
- **Webview http** — `isAllowedWebviewUrl` now allows only `https` + loopback `http`, rejecting remote cleartext pages as `<webview>` embeds.

### Already mitigated (documented)
- Preload is method-per-channel (no generic `invoke` passthrough); strict prod CSP; `shell.openExternal` gated to https+loopback.

### Reviewed / residual
- Repo build/run is user-driven in the PTY; a key-free network-restricted repo worker is an architectural follow-up. `imapflow`/`nodemailer` use structured APIs (no shell concatenation).
- **Mobile follow-up**: `apps/seeker-mobile` must send `Authorization: Bearer <token>` from the deep-link `token` param.

### Tests
- `test/services/SeekerRelayService.test.ts`: no-token/wrong-token/browser-origin/unauth-approval rejected; correct token accepted.
- `test/security/ExternalNavigation.test.ts`: remote http now rejected.
- `tsc` clean; security suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)