### PR TITLE
ci: suppress non-applicable vitest UI advisory in OSV scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,13 @@ jobs:
       - name: Install Linux UI test dependencies
         run: sudo apt-get update && sudo apt-get install -y xvfb
       # Disable lifecycle scripts on install (Shai-Hulud-class supply-chain
-      # defense); native modules are rebuilt explicitly afterward.
+      # defense); native modules and the Electron binary are set up explicitly.
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm run rebuild:native
+      # --ignore-scripts skips electron's postinstall binary download; run only
+      # electron's own install (not arbitrary lifecycle scripts) so tests that
+      # import electron can load.
+      - run: node node_modules/electron/install.js
       - name: OSV supply-chain scan (lockfile)
         uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
         with:
@@ -73,6 +77,7 @@ jobs:
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm run rebuild:native
+      - run: node node_modules/electron/install.js
       - run: pnpm run build
       - run: pnpm run test:visual
       - run: pnpm exec electron-builder --publish never
@@ -101,6 +106,7 @@ jobs:
             electron-cache-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm run rebuild:native
+      - run: node node_modules/electron/install.js
       - run: pnpm run build
       - name: Pre-cache Electron binary
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
         with:
           scan-args: |-
+            --config=osv-scanner.toml
             --lockfile=pnpm-lock.yaml
       - run: pnpm run typecheck
       - run: pnpm run lint:styles

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,14 @@
+# OSV scanner config — https://google.github.io/osv-scanner/configuration/
+# Suppressions are deliberate, justified exceptions. Everything not listed here
+# still fails CI. Review each entry by its `reviewBy` date.
+
+[[IgnoredVulns]]
+id = "GHSA-5xrq-8626-4rwp"  # CVE-2026-47429 — vitest < 4.1.0
+# Why ignored: the advisory only affects the Vitest UI server when it is exposed
+# to the network (--api.host) or when running Vitest UI / Browser Mode on Windows.
+# DAEMON runs vitest exclusively headless (`vitest run`) in CI and locally — no UI
+# server, no exposed API — so the app, its users, and the wallet are unaffected.
+# The fix landed only in vitest 4.1.0 (a major bump); upgrading is tracked
+# separately to avoid breaking the test suite on a release.
+ignoreUntil = 2026-09-01
+reason = "Dev-only: vitest UI/Browser-mode server not used; we run headless `vitest run`. Bump to vitest 4.x tracked post-release."

--- a/package.json
+++ b/package.json
@@ -174,6 +174,11 @@
         "@solana/kit": "6.9.0",
         "@solana/sysvars": "6.9.0"
       }
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-5xrq-8626-4rwp"
+      ]
     }
   }
 }


### PR DESCRIPTION
Unblocks the v4 release CI. The OSV scanner (added in #177) flagged **GHSA-5xrq-8626-4rwp / CVE-2026-47429** — a CVSS 9.8 in vitest < 4.1.0.

It only affects the **Vitest UI server exposed to the network** (`--api.host`) or **UI/Browser mode on Windows**. DAEMON runs headless `vitest run` — no UI server, no exposed API — so the app, its users, and the wallet are unaffected. The fix is only in vitest 4.1.0 (a major bump), tracked separately to avoid breaking the test suite on a release.

Suppressed in `osv-scanner.toml` with a written justification and a **2026-09-01 review date**. Every other advisory still fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)