### PR TITLE
ci: split build into separate tsc and vite steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,10 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm run rebuild:native
       - run: node node_modules/electron/install.js
-      - run: pnpm run build
+      # Split build = tsc && vite build into separate steps so the type-checker's
+      # heap is released before Rollup bundles, lowering peak memory.
+      - run: pnpm run typecheck
+      - run: pnpm exec vite build
       - run: pnpm run test:visual
       - run: pnpm exec electron-builder --publish never
 
@@ -112,7 +115,10 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm run rebuild:native
       - run: node node_modules/electron/install.js
-      - run: pnpm run build
+      # Split build = tsc && vite build into separate steps so the type-checker's
+      # heap is released before Rollup bundles, lowering peak memory.
+      - run: pnpm run typecheck
+      - run: pnpm exec vite build
       - name: Pre-cache Electron binary
         shell: bash
         run: |


### PR DESCRIPTION
Post-release CI hygiene follow-up.

Splits `pnpm run build` (`tsc && vite build`) into two distinct steps in the build jobs so the type-checker's heap is released before Rollup bundles, lowering peak memory. Complements the `--max-old-space-size=6144` headroom added when the macOS build OOM'd during the v4 release.

No product change: `tsconfig` is `noEmit`, so `tsc` only type-checks (no output); `vite build` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)