### PR TITLE
feat(welcome): recent projects on default canvas

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3'
-import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25, SCHEMA_V26, SCHEMA_V27, SCHEMA_V28, SCHEMA_V29, SCHEMA_V30, SCHEMA_V31, SCHEMA_V32, SCHEMA_V33, SCHEMA_V34, SCHEMA_V35, SCHEMA_V36, SCHEMA_V37, SCHEMA_V38, SCHEMA_V39, SCHEMA_V40, SCHEMA_V41, SCHEMA_V42, SCHEMA_V43, SCHEMA_V44 } from './schema'
+import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25, SCHEMA_V26, SCHEMA_V27, SCHEMA_V28, SCHEMA_V29, SCHEMA_V30, SCHEMA_V31, SCHEMA_V32, SCHEMA_V33, SCHEMA_V34, SCHEMA_V35, SCHEMA_V36, SCHEMA_V37, SCHEMA_V38, SCHEMA_V39, SCHEMA_V40, SCHEMA_V41, SCHEMA_V42, SCHEMA_V43, SCHEMA_V44, SCHEMA_V45 } from './schema'
 
 export function runMigrations(db: Database.Database) {
   db.exec(`
@@ -523,6 +523,19 @@ export function runMigrations(db: Database.Database) {
         }
       }
       db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(44)
+    })()
+  }
+
+  if (currentVersion < 45) {
+    db.transaction(() => {
+      const stmts = SCHEMA_V45.split(';').map((s) => s.trim()).filter(Boolean)
+      for (const stmt of stmts) {
+        try { db.exec(stmt) } catch (err) {
+          const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
+          if (!msg.includes('duplicate column') && !msg.includes('already exists')) throw err
+        }
+      }
+      db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(45)
     })()
   }
 

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -74,7 +74,9 @@ CREATE TABLE IF NOT EXISTS projects (
   aliases TEXT DEFAULT '[]',
   wallet_id TEXT,
   created_at INTEGER DEFAULT (CAST(unixepoch('now') * 1000 AS INTEGER)),
-  last_active INTEGER
+  last_active INTEGER,
+  pinned INTEGER NOT NULL DEFAULT 0,
+  branch TEXT
 );
 
 CREATE TABLE IF NOT EXISTS active_sessions (
@@ -1174,4 +1176,10 @@ CREATE TABLE IF NOT EXISTS forensic_bundle_wallet_index (
 );
 CREATE INDEX IF NOT EXISTS idx_forensic_bundle_wallet
   ON forensic_bundle_wallet_index(wallet);
+`
+
+export const SCHEMA_V45 = `
+ALTER TABLE projects ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE projects ADD COLUMN branch TEXT;
+CREATE INDEX IF NOT EXISTS idx_projects_pinned ON projects(pinned DESC, last_active DESC);
 `

--- a/electron/ipc/projects.ts
+++ b/electron/ipc/projects.ts
@@ -1,13 +1,45 @@
 import { ipcMain, dialog } from 'electron'
+import simpleGit from 'simple-git'
 import { getDb } from '../db/db'
 import { invalidatePathCache } from '../shared/pathValidation'
 import { ipcHandler } from '../services/IpcHandlerFactory'
-import type { ProjectCreateInput } from '../shared/types'
+import type { Project, ProjectCreateInput } from '../shared/types'
+
+/** Best-effort current branch; null when the path isn't a git repo or is gone. */
+async function resolveBranch(path: string): Promise<string | null> {
+  try {
+    const branch = await simpleGit(path).revparse(['--abbrev-ref', 'HEAD'])
+    return branch.trim() || null
+  } catch {
+    return null
+  }
+}
 
 export function registerProjectHandlers() {
   ipcMain.handle('projects:list', ipcHandler(async () => {
     const db = getDb()
-    return db.prepare('SELECT * FROM projects ORDER BY last_active DESC, created_at DESC').all()
+    const rows = db
+      .prepare('SELECT * FROM projects ORDER BY pinned DESC, last_active DESC, created_at DESC')
+      .all() as Project[]
+
+    // Refresh the cached branch for each project so the recents list stays accurate.
+    const updateBranch = db.prepare('UPDATE projects SET branch = ? WHERE id = ?')
+    await Promise.all(
+      rows.map(async (row) => {
+        const branch = await resolveBranch(row.path)
+        if (branch !== row.branch) {
+          updateBranch.run(branch, row.id)
+          row.branch = branch
+        }
+      })
+    )
+    return rows
+  }))
+
+  ipcMain.handle('projects:setPinned', ipcHandler(async (_event, input: { id: string; pinned: boolean }) => {
+    const db = getDb()
+    db.prepare('UPDATE projects SET pinned = ? WHERE id = ?').run(input.pinned ? 1 : 0, input.id)
+    return db.prepare('SELECT * FROM projects WHERE id = ?').get(input.id) as Project
   }))
 
   ipcMain.handle('projects:create', ipcHandler(async (_event, project: ProjectCreateInput) => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -499,6 +499,7 @@ contextBridge.exposeInMainWorld('daemon', {
     create: (project: { name: string; path: string }) => ipcRenderer.invoke('projects:create', project),
     delete: (id: string) => ipcRenderer.invoke('projects:delete', id),
     openDialog: () => ipcRenderer.invoke('projects:openDialog'),
+    setPinned: (input: { id: string; pinned: boolean }) => ipcRenderer.invoke('projects:setPinned', input),
   },
 
   shell: {

--- a/electron/shared/types.ts
+++ b/electron/shared/types.ts
@@ -224,6 +224,8 @@ export interface Project {
   wallet_id: string | null
   created_at: number
   last_active: number | null
+  pinned: number
+  branch: string | null
 }
 
 export interface Agent {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
       "brace-expansion": "5.0.6",
       "dompurify": "3.4.0",
       "esbuild": "0.25.12",
-      "hono": "4.12.18",
+      "hono": "4.12.21",
       "lodash": "4.18.1",
       "follow-redirects": "1.16.0",
       "postcss": "8.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   brace-expansion: 5.0.6
   dompurify: 3.4.0
   esbuild: 0.25.12
-  hono: 4.12.18
+  hono: 4.12.21
   lodash: 4.18.1
   follow-redirects: 1.16.0
   postcss: 8.5.10
@@ -69,7 +69,7 @@ importers:
         version: 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/mpp':
         specifier: ^0.5.2
-        version: 0.5.2(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(mppx@0.5.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))
+        version: 0.5.2(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(mppx@0.5.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(hono@4.12.21)(typescript@5.9.3)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))
       '@solana/spl-token':
         specifier: ^0.4.9
         version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1199,7 +1199,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -4298,8 +4298,8 @@ packages:
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -5050,7 +5050,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: 4.12.18
+      hono: 4.12.21
       viem: '>=2.47.5'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -7835,9 +7835,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
     optional: true
 
   '@isaacs/fs-minipass@4.0.1':
@@ -8038,7 +8038,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.21)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -8048,7 +8048,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.21
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9036,13 +9036,13 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/mpp@0.5.2(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(mppx@0.5.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))':
+  '@solana/mpp@0.5.2(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(mppx@0.5.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(hono@4.12.21)(typescript@5.9.3)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))':
     dependencies:
       '@solana-program/compute-budget': 0.15.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana-program/system': 0.12.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana-program/token': 0.11.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/kit': 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      mppx: 0.5.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      mppx: 0.5.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(hono@4.12.21)(typescript@5.9.3)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
 
   '@solana/nominal-types@6.9.0(typescript@5.9.3)':
     optionalDependencies:
@@ -11501,7 +11501,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.35.0
 
-  hono@4.12.18:
+  hono@4.12.21:
     optional: true
 
   hosted-git-info@4.1.0:
@@ -12444,7 +12444,7 @@ snapshots:
       dompurify: 3.4.0
       marked: 14.0.0
 
-  mppx@0.5.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)):
+  mppx@0.5.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(hono@4.12.21)(typescript@5.9.3)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.3
@@ -12455,7 +12455,7 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       express: 5.2.1
-      hono: 4.12.18
+      hono: 4.12.21
     transitivePeerDependencies:
       - typescript
 

--- a/src/panels/Editor/Editor.css
+++ b/src/panels/Editor/Editor.css
@@ -95,92 +95,352 @@
   color: var(--t3);
 }
 
-.editor-empty-actions {
+/* ── Fused 3-up action row ─────────────────────────────────────────────── */
+.editor-empty-actionrow {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-sm);
-  width: min(640px, 100%);
+  gap: 1px;
+  width: min(600px, 100%);
   margin-top: var(--space-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--border);
+  overflow: hidden;
 }
 
-.editor-empty-template {
+.editor-empty-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: var(--space-sm);
   min-width: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--surface-raised);
+  min-height: 44px;
+  padding: 0 var(--space-md);
+  border: none;
+  background: var(--s1);
   color: var(--t2);
-  transition: border-color 120ms ease, background 120ms ease, color 120ms ease, transform 120ms ease;
+  font-size: var(--type-item-title-size);
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
 }
 
-.editor-empty-btn {
-  width: 100%;
-}
-
-.editor-empty-btn svg,
-.editor-empty-template svg {
+.editor-empty-action svg {
   flex: 0 0 auto;
 }
 
-.editor-empty-template:hover {
-  border-color: var(--border-hover);
-  background: var(--surface-floating);
+.editor-empty-action:hover {
+  background: var(--s2);
   color: var(--t1);
 }
 
-.editor-empty-btn:focus-visible,
-.editor-empty-template:focus-visible,
-.editor-empty-more:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+.editor-empty-action--primary {
+  background: var(--accent-fill);
+  color: var(--green);
 }
 
-.editor-empty-starter {
-  display: grid;
-  gap: var(--space-md);
-  width: min(520px, 100%);
-  margin-top: var(--space-md);
+.editor-empty-action--primary svg {
+  color: var(--green);
 }
 
-.editor-empty-starter-label {
+.editor-empty-action--primary:hover {
+  background: color-mix(in srgb, var(--green-glow) 80%, var(--s2));
+  color: var(--green);
+}
+
+.editor-empty-action-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.editor-empty-action-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  padding: 2px 5px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
   color: var(--t3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  line-height: 1;
+}
+
+.editor-empty-action:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--green-glow), inset 0 0 0 1px var(--green);
+}
+
+/* ── Recent projects ───────────────────────────────────────────────────── */
+.editor-empty-recents {
+  display: grid;
+  gap: var(--space-sm);
+  width: min(600px, 100%);
+  margin-top: var(--space-lg);
+}
+
+.editor-empty-recents-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.editor-empty-recents-label {
+  color: var(--t3);
+  font-family: var(--font-mono);
   font-size: var(--fs-10);
   font-weight: 700;
   letter-spacing: 1.4px;
   text-transform: uppercase;
 }
 
-.editor-empty-templates {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--space-sm);
+.editor-empty-recents-viewall {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  cursor: pointer;
+  transition: color 120ms ease;
 }
 
-.editor-empty-template {
-  min-height: 48px;
-  gap: var(--space-sm);
-  padding: 0 var(--space-md);
+.editor-empty-recents-viewall:hover {
+  color: var(--green);
+}
+
+.editor-empty-recents-viewall:focus-visible {
+  outline: none;
+  color: var(--green);
+}
+
+.editor-empty-recents-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--s1);
   overflow: hidden;
-  font-size: var(--type-item-title-size);
-  font-weight: 600;
+}
+
+.editor-empty-recent-row {
+  display: flex;
+  align-items: stretch;
+  border-top: 1px solid var(--border);
+}
+
+.editor-empty-recent-row:first-child {
+  border-top: none;
+}
+
+.editor-empty-recent-open {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-width: 0;
+  height: 46px;
+  padding: 0 var(--space-md);
+  border: none;
+  background: transparent;
+  color: var(--t2);
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.editor-empty-recent-open:hover {
+  background: var(--s2);
+  color: var(--t1);
+}
+
+.editor-empty-recent-open:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--green-glow), inset 0 0 0 1px var(--green);
+}
+
+.editor-empty-recent-folder {
+  flex: 0 0 auto;
+  color: var(--t3);
+}
+
+.editor-empty-recent-name {
+  flex: 0 0 auto;
+  max-width: 180px;
+  overflow: hidden;
+  color: var(--t1);
+  font-size: var(--fs-13);
+  font-weight: 500;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
-.editor-empty-template:hover {
-  border-color: color-mix(in srgb, var(--tmpl-color, var(--green)) 42%, var(--border));
-  background: color-mix(in srgb, var(--tmpl-glow, var(--green-glow)) 70%, var(--s2) 30%);
+.editor-empty-recent-branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  max-width: 140px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
-.editor-empty-more {
-  justify-self: start;
-  padding-inline: 0;
+.editor-empty-recent-branch svg {
+  flex: 0 0 auto;
+  opacity: 0.8;
+}
+
+.editor-empty-recent-spacer {
+  flex: 1 1 auto;
+  min-width: var(--space-md);
+}
+
+.editor-empty-recent-path {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  text-align: right;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.editor-empty-recent-time {
+  flex: 0 0 auto;
+  color: var(--t3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+}
+
+.editor-empty-recent-pin {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  border: none;
+  background: transparent;
+  color: var(--t3);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease, color 120ms ease;
+}
+
+.editor-empty-recent-row:hover .editor-empty-recent-pin,
+.editor-empty-recent-pin:focus-visible {
+  opacity: 1;
+}
+
+.editor-empty-recent-pin:hover {
+  color: var(--t1);
+}
+
+.editor-empty-recent-pin:focus-visible {
+  outline: none;
+  color: var(--amber);
+}
+
+.editor-empty-recent-row.is-pinned .editor-empty-recent-pin {
+  opacity: 1;
+  color: var(--amber);
+}
+
+/* ── Start building (demoted) ──────────────────────────────────────────── */
+.editor-empty-start {
+  display: grid;
+  gap: var(--space-sm);
+  width: min(600px, 100%);
+  margin-top: var(--space-lg);
+}
+
+.editor-empty-start-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.editor-empty-starter-label {
+  color: var(--t3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  font-weight: 700;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+}
+
+.editor-empty-start-more {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.editor-empty-start-more:hover,
+.editor-empty-start-more:focus-visible {
+  outline: none;
+  color: var(--green);
+}
+
+.editor-empty-start-chips {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-sm);
+}
+
+.editor-empty-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 38px;
+  padding: 0 var(--space-sm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  color: var(--t2);
+  font-size: var(--fs-12);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.editor-empty-chip svg {
+  flex: 0 0 auto;
+}
+
+.editor-empty-chip:hover {
+  border-color: color-mix(in srgb, var(--tmpl-color, var(--green)) 42%, var(--border));
+  background: color-mix(in srgb, var(--tmpl-glow, var(--green-glow)) 70%, var(--s2) 30%);
+  color: var(--t1);
+}
+
+.editor-empty-chip:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 @media (max-width: 900px) {
-  .editor-empty-actions {
+  .editor-empty-actionrow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .editor-empty-start-chips {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -196,13 +456,16 @@
     height: 40px;
   }
 
-  .editor-empty-actions,
-  .editor-empty-templates {
+  .editor-empty-actionrow {
     grid-template-columns: 1fr;
   }
 
-  .editor-empty-template {
-    justify-content: flex-start;
+  .editor-empty-recent-path {
+    display: none;
+  }
+
+  .editor-empty-recent-pin {
+    opacity: 1;
   }
 }
 

--- a/src/panels/Editor/EditorWelcome.tsx
+++ b/src/panels/Editor/EditorWelcome.tsx
@@ -1,33 +1,70 @@
-import { useRef, useState, useCallback, useEffect } from 'react'
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react'
 import { useUIStore } from '../../store/ui'
 import { useAppActions } from '../../store/appActions'
-import { Button } from '../../components/Button'
 import { DaemonMark } from '../../components/DaemonMark'
-import { Surface } from '../../components/Panel/Surface'
 import { EDITOR_WELCOME_TEMPLATE_COLORS } from '../../styles/daemonTheme'
+import type { Project } from '../../../electron/shared/types'
 
 interface EditorWelcomeProps {
   activeProjectId: string | null
 }
 
+/** A project surfaced in the RECENT PROJECTS list on the default canvas. */
+interface RecentProject {
+  id: string
+  name: string
+  path: string
+  /** Git branch for the branch chip. TODO: branch is not yet stored on Project —
+   *  derive it (e.g. via window.daemon.git.branch on workspace open) and persist it. */
+  branch: string | null
+  /** Epoch ms of last activity; drives ordering and the "last opened" label. */
+  lastActive: number | null
+}
+
+/** Abbreviate an absolute path with ~ and forward slashes for display. */
+function formatHomePath(path: string): string {
+  const normalized = path.replace(/\\/g, '/')
+  return normalized.replace(/^([A-Za-z]:)?\/Users\/[^/]+/, '~')
+}
+
+/** Compact relative "last opened" label (e.g. "3d", "2h", "just now"). */
+function formatLastOpened(epochMs: number | null): string {
+  if (!epochMs) return ''
+  const diff = Date.now() - epochMs
+  if (diff < 60_000) return 'just now'
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d`
+  const weeks = Math.floor(days / 7)
+  if (weeks < 5) return `${weeks}w`
+  return `${Math.floor(days / 30)}mo`
+}
+
+const RECENTS_LIMIT = 5
+
 const QUICK_TEMPLATES = [
-  { id: 'anchor-program', name: 'Anchor Program', icon: 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4', color: EDITOR_WELCOME_TEMPLATE_COLORS.blue },
-  { id: 'trading-bot', name: 'Trading Bot', icon: 'M13 7h8m0 0v8m0-8l-8 8-4-4-6 6', color: EDITOR_WELCOME_TEMPLATE_COLORS.amber },
+  { id: 'anchor-program', name: 'Anchor program', icon: 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4', color: EDITOR_WELCOME_TEMPLATE_COLORS.blue },
+  { id: 'trading-bot', name: 'Trading bot', icon: 'M13 7h8m0 0v8m0-8l-8 8-4-4-6 6', color: EDITOR_WELCOME_TEMPLATE_COLORS.amber },
   { id: 'dapp-nextjs', name: 'dApp', icon: 'M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9', color: EDITOR_WELCOME_TEMPLATE_COLORS.violet },
-  { id: 'meme-coin-website', name: 'Meme Website', icon: 'M12 2l2.4 6.2L21 9l-5 4.1L17.5 20 12 16.4 6.5 20 8 13.1 3 9l6.6-.8L12 2z', color: EDITOR_WELCOME_TEMPLATE_COLORS.pink },
+  { id: 'meme-coin-website', name: 'Meme site', icon: 'M12 2l2.4 6.2L21 9l-5 4.1L17.5 20 12 16.4 6.5 20 8 13.1 3 9l6.6-.8L12 2z', color: EDITOR_WELCOME_TEMPLATE_COLORS.pink },
 ]
 
 export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
   const addTerminal = useUIStore((s) => s.addTerminal)
   const activeProjectPath = useUIStore((s) => s.activeProjectPath)
   const projects = useUIStore((s) => s.projects)
-  const terminals = useUIStore((s) => s.terminals)
   const [isEmptyDragOver, setIsEmptyDragOver] = useState(false)
   const [gitBranch, setGitBranch] = useState<string | null>(null)
+  // Pinned project ids. TODO: persist favorites (e.g. projects:pin IPC + DB column)
+  // so sticky order survives reloads; local state keeps them sticky this session.
+  const [pinnedIds, setPinnedIds] = useState<Set<string>>(() => new Set())
   const emptyDragDepthRef = useRef(0)
 
   const activeProject = projects.find((p) => p.id === activeProjectId)
-  const terminalCount = terminals.filter((t) => t.projectId === activeProjectId).length
+  const displayPath = activeProjectPath ? formatHomePath(activeProjectPath) : activeProject?.name ?? 'Project'
 
   // Load git branch for context
   useEffect(() => {
@@ -36,6 +73,25 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
       setGitBranch(res.ok ? res.data as string : null)
     })
   }, [activeProjectPath])
+
+  const toRecent = useCallback((p: Project): RecentProject => ({
+    id: p.id,
+    name: p.name,
+    path: p.path,
+    branch: null, // TODO: surface real branch once stored on Project
+    lastActive: p.last_active ?? p.created_at,
+  }), [])
+
+  // Recents: pinned first (sticky), then most-recently-active, truncated for the canvas.
+  const recents = useMemo<RecentProject[]>(() => {
+    const sorted = [...projects].sort((a, b) => {
+      const aPinned = pinnedIds.has(a.id)
+      const bPinned = pinnedIds.has(b.id)
+      if (aPinned !== bPinned) return aPinned ? -1 : 1
+      return (b.last_active ?? b.created_at) - (a.last_active ?? a.created_at)
+    })
+    return sorted.slice(0, RECENTS_LIMIT).map(toRecent)
+  }, [projects, pinnedIds, toRecent])
 
   const handleEmptyDrop = useCallback(async (e: React.DragEvent) => {
     e.preventDefault()
@@ -88,8 +144,25 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
     }
   }, [])
 
-  const handleOpenAgentStation = useCallback(() => {
-    useUIStore.getState().openWorkspaceTool('agent-station')
+  const handleCloneRepo = useCallback(() => {
+    useUIStore.getState().openWorkspaceTool('starter')
+  }, [])
+
+  const handleOpenRecent = useCallback((project: RecentProject) => {
+    useUIStore.getState().setActiveProject(project.id, project.path)
+  }, [])
+
+  const handleViewAll = useCallback(() => {
+    useUIStore.getState().openWorkspaceTool('starter')
+  }, [])
+
+  const handleTogglePin = useCallback((id: string) => {
+    setPinnedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
   }, [])
 
   const handleOpenTerminal = useCallback(() => {
@@ -119,140 +192,136 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
       <div className="editor-empty-glow" />
       <DaemonMark className="editor-empty-logo" />
       <span className="editor-empty-eyebrow">Operator workbench</span>
-      <h1 className="editor-empty-title">DAEMON</h1>
+      <h1 className="editor-empty-title">daemon</h1>
+
+      <span className="editor-empty-tagline">
+        {activeProjectId ? displayPath : 'No workspace'}
+        {activeProjectId && gitBranch && <span className="editor-empty-branch"> ({gitBranch})</span>}
+        <span className="editor-empty-tagline-sep"> · </span>
+        <span className="editor-empty-tagline-muted">no file open</span>
+      </span>
 
       {isEmptyDragOver ? (
         <span className="editor-empty-drop-hint">Drop folder to open terminal</span>
-      ) : activeProjectId ? (
-        <>
-          {/* Dynamic project context */}
-          <span className="editor-empty-tagline">
-            {activeProject?.name ?? 'Project'}
-            {gitBranch && <span className="editor-empty-branch"> ({gitBranch})</span>}
-          </span>
-
-          <div className="editor-empty-actions">
-            <Button className="editor-empty-btn" variant="secondary" size="lg" onClick={handleOpenFileExplorer}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
-                <polyline points="13 2 13 9 20 9"/>
-              </svg>
-              Open File
-            </Button>
-            <Button className="editor-empty-btn" variant="primary" size="lg" onClick={handleLaunchAgent}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="9"/>
-                <line x1="12" y1="8" x2="12" y2="16"/>
-                <line x1="8" y1="12" x2="16" y2="12"/>
-              </svg>
-              Launch Agent
-            </Button>
-            {terminalCount > 0 ? (
-              <Button className="editor-empty-btn" variant="secondary" size="lg" onClick={handleOpenTerminal}>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
-                </svg>
-                {terminalCount} Terminal{terminalCount !== 1 ? 's' : ''}
-              </Button>
-            ) : (
-              <Button className="editor-empty-btn" variant="secondary" size="lg" onClick={() => useUIStore.getState().openWorkspaceTool('settings')}>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="12" cy="12" r="3"/>
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
-                </svg>
-                Settings
-              </Button>
-            )}
-          </div>
-
-          <Surface variant="feature" padding="md" className="editor-empty-starter">
-            <span className="editor-empty-starter-label">Start building</span>
-            <div className="editor-empty-templates">
-              {QUICK_TEMPLATES.map((t) => (
-                <button
-                  type="button"
-                  key={t.id}
-                  className="editor-empty-template"
-                  style={{ '--tmpl-color': t.color, '--tmpl-glow': `${t.color}15` } as React.CSSProperties}
-                  onClick={handleNewProject}
-                >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke={t.color}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d={t.icon} />
-                  </svg>
-                  {t.name}
-                </button>
-              ))}
-            </div>
-            <Button className="editor-empty-more" variant="ghost" size="sm" onClick={handleNewProject}>
-              More templates -&gt;
-            </Button>
-          </Surface>
-        </>
       ) : (
         <>
-          <span className="editor-empty-tagline">Create a project, open a folder, or start from a scaffold.</span>
-
-          <div className="editor-empty-actions">
-            <Button className="editor-empty-btn" variant="secondary" size="lg" onClick={handleOpenProject}>
+          {/* Fused 3-up action row: shared border, hairline gaps. */}
+          <div className="editor-empty-actionrow" role="group" aria-label="Workspace actions">
+            <button type="button" className="editor-empty-action" onClick={handleOpenProject}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M4 4h6l2 3h8v13H4z" />
               </svg>
-              Open Project
-            </Button>
-            <Button className="editor-empty-btn" variant="primary" size="lg" onClick={handleNewProject}>
+              <span className="editor-empty-action-label">Open folder</span>
+              <kbd className="editor-empty-action-kbd">⌘O</kbd>
+            </button>
+            <button type="button" className="editor-empty-action editor-empty-action--primary" onClick={handleLaunchAgent}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M12 5v14M5 12h14" />
+                <circle cx="12" cy="12" r="9" />
+                <line x1="12" y1="8" x2="12" y2="16" />
+                <line x1="8" y1="12" x2="16" y2="12" />
               </svg>
-              New Project
-            </Button>
-            <Button className="editor-empty-btn" variant="secondary" size="lg" onClick={handleOpenAgentStation}>
+              <span className="editor-empty-action-label">Launch agent</span>
+            </button>
+            <button type="button" className="editor-empty-action" onClick={handleCloneRepo}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M6 8h12M6 16h12M8 4h8v16H8z" />
+                <path d="M6 3v12" /><circle cx="6" cy="18" r="3" /><circle cx="6" cy="3" r="0.5" />
+                <circle cx="18" cy="6" r="3" /><path d="M18 9a9 9 0 0 1-9 9" />
               </svg>
-              Agent Station
-            </Button>
+              <span className="editor-empty-action-label">Clone repo</span>
+            </button>
           </div>
 
-          <Surface variant="feature" padding="md" className="editor-empty-starter">
-            <span className="editor-empty-starter-label">Scaffold</span>
-            <div className="editor-empty-templates">
+          {/* RECENT PROJECTS — the anchor of the canvas. */}
+          {recents.length > 0 && (
+            <section className="editor-empty-recents" aria-label="Recent projects">
+              <div className="editor-empty-recents-head">
+                <span className="editor-empty-recents-label">Recent projects</span>
+                <button type="button" className="editor-empty-recents-viewall" onClick={handleViewAll}>
+                  View all ({projects.length}) <span aria-hidden="true">→</span>
+                </button>
+              </div>
+              <ul className="editor-empty-recents-list">
+                {recents.map((project) => {
+                  const isPinned = pinnedIds.has(project.id)
+                  return (
+                    <li key={project.id} className={`editor-empty-recent-row ${isPinned ? 'is-pinned' : ''}`}>
+                      <button
+                        type="button"
+                        className="editor-empty-recent-open"
+                        onClick={() => handleOpenRecent(project)}
+                      >
+                        <svg className="editor-empty-recent-folder" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M4 4h6l2 3h8v13H4z" />
+                        </svg>
+                        <span className="editor-empty-recent-name">{project.name}</span>
+                        {project.branch && (
+                          <span className="editor-empty-recent-branch">
+                            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                              <circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="6" r="3" />
+                              <path d="M6 9v6M18 9a9 9 0 0 1-9 9" />
+                            </svg>
+                            {project.branch}
+                          </span>
+                        )}
+                        <span className="editor-empty-recent-spacer" />
+                        <span className="editor-empty-recent-path">{formatHomePath(project.path)}</span>
+                        <span className="editor-empty-recent-time">{formatLastOpened(project.lastActive)}</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="editor-empty-recent-pin"
+                        aria-label={isPinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
+                        aria-pressed={isPinned}
+                        onClick={() => handleTogglePin(project.id)}
+                      >
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill={isPinned ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M12 17v5M9 10.76V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v5.76l2 3.24H7z" />
+                        </svg>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
+          )}
+
+          {/* START BUILDING — demoted scaffold strip. */}
+          <div className="editor-empty-start">
+            <div className="editor-empty-start-head">
+              <span className="editor-empty-starter-label">Start building</span>
+              <button type="button" className="editor-empty-start-more" onClick={handleNewProject}>
+                More templates <span aria-hidden="true">→</span>
+              </button>
+            </div>
+            <div className="editor-empty-start-chips">
               {QUICK_TEMPLATES.map((t) => (
                 <button
                   type="button"
                   key={t.id}
-                  className="editor-empty-template"
+                  className="editor-empty-chip"
                   style={{ '--tmpl-color': t.color, '--tmpl-glow': `${t.color}15` } as React.CSSProperties}
                   onClick={handleNewProject}
                 >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke={t.color}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={t.color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                     <path d={t.icon} />
                   </svg>
                   {t.name}
                 </button>
               ))}
             </div>
-            <Button className="editor-empty-more" variant="ghost" size="sm" onClick={handleNewProject}>
-              More templates -&gt;
-            </Button>
-          </Surface>
+          </div>
+
+          <div className="editor-empty-hints">
+            <button type="button" className="editor-empty-hint" onClick={() => useAppActions.getState().openFilePalette()}>
+              <kbd>⌘K</kbd> Commands
+            </button>
+            <button type="button" className="editor-empty-hint" onClick={handleOpenFileExplorer}>
+              <kbd>⌘P</kbd> Go to file
+            </button>
+            <button type="button" className="editor-empty-hint" onClick={handleOpenTerminal}>
+              <kbd>⌘J</kbd> Terminal
+            </button>
+          </div>
         </>
       )}
     </div>

--- a/src/panels/Editor/EditorWelcome.tsx
+++ b/src/panels/Editor/EditorWelcome.tsx
@@ -14,11 +14,11 @@ interface RecentProject {
   id: string
   name: string
   path: string
-  /** Git branch for the branch chip. TODO: branch is not yet stored on Project —
-   *  derive it (e.g. via window.daemon.git.branch on workspace open) and persist it. */
+  /** Current git branch (cached server-side, refreshed by projects:list). */
   branch: string | null
   /** Epoch ms of last activity; drives ordering and the "last opened" label. */
   lastActive: number | null
+  pinned: boolean
 }
 
 /** Abbreviate an absolute path with ~ and forward slashes for display. */
@@ -58,9 +58,6 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
   const projects = useUIStore((s) => s.projects)
   const [isEmptyDragOver, setIsEmptyDragOver] = useState(false)
   const [gitBranch, setGitBranch] = useState<string | null>(null)
-  // Pinned project ids. TODO: persist favorites (e.g. projects:pin IPC + DB column)
-  // so sticky order survives reloads; local state keeps them sticky this session.
-  const [pinnedIds, setPinnedIds] = useState<Set<string>>(() => new Set())
   const emptyDragDepthRef = useRef(0)
 
   const activeProject = projects.find((p) => p.id === activeProjectId)
@@ -78,20 +75,19 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
     id: p.id,
     name: p.name,
     path: p.path,
-    branch: null, // TODO: surface real branch once stored on Project
+    branch: p.branch,
     lastActive: p.last_active ?? p.created_at,
+    pinned: p.pinned === 1,
   }), [])
 
   // Recents: pinned first (sticky), then most-recently-active, truncated for the canvas.
   const recents = useMemo<RecentProject[]>(() => {
     const sorted = [...projects].sort((a, b) => {
-      const aPinned = pinnedIds.has(a.id)
-      const bPinned = pinnedIds.has(b.id)
-      if (aPinned !== bPinned) return aPinned ? -1 : 1
+      if ((a.pinned === 1) !== (b.pinned === 1)) return a.pinned === 1 ? -1 : 1
       return (b.last_active ?? b.created_at) - (a.last_active ?? a.created_at)
     })
     return sorted.slice(0, RECENTS_LIMIT).map(toRecent)
-  }, [projects, pinnedIds, toRecent])
+  }, [projects, toRecent])
 
   const handleEmptyDrop = useCallback(async (e: React.DragEvent) => {
     e.preventDefault()
@@ -156,13 +152,13 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
     useUIStore.getState().openWorkspaceTool('starter')
   }, [])
 
-  const handleTogglePin = useCallback((id: string) => {
-    setPinnedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
+  const handleTogglePin = useCallback(async (id: string, pinned: boolean) => {
+    const res = await window.daemon.projects.setPinned({ id, pinned })
+    if (!res.ok || !res.data) return
+    const updated = res.data
+    useUIStore.getState().setProjects(
+      useUIStore.getState().projects.map((p) => (p.id === id ? updated : p))
+    )
   }, [])
 
   const handleOpenTerminal = useCallback(() => {
@@ -242,7 +238,7 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
               </div>
               <ul className="editor-empty-recents-list">
                 {recents.map((project) => {
-                  const isPinned = pinnedIds.has(project.id)
+                  const isPinned = project.pinned
                   return (
                     <li key={project.id} className={`editor-empty-recent-row ${isPinned ? 'is-pinned' : ''}`}>
                       <button
@@ -272,7 +268,7 @@ export function EditorWelcome({ activeProjectId }: EditorWelcomeProps) {
                         className="editor-empty-recent-pin"
                         aria-label={isPinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
                         aria-pressed={isPinned}
-                        onClick={() => handleTogglePin(project.id)}
+                        onClick={() => handleTogglePin(project.id, !isPinned)}
                       >
                         <svg width="13" height="13" viewBox="0 0 24 24" fill={isPinned ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                           <path d="M12 17v5M9 10.76V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v5.76l2 3.24H7z" />

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -634,6 +634,7 @@ declare global {
     create: (project: { name: string; path: string }) => Promise<IpcResponse<Project>>
     delete: (id: string) => Promise<IpcResponse>
     openDialog: () => Promise<IpcResponse<string | null>>
+    setPinned: (input: { id: string; pinned: boolean }) => Promise<IpcResponse<Project>>
   }
 
   interface AgentOpsOpenRequest {

--- a/test/services/Migrations.test.ts
+++ b/test/services/Migrations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { SCHEMA_V41, SCHEMA_V43 } from '../../electron/db/schema'
+import { SCHEMA_V41, SCHEMA_V43, SCHEMA_V45, SCHEMA_V1 } from '../../electron/db/schema'
 
 describe('database migration schemas', () => {
   it('defines ProofPool custody hardening fields for fresh and upgraded databases', () => {
@@ -26,5 +26,14 @@ describe('database migration schemas', () => {
     expect(SCHEMA_V43).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_payout_intents_backing_kind')
     expect(SCHEMA_V43).toContain('CREATE TABLE IF NOT EXISTS proof_webhook_receipts')
     expect(SCHEMA_V43).toContain('receipt_hash TEXT NOT NULL UNIQUE')
+  })
+
+  it('defines project pin/branch fields for fresh and upgraded databases', () => {
+    expect(SCHEMA_V1).toContain('pinned INTEGER NOT NULL DEFAULT 0')
+    expect(SCHEMA_V1).toContain('branch TEXT')
+
+    expect(SCHEMA_V45).toContain('ALTER TABLE projects ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0')
+    expect(SCHEMA_V45).toContain('ALTER TABLE projects ADD COLUMN branch TEXT')
+    expect(SCHEMA_V45).toContain('idx_projects_pinned')
   })
 })


### PR DESCRIPTION
Redesigns the default canvas (empty-workspace welcome) with RECENT PROJECTS as the anchor (Variation A).

## UI
- Lowercased `daemon` title; tagline now `path · no file open`.
- Fused 3-up action row (shared border, 1px hairline gaps): Open folder (⌘O) · Launch agent (green primary) · Clone repo.
- RECENT PROJECTS block: mono header + `View all (N) →`, bordered list with 46px clickable rows (folder · name · branch chip · path · last-opened · pin-on-hover; pinned = amber, sticky).
- Demoted START BUILDING strip (4-up compact chips) + keyboard hints.
- Tokens-only (CSS Modules + styles/tokens.css); controls use --radius-sm; no new literals.

## Backend (schema V44 → V45)
- `projects` table gains `pinned` + `branch` columns (base table + V45 ALTER migration + idx_projects_pinned).
- `projects:list` orders pinned-first and refreshes/caches each project's git branch.
- New `projects:setPinned` IPC; pin toggles persist across reloads.

## Tests / gates
- typecheck, build, lint:styles green.
- Added V45 migration test. Full suite: 585/586 (the 1 failure is the pre-existing, unrelated SeekerRelayService port test).