### PR TITLE
fix: Windows swarm hardening, active-install telemetry, runnable trading-bot scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ scripts/_icc_row.css
 apps/seeker-mobile/.expo/
 apps/seeker-mobile/dapp-store/build/
 apps/seeker-mobile/dapp-store/publisher-keypair.json
+dist-bridge/

--- a/electron/ipc/telemetry.ts
+++ b/electron/ipc/telemetry.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron'
 import { ipcHandler } from '../services/IpcHandlerFactory'
+import { isRemoteTelemetryEnabled, setRemoteTelemetryEnabled } from '../services/RemoteTelemetryService'
 import * as TelemetryService from '../services/TelemetryService'
 
 export function initTelemetry(version: string) {
@@ -27,5 +28,14 @@ export function registerTelemetryHandlers() {
 
   ipcMain.handle('telemetry:recent', ipcHandler(async (_event, limit?: number) => {
     return { ok: true, data: TelemetryService.getRecentEvents(limit || 50) }
+  }))
+
+  ipcMain.handle('telemetry:remote-enabled', ipcHandler(async () => {
+    return isRemoteTelemetryEnabled()
+  }))
+
+  ipcMain.handle('telemetry:set-remote-enabled', ipcHandler(async (_event, enabled: boolean) => {
+    setRemoteTelemetryEnabled(enabled === true)
+    return isRemoteTelemetryEnabled()
   }))
 }

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -67,7 +67,7 @@ import { registerTelemetryHandlers, initTelemetry } from '../ipc/telemetry'
 import { registerVoightHandlers } from '../ipc/voight'
 import { registerPackHandlers, setPackDomainRegistrar } from '../ipc/packs'
 import { enabledIpcDomains, type IpcDomainId } from '../shared/packManifest'
-import { flushRemoteTelemetry } from '../services/RemoteTelemetryService'
+import { startRemoteTelemetryLoop } from '../services/RemoteTelemetryService'
 import { flushQueue as flushVoightQueue } from '../services/VoightService'
 import { clearLoadedWallets } from '../services/RecoveryService'
 import { maybeRecoverUnstableUiState, getEnabledPacks, type UiRecoveryResult } from '../services/SettingsService'
@@ -698,9 +698,9 @@ app.whenReady().then(() => {
   })
   dispatchInitialAgentOpsOpenRequest()
   setTimeout(() => {
-    flushRemoteTelemetry().catch((err) => {
-      console.warn('[telemetry] Remote telemetry startup failed:', err instanceof Error ? err.message : String(err))
-    })
+    // Loop (not one-shot): an IDE session can outlive the UTC day, and the
+    // startup-only flush undercounted every long-running install.
+    startRemoteTelemetryLoop()
     flushVoightQueue().catch((err) => {
       console.warn('[voight] Queue flush failed:', err instanceof Error ? err.message : String(err))
     })

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -255,6 +255,8 @@ contextBridge.exposeInMainWorld('daemon', {
     session: () => ipcRenderer.invoke('telemetry:session'),
     stats: () => ipcRenderer.invoke('telemetry:stats'),
     recent: (limit?: number) => ipcRenderer.invoke('telemetry:recent', limit),
+    remoteEnabled: () => ipcRenderer.invoke('telemetry:remote-enabled'),
+    setRemoteEnabled: (enabled: boolean) => ipcRenderer.invoke('telemetry:set-remote-enabled', enabled),
   },
 
   voight: {

--- a/electron/services/ClaudeRouter.ts
+++ b/electron/services/ClaudeRouter.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import os from 'node:os'
 import { spawn, execSync } from 'node:child_process'
 import { getDb } from '../db/db'
+import { buildCliSpawn } from './cliSpawn'
 import * as SecureKey from './SecureKeyService'
 import { sanitizeAiPrompt } from '../security/PrivacyGuard'
 import { writeProjectMcpConfig, readProjectMcpConfig, getRegistryMcps, hasProjectMcpFile } from './McpConfig'
@@ -403,10 +404,15 @@ function buildSubscriptionEnv(): NodeJS.ProcessEnv {
 
 function runCliCommand(command: string, args: string[], cwd: string, timeout: number): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    // claude is a .cmd shim on Windows npm installs — Node 20.12+ throws spawn
+    // EINVAL on those without a shell.
+    const spec = buildCliSpawn(command, args)
+    const child = spawn(spec.command, spec.args, {
       cwd,
       env: buildSubscriptionEnv(),
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: spec.shell,
+      windowsHide: true,
     })
 
     // Close stdin immediately — prevents "no stdin data received" warning

--- a/electron/services/RemoteTelemetryService.ts
+++ b/electron/services/RemoteTelemetryService.ts
@@ -4,9 +4,14 @@ import { app } from 'electron'
 
 import { getDb } from '../db/db'
 import { sanitizeErrorMessage } from '../security/PrivacyGuard'
+import { getBooleanSetting, setBooleanSetting } from './SettingsService'
 
 const DEFAULT_TELEMETRY_ENDPOINT = 'https://daemon-landing.vercel.app/api/telemetry'
 const STATE_TABLE = 'remote_telemetry_state'
+const ENABLED_SETTING_KEY = 'telemetry_remote_enabled'
+// DAEMON is an IDE — sessions span days. Re-flush hourly so the UTC-day
+// rollover emits daily_active without a restart (per-day state keys dedupe).
+const FLUSH_INTERVAL_MS = 60 * 60 * 1000
 
 type TelemetryEventName = 'first_open' | 'daily_active'
 
@@ -26,8 +31,18 @@ type TelemetryPayload = {
   estimatedFirstSeenAt?: number
 }
 
+/** User-facing opt-out, persisted in app_settings and surfaced in Settings → Privacy. */
+export function isRemoteTelemetryEnabled(): boolean {
+  return getBooleanSetting(ENABLED_SETTING_KEY, true)
+}
+
+export function setRemoteTelemetryEnabled(enabled: boolean): void {
+  setBooleanSetting(ENABLED_SETTING_KEY, enabled)
+}
+
 function remoteTelemetryEnabled(): boolean {
   if (process.env.DAEMON_TELEMETRY_DISABLED === '1') return false
+  if (!isRemoteTelemetryEnabled()) return false
   if (process.env.DAEMON_REMOTE_TELEMETRY_DEV === '1') return true
   return app.isPackaged
 }
@@ -151,4 +166,14 @@ export async function flushRemoteTelemetry(): Promise<void> {
   } catch (err) {
     console.warn('[telemetry] Remote telemetry flush failed:', sanitizeErrorMessage(err))
   }
+}
+
+let flushTimer: NodeJS.Timeout | null = null
+
+/** Flush now, then keep re-flushing so multi-day sessions emit daily_active. */
+export function startRemoteTelemetryLoop(): void {
+  if (flushTimer) return
+  void flushRemoteTelemetry()
+  flushTimer = setInterval(() => void flushRemoteTelemetry(), FLUSH_INTERVAL_MS)
+  flushTimer.unref?.()
 }

--- a/electron/services/SwarmOrchestrator.ts
+++ b/electron/services/SwarmOrchestrator.ts
@@ -15,8 +15,10 @@ import os from 'node:os'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import { BrowserWindow } from 'electron'
+import { buildCliSpawn } from './cliSpawn'
 import { getClaudePath } from './ClaudeRouter'
 import { LogService } from './LogService'
+import { killProcessTree, waitForExit } from './procKill'
 import * as Worktree from './WorktreeService'
 
 const MAX_CONCURRENT_LANES = 4
@@ -88,17 +90,28 @@ export async function launch(input: SwarmLaunchInput): Promise<string> {
   return run.id
 }
 
-/** Start as many pending lanes as the concurrency cap allows. */
-async function drainQueue(runId: string): Promise<void> {
-  const running = liveLanes.size
-  let slots = Math.max(0, MAX_CONCURRENT_LANES - running)
+/**
+ * Start as many pending lanes as the concurrency cap allows. Drains across
+ * ALL running runs (preferRunId first) — draining only the finishing lane's
+ * run would strand a second run's pending lanes forever once the first run
+ * completed, since nothing else ever re-triggers them.
+ */
+async function drainQueue(preferRunId: string): Promise<void> {
+  let slots = Math.max(0, MAX_CONCURRENT_LANES - liveLanes.size)
   if (slots === 0) return
 
-  const lanes = Worktree.listLanes(runId).filter((l) => l.status === 'pending')
-  for (const lane of lanes) {
-    if (slots <= 0) break
-    slots -= 1
-    await startLane(runId, lane.id)
+  const runIds = Worktree.listRuns()
+    .filter((r) => r.status === 'running')
+    .map((r) => r.id)
+    .sort((a, b) => (a === preferRunId ? -1 : b === preferRunId ? 1 : 0))
+
+  for (const runId of runIds) {
+    const lanes = Worktree.listLanes(runId).filter((l) => l.status === 'pending')
+    for (const lane of lanes) {
+      if (slots <= 0) return
+      slots -= 1
+      await startLane(runId, lane.id)
+    }
   }
 }
 
@@ -138,11 +151,15 @@ async function startLane(runId: string, laneId: string): Promise<void> {
   delete laneEnv.ANTHROPIC_API_KEY
   delete laneEnv.ANTHROPIC_AUTH_TOKEN
 
+  // claude is a .cmd shim on Windows npm installs — Node 20.12+ throws spawn
+  // EINVAL on those without a shell, which failed every lane instantly.
+  const spec = buildCliSpawn(getClaudePath(), args)
   let child: ChildProcess
   try {
-    child = spawn(getClaudePath(), args, {
+    child = spawn(spec.command, spec.args, {
       cwd: lane.worktree_path,
       env: laneEnv,
+      shell: spec.shell,
       windowsHide: true,
       // Close stdin so `claude -p` doesn't block waiting for piped input
       // (it otherwise times out after 3s and exits 1); keep stdout/stderr piped.
@@ -167,7 +184,12 @@ async function startLane(runId: string, laneId: string): Promise<void> {
   child.stderr?.on('data', (d) => { stderr = (stderr + String(d)).slice(-4000) })
   child.stdout?.on('data', (d) => { stdout = (stdout + String(d)).slice(-4000) })
 
-  child.on('exit', (code) => {
+  // 'error' fires instead of (or as well as) 'close' when the spawn itself
+  // fails (shell-mode errors are async, never thrown) — settle exactly once.
+  let settled = false
+  const settleLane = (code: number | null) => {
+    if (settled) return
+    settled = true
     cleanupContext(contextFile)
     // Snapshot RESULTS.md to a stable cache outside the worktree so it survives
     // worktree teardown (cancel/dismiss). results_path points at the snapshot.
@@ -176,10 +198,17 @@ async function startLane(runId: string, laneId: string): Promise<void> {
     if (status === 'failed') {
       LogService.warn('Swarm', `Lane ${laneId} exited ${code}`, { stderr: stderr.trim().slice(-1000), stdout: stdout.trim().slice(-1000) })
     }
-    Worktree.setLaneStatus(laneId, status, { exitCode: code ?? null, resultsPath: snapshot })
-    emit('swarm:lane-update', { runId, laneId, status, exitCode: code ?? null })
+    Worktree.setLaneStatus(laneId, status, { exitCode: code, resultsPath: snapshot })
+    emit('swarm:lane-update', { runId, laneId, status, exitCode: code })
     finishLane(runId, laneId)
+  }
+
+  child.on('error', (err) => {
+    LogService.error('Swarm', `Lane ${laneId} process error`, err)
+    settleLane(null)
   })
+  // 'close' (not 'exit') so stdout/stderr are fully flushed before we log them.
+  child.on('close', (code) => settleLane(code ?? null))
 }
 
 /** Common post-lane bookkeeping: drop from live map, roll up run, drain more, cleanup terminal worktrees. */
@@ -239,7 +268,10 @@ export async function cancelRun(runId: string): Promise<void> {
   for (const lane of Worktree.listLanes(runId)) {
     const live = liveLanes.get(lane.id)
     if (live?.child) {
-      try { live.child.kill() } catch { /* already gone */ }
+      // Tree-kill, then wait for the exit: on Windows a still-dying process
+      // keeps cwd handles open and worktree removal would hit EBUSY.
+      killProcessTree(live.child)
+      await waitForExit(live.child, 5_000)
     }
     if (lane.status !== 'done' && lane.status !== 'failed') {
       Worktree.setLaneStatus(lane.id, 'cancelled')
@@ -254,7 +286,7 @@ export async function cancelRun(runId: string): Promise<void> {
 /** Kill every live lane (app shutdown). */
 export function killAll(): void {
   for (const live of liveLanes.values()) {
-    try { live.child?.kill() } catch { /* ignore */ }
+    if (live.child) killProcessTree(live.child)
     cleanupContext(live.contextFile)
   }
   liveLanes.clear()

--- a/electron/services/WorktreeService.ts
+++ b/electron/services/WorktreeService.ts
@@ -13,7 +13,18 @@ import path from 'node:path'
 import simpleGit from 'simple-git'
 import { getDb } from '../db/db'
 import { LogService } from './LogService'
+import { killOrphanLanePid } from './procKill'
 import { swarmRootFor } from '../ipc/git'
+
+// Windows: a lane process (or Defender/indexer) holding any handle inside the
+// worktree makes removal fail with EBUSY/EPERM. Retry with backoff instead of
+// failing once and leaking the worktree.
+const REMOVE_ATTEMPTS = 4
+const REMOVE_BACKOFF_MS = 350
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 export type SwarmRunStatus = 'running' | 'done' | 'failed' | 'cancelled'
 export type SwarmLaneStatus = 'pending' | 'spawning' | 'running' | 'done' | 'failed' | 'cancelled'
@@ -124,9 +135,14 @@ export function rollupRunStatus(runId: string): void {
 
 // ---------------- worktree lifecycle ----------------
 
-/** Build the per-lane worktree path under the managed swarm root. */
+/**
+ * Build the per-lane worktree path under the managed swarm root. Short id
+ * prefixes instead of full UUIDs: a worktree with node_modules inside it
+ * blows past Windows' 260-char MAX_PATH fast, and the full path is stored
+ * on the lane row anyway so the dir name doesn't need to be unique forever.
+ */
 export function laneWorktreePath(projectPath: string, runId: string, laneId: string): string {
-  return path.join(swarmRootFor(projectPath), runId, laneId)
+  return path.join(swarmRootFor(projectPath), runId.slice(0, 8), laneId.slice(0, 8))
 }
 
 export async function addWorktree(projectPath: string, worktreePath: string, branch: string, base: string | null): Promise<void> {
@@ -146,11 +162,30 @@ export async function addWorktree(projectPath: string, worktreePath: string, bra
 
 export async function removeWorktree(projectPath: string, worktreePath: string, branch?: string | null): Promise<void> {
   const git = simpleGit(projectPath)
-  try {
-    await git.raw(['worktree', 'remove', worktreePath, '--force'])
-  } catch (err) {
-    LogService.warn('Swarm', `Failed to remove worktree ${worktreePath}`, { error: (err as Error).message })
+  let removed = false
+  for (let attempt = 1; attempt <= REMOVE_ATTEMPTS; attempt++) {
+    try {
+      await git.raw(['worktree', 'remove', worktreePath, '--force'])
+      removed = true
+      break
+    } catch (err) {
+      if (!fs.existsSync(worktreePath)) { removed = true; break }
+      if (attempt === REMOVE_ATTEMPTS) {
+        LogService.warn('Swarm', `Failed to remove worktree ${worktreePath} after ${REMOVE_ATTEMPTS} attempts`, { error: (err as Error).message })
+      } else {
+        await sleep(REMOVE_BACKOFF_MS * attempt)
+      }
+    }
   }
+  // Force-delete whatever git couldn't; rmSync retries EBUSY/EPERM natively.
+  try {
+    fs.rmSync(worktreePath, { recursive: true, force: true, maxRetries: 8, retryDelay: 250 })
+    const parent = path.dirname(worktreePath)
+    if (fs.existsSync(parent) && fs.readdirSync(parent).length === 0) fs.rmdirSync(parent)
+  } catch (err) {
+    if (!removed) LogService.warn('Swarm', `Worktree dir still locked: ${worktreePath}`, { error: (err as Error).message })
+  }
+  // Prune AFTER the dir is gone so git drops the stale metadata entry.
   try {
     await git.raw(['worktree', 'prune'])
   } catch { /* best-effort */ }
@@ -158,12 +193,6 @@ export async function removeWorktree(projectPath: string, worktreePath: string, 
   if (branch) {
     try { await git.raw(['branch', '-D', branch]) } catch { /* may not exist */ }
   }
-  // Remove the now-empty <run>/<lane> dir and prune an empty <run> parent.
-  try {
-    fs.rmSync(worktreePath, { recursive: true, force: true })
-    const parent = path.dirname(worktreePath)
-    if (fs.existsSync(parent) && fs.readdirSync(parent).length === 0) fs.rmdirSync(parent)
-  } catch { /* best-effort */ }
 }
 
 /**
@@ -182,7 +211,10 @@ export async function reconcileOnBoot(): Promise<void> {
   for (const run of runs) {
     for (const lane of listLanes(run.id)) {
       if (!TERMINAL_LANE.includes(lane.status)) {
-        // A running lane at boot means the process is gone (we don't persist PIDs across restarts safely).
+        // A crashed app can leave the lane's claude process alive, holding
+        // locks that block worktree removal on Windows — kill it (guarded by
+        // an image-name check, since PIDs get reused) before failing the lane.
+        if (lane.pid) await killOrphanLanePid(lane.pid)
         setLaneStatus(lane.id, 'failed', { exitCode: null })
       }
       await removeWorktree(run.project_path, lane.worktree_path, lane.branch)

--- a/electron/services/cliSpawn.ts
+++ b/electron/services/cliSpawn.ts
@@ -1,0 +1,33 @@
+/**
+ * Spawn-spec builder for CLI tools that are .cmd/.bat shims on Windows
+ * (npm global installs). Node 20.12+/22 refuses to spawn those without a
+ * shell (spawn EINVAL, CVE-2024-27980), so they must route through cmd.exe
+ * with every argument quoted by us — cmd would otherwise reparse prompt
+ * text containing &, |, %, or quotes.
+ */
+
+export interface CliSpawnSpec {
+  command: string
+  args: string[]
+  shell: boolean
+}
+
+/**
+ * Quote an argument for a Windows cmd.exe shell invocation: wrap in double
+ * quotes, escape embedded double quotes, and neutralize the %VAR% expansion
+ * cmd performs even inside quotes (a lone % can't be escaped, so we break
+ * the pair with "^").
+ */
+export function quoteWinArg(arg: string): string {
+  const escaped = arg.replace(/"/g, '\\"').replace(/%/g, '%^')
+  return `"${escaped}"`
+}
+
+export function needsWinShell(command: string): boolean {
+  return process.platform === 'win32' && /\.(cmd|bat)$/i.test(command)
+}
+
+export function buildCliSpawn(command: string, args: string[]): CliSpawnSpec {
+  if (!needsWinShell(command)) return { command, args, shell: false }
+  return { command: quoteWinArg(command), args: args.map(quoteWinArg), shell: true }
+}

--- a/electron/services/procKill.ts
+++ b/electron/services/procKill.ts
@@ -1,0 +1,56 @@
+/**
+ * Process-tree termination for swarm lanes. On Windows, ChildProcess.kill()
+ * only signals the direct child (often a cmd.exe shim), leaving the real
+ * claude/node descendants alive — and any live descendant holds file locks
+ * that make worktree removal fail with EBUSY/EPERM. taskkill /T takes the
+ * whole tree down.
+ */
+import { execFile } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+
+const TASKKILL_TIMEOUT_MS = 5_000
+
+export function killProcessTree(child: ChildProcess): void {
+  if (child.pid && process.platform === 'win32') {
+    execFile('taskkill', ['/PID', String(child.pid), '/T', '/F'], { timeout: TASKKILL_TIMEOUT_MS, windowsHide: true }, () => {})
+    return
+  }
+  try { child.kill('SIGKILL') } catch { /* already gone */ }
+}
+
+/** Resolve once the child has exited, or after timeoutMs — whichever is first. */
+export function waitForExit(child: ChildProcess, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve()
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, timeoutMs)
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
+}
+
+/**
+ * Boot-time kill of an orphaned lane process by recorded PID. PIDs get reused,
+ * so on Windows we only fire when the image name still looks like a CLI lane
+ * (claude/node/cmd). Elsewhere this is a no-op: POSIX lets us delete a
+ * worktree out from under a running process, so there is nothing to unlock.
+ */
+export function killOrphanLanePid(pid: number): Promise<void> {
+  if (process.platform !== 'win32') return Promise.resolve()
+  return new Promise((resolve) => {
+    execFile(
+      'tasklist',
+      ['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH'],
+      { timeout: TASKKILL_TIMEOUT_MS, windowsHide: true },
+      (err, stdout) => {
+        const imageName = stdout?.split(',')[0]?.replace(/"/g, '').toLowerCase() ?? ''
+        if (err || !/^(claude|node|cmd)(\.exe)?$/.test(imageName)) {
+          resolve()
+          return
+        }
+        execFile('taskkill', ['/PID', String(pid), '/T', '/F'], { timeout: TASKKILL_TIMEOUT_MS, windowsHide: true }, () => resolve())
+      },
+    )
+  })
+}

--- a/electron/services/providers/ClaudeProvider.ts
+++ b/electron/services/providers/ClaudeProvider.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import { randomUUID } from 'node:crypto'
 import { spawn, execSync } from 'node:child_process'
 import { getDb } from '../../db/db'
+import { buildCliSpawn } from '../cliSpawn'
 import * as SecureKey from '../SecureKeyService'
 import { TIMEOUTS } from '../../config/constants'
 import { writeProjectMcpConfig, readProjectMcpConfig, getRegistryMcps, hasProjectMcpFile } from '../McpConfig'
@@ -430,29 +431,14 @@ async function runPromptViaCli(
   }
 }
 
-/**
- * Quote an argument for a Windows cmd.exe shell invocation: wrap in double quotes,
- * escape embedded double quotes, and neutralize the %VAR% expansion that cmd performs
- * even inside quotes (a lone % can't be escaped, so we break the pair with "^").
- */
-function quoteWinArg(arg: string): string {
-  const escaped = arg.replace(/"/g, '\\"').replace(/%/g, '%^')
-  return `"${escaped}"`
-}
-
 function runCliCommand(command: string, args: string[], cwd: string, timeout: number): Promise<string> {
   return new Promise((resolve, reject) => {
-    // Node 20+ refuses to spawn a Windows .cmd/.bat without a shell (spawn EINVAL).
-    // Route those through a shell and quote each arg ourselves so prompt text
-    // containing shell metacharacters (&, |, %, ") is passed verbatim, not reparsed.
-    const win = process.platform === 'win32' && /\.(cmd|bat)$/i.test(command)
-    const spawnCommand = win ? quoteWinArg(command) : command
-    const spawnArgs = win ? args.map(quoteWinArg) : args
-    const child = spawn(spawnCommand, spawnArgs, {
+    const spec = buildCliSpawn(command, args)
+    const child = spawn(spec.command, spec.args, {
       cwd,
       env: buildSubscriptionEnv(),
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: win,
+      shell: spec.shell,
       windowsHide: true,
     })
 

--- a/electron/services/providers/CodexProvider.ts
+++ b/electron/services/providers/CodexProvider.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import { randomUUID } from 'node:crypto'
 import { spawn, execSync } from 'node:child_process'
 import { getDb } from '../../db/db'
+import { buildCliSpawn } from '../cliSpawn'
 import * as SecureKey from '../SecureKeyService'
 import { TIMEOUTS } from '../../config/constants'
 import { parseContextTags, stripContextTags, buildPortMap, buildEmailContext, buildMppContext } from './contextUtils'
@@ -329,28 +330,14 @@ function buildCodexEnv(): NodeJS.ProcessEnv {
   return env
 }
 
-/**
- * Quote an argument for a Windows cmd.exe shell invocation: wrap in double quotes,
- * escape embedded double quotes, and neutralize %VAR% expansion (cmd expands even
- * inside quotes; a lone % can't be escaped, so break the pair with "^").
- */
-function quoteWinArg(arg: string): string {
-  const escaped = arg.replace(/"/g, '\\"').replace(/%/g, '%^')
-  return `"${escaped}"`
-}
-
 function runCliCommand(command: string, args: string[], cwd: string, timeout: number): Promise<string> {
   return new Promise((resolve, reject) => {
-    // Node 20+ refuses to spawn a Windows .cmd/.bat without a shell (spawn EINVAL).
-    // Route those through a shell and quote each arg so prompt metacharacters pass verbatim.
-    const win = process.platform === 'win32' && /\.(cmd|bat)$/i.test(command)
-    const spawnCommand = win ? quoteWinArg(command) : command
-    const spawnArgs = win ? args.map(quoteWinArg) : args
-    const child = spawn(spawnCommand, spawnArgs, {
+    const spec = buildCliSpawn(command, args)
+    const child = spawn(spec.command, spec.args, {
       cwd,
       env: buildCodexEnv(),
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: win,
+      shell: spec.shell,
       windowsHide: true,
     })
 

--- a/scripts/verify-trading-bot-scaffold.mts
+++ b/scripts/verify-trading-bot-scaffold.mts
@@ -1,0 +1,57 @@
+/**
+ * One-off verification: materialize the trading-bot scaffold into a temp dir,
+ * install real deps, and typecheck the generated project so kit/zod API usage
+ * is validated against actual package types (transpile tests only catch syntax).
+ * Run: node scripts/verify-trading-bot-scaffold.mts   (Node 23+, native type stripping)
+ */
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { tradingBotFiles } from '../src/panels/ProjectStarter/tradingBotScaffold.ts'
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-bot-verify-'))
+
+const packageJson = {
+  name: 'bot-verify',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  dependencies: {
+    '@solana/kit': '^2.3.0',
+    dotenv: '^16.4.7',
+    pino: '^9.7.0',
+    zod: '^3.25.0',
+  },
+  devDependencies: {
+    '@types/node': '^22.10.0',
+    typescript: '^5.9.0',
+  },
+}
+
+const tsconfig = {
+  compilerOptions: {
+    target: 'ES2022',
+    module: 'NodeNext',
+    moduleResolution: 'NodeNext',
+    strict: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    outDir: 'dist',
+    lib: ['ES2022', 'DOM'],
+  },
+  include: ['src'],
+}
+
+fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson, null, 2))
+fs.writeFileSync(path.join(root, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2))
+fs.mkdirSync(path.join(root, 'src'), { recursive: true })
+for (const file of tradingBotFiles()) {
+  fs.writeFileSync(path.join(root, file.path), file.content)
+}
+
+console.log(`scaffold written to ${root}`)
+execSync('pnpm install --ignore-workspace --reporter=silent', { cwd: root, stdio: 'inherit' })
+execSync('pnpm exec tsc --noEmit', { cwd: root, stdio: 'inherit' })
+console.log('generated trading bot typechecks clean')
+fs.rmSync(root, { recursive: true, force: true })

--- a/src/panels/ProjectStarter/ProjectStarter.tsx
+++ b/src/panels/ProjectStarter/ProjectStarter.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
+import { tradingBotFiles } from './tradingBotScaffold'
 import { useUIStore } from '../../store/ui'
 import { useWorkflowShellStore } from '../../store/workflowShell'
 import { useNotificationsStore } from '../../store/notifications'
@@ -826,7 +827,7 @@ function envForTemplate(templateId: string): string {
 
   const byTemplate: Record<string, string[]> = {
     'nft-collection': ['COLLECTION_NAME=Daemon Collection', 'COLLECTION_SIZE=1000'],
-    'trading-bot': ['TOKEN_MINT_A=So11111111111111111111111111111111111111112', 'TOKEN_MINT_B=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'SLIPPAGE_BPS=50', 'CHECK_INTERVAL_MS=10000'],
+    'trading-bot': ['TOKEN_MINT_A=So11111111111111111111111111111111111111112', 'TOKEN_MINT_B=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'TRADE_AMOUNT=10000000', 'SLIPPAGE_BPS=50', 'CHECK_INTERVAL_MS=10000', 'DIP_THRESHOLD=0.02', 'DRY_RUN=true', 'JUPITER_API_URL=https://lite-api.jup.ag/swap/v1'],
     'telegram-bot': ['TELEGRAM_BOT_TOKEN=', 'MASTER_WALLET_PATH=~/.config/solana/id.json'],
     'mcp-server': [],
     'solana-foundation': ['NEXT_PUBLIC_CLUSTER=devnet'],
@@ -872,7 +873,6 @@ function buildPackageJson(template: Template, projectName: string) {
   }
   if (template.id === 'telegram-bot') dependencies.grammy = '^1.37.0'
   if (template.id.startsWith('perps-')) dependencies['@pythnetwork/price-service-client'] = '^1.9.0'
-  if (template.id === 'trading-bot') dependencies['@jup-ag/api'] = '^6.0.42'
   if (template.id === 'nft-collection') {
     dependencies['@metaplex-foundation/umi'] = '^1.2.0'
     dependencies['@metaplex-foundation/umi-bundle-defaults'] = '^1.2.0'
@@ -1707,7 +1707,7 @@ function nodeAppFiles(template: Template): ScaffoldFile[] {
     },
     {
       path: 'src/index.ts',
-      content: `import { config } from './config'\nimport { logger } from './logger'\n\nlet shuttingDown = false\n\nasync function main() {\n  logger.info({ template: '${title}', rpcUrl: config.rpcUrl, venue: config.venue }, 'starting DAEMON scaffold')\n  logger.info('replace src/strategy.ts with your project-specific logic')\n}\n\nprocess.on('SIGINT', () => { shuttingDown = true; logger.warn({ shuttingDown }, 'shutdown requested'); process.exit(0) })\nprocess.on('SIGTERM', () => { shuttingDown = true; logger.warn({ shuttingDown }, 'shutdown requested'); process.exit(0) })\n\nmain().catch((err) => {\n  logger.error({ err }, 'fatal startup error')\n  process.exit(1)\n})\n`,
+      content: `import { config } from './config.js'\nimport { logger } from './logger.js'\n\nlet shuttingDown = false\n\nasync function main() {\n  logger.info({ template: '${title}', rpcUrl: config.rpcUrl, venue: config.venue }, 'starting DAEMON scaffold')\n  logger.info('replace src/strategy.ts with your project-specific logic')\n}\n\nprocess.on('SIGINT', () => { shuttingDown = true; logger.warn({ shuttingDown }, 'shutdown requested'); process.exit(0) })\nprocess.on('SIGTERM', () => { shuttingDown = true; logger.warn({ shuttingDown }, 'shutdown requested'); process.exit(0) })\n\nmain().catch((err) => {\n  logger.error({ err }, 'fatal startup error')\n  process.exit(1)\n})\n`,
     },
     {
       path: 'src/strategy.ts',
@@ -1732,9 +1732,16 @@ export function buildDeterministicScaffold(
   options: { memeSettings?: MemeCoinWebsiteScaffoldSettings | null } = {},
 ): DeterministicScaffold {
   const isNext = isNextTemplate(template.id)
+  const templateFiles = template.id === 'anchor-program'
+    ? anchorFiles(projectName)
+    : isNext
+      ? nextAppFiles(template, projectName, options.memeSettings)
+      : template.id === 'trading-bot'
+        ? tradingBotFiles()
+        : nodeAppFiles(template)
   const files = [
     ...commonFiles(template, projectName, options.memeSettings),
-    ...(template.id === 'anchor-program' ? anchorFiles(projectName) : isNext ? nextAppFiles(template, projectName, options.memeSettings) : nodeAppFiles(template)),
+    ...templateFiles,
   ]
 
   const dirs = new Set<string>(['src'])

--- a/src/panels/ProjectStarter/tradingBotScaffold.ts
+++ b/src/panels/ProjectStarter/tradingBotScaffold.ts
@@ -1,0 +1,311 @@
+/**
+ * Deterministic file set for the Trading Bot template. Unlike the generic
+ * node scaffold (config + hold-only strategy stub), this emits a runnable
+ * Jupiter swap bot: quote polling, price history, a swappable strategy,
+ * wallet loading, and live execution via @solana/kit — gated behind
+ * DRY_RUN=true so a fresh scaffold can never trade real funds by accident.
+ */
+
+interface ScaffoldFile {
+  path: string
+  content: string
+}
+
+const CONFIG_TS = `import 'dotenv/config'
+
+export const config = {
+  rpcUrl: process.env.RPC_URL ?? 'https://api.devnet.solana.com',
+  walletPath: process.env.WALLET_PATH ?? '~/.config/solana/id.json',
+  // Default pair: wSOL -> USDC
+  inputMint: process.env.TOKEN_MINT_A ?? 'So11111111111111111111111111111111111111112',
+  outputMint: process.env.TOKEN_MINT_B ?? 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  // Raw units of the input mint (lamports for wSOL)
+  tradeAmount: BigInt(process.env.TRADE_AMOUNT ?? '10000000'),
+  slippageBps: Number(process.env.SLIPPAGE_BPS ?? '50'),
+  checkIntervalMs: Number(process.env.CHECK_INTERVAL_MS ?? '10000'),
+  // Anything except the literal string "false" stays in dry-run.
+  dryRun: (process.env.DRY_RUN ?? 'true').toLowerCase() !== 'false',
+  jupiterBaseUrl: process.env.JUPITER_API_URL ?? 'https://lite-api.jup.ag/swap/v1',
+}
+`
+
+const LOGGER_TS = `import pino from 'pino'
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? 'info',
+})
+`
+
+const JUPITER_TS = `import { z } from 'zod'
+import { config } from './config.js'
+
+const quoteSchema = z
+  .object({
+    inputMint: z.string(),
+    outputMint: z.string(),
+    inAmount: z.string(),
+    outAmount: z.string(),
+    priceImpactPct: z.string(),
+  })
+  .passthrough()
+
+export type JupiterQuote = z.infer<typeof quoteSchema>
+
+export async function fetchQuote(inputMint: string, outputMint: string, amount: bigint): Promise<JupiterQuote> {
+  const params = new URLSearchParams({
+    inputMint,
+    outputMint,
+    amount: amount.toString(),
+    slippageBps: String(config.slippageBps),
+  })
+  const res = await fetch(config.jupiterBaseUrl + '/quote?' + params.toString())
+  if (!res.ok) throw new Error('Jupiter quote failed: HTTP ' + res.status)
+  return quoteSchema.parse(await res.json())
+}
+
+export async function fetchSwapTransaction(quote: JupiterQuote, userPublicKey: string): Promise<string> {
+  const res = await fetch(config.jupiterBaseUrl + '/swap', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      quoteResponse: quote,
+      userPublicKey,
+      dynamicComputeUnitLimit: true,
+      dynamicSlippage: true,
+    }),
+  })
+  if (!res.ok) throw new Error('Jupiter swap build failed: HTTP ' + res.status)
+  const body = z.object({ swapTransaction: z.string() }).parse(await res.json())
+  return body.swapTransaction
+}
+`
+
+const WALLET_TS = `import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createKeyPairFromBytes, getAddressFromPublicKey, type Address } from '@solana/kit'
+import { config } from './config.js'
+
+export interface BotWallet {
+  keyPair: CryptoKeyPair
+  address: Address
+}
+
+export async function loadWallet(): Promise<BotWallet> {
+  const resolved = config.walletPath.startsWith('~')
+    ? path.join(os.homedir(), config.walletPath.slice(1))
+    : config.walletPath
+  const secret = new Uint8Array(JSON.parse(fs.readFileSync(resolved, 'utf8')))
+  const keyPair = await createKeyPairFromBytes(secret)
+  const address = await getAddressFromPublicKey(keyPair.publicKey)
+  return { keyPair, address }
+}
+`
+
+const EXECUTOR_TS = `import {
+  createSolanaRpc,
+  getBase64Encoder,
+  getBase64EncodedWireTransaction,
+  getTransactionDecoder,
+  signTransaction,
+} from '@solana/kit'
+import { config } from './config.js'
+import { fetchSwapTransaction, type JupiterQuote } from './jupiter.js'
+import type { BotWallet } from './wallet.js'
+
+const rpc = createSolanaRpc(config.rpcUrl)
+
+export async function executeSwap(quote: JupiterQuote, wallet: BotWallet): Promise<string> {
+  const swapTransactionB64 = await fetchSwapTransaction(quote, wallet.address)
+  const txBytes = getBase64Encoder().encode(swapTransactionB64)
+  const tx = getTransactionDecoder().decode(txBytes)
+  const signed = await signTransaction([wallet.keyPair], tx)
+  const wire = getBase64EncodedWireTransaction(signed)
+  return await rpc.sendTransaction(wire, { encoding: 'base64' }).send()
+}
+`
+
+const POSITIONS_TS = `import fs from 'node:fs'
+
+export interface PositionRecord {
+  timestamp: number
+  side: 'buy' | 'sell'
+  inAmount: string
+  outAmount: string
+  price: number
+  signature: string | null
+}
+
+const POSITIONS_FILE = 'positions.json'
+
+export function loadPositions(): PositionRecord[] {
+  try {
+    return JSON.parse(fs.readFileSync(POSITIONS_FILE, 'utf8')) as PositionRecord[]
+  } catch {
+    return []
+  }
+}
+
+export function recordPosition(position: PositionRecord): void {
+  const all = loadPositions()
+  all.push(position)
+  fs.writeFileSync(POSITIONS_FILE, JSON.stringify(all, null, 2))
+}
+
+/**
+ * Raw-unit accounting: buys accumulate output-token units against input-token
+ * cost; sells unwind them. Values are in raw mint units (no decimal scaling),
+ * so PnL is directional rather than display-ready.
+ */
+export function portfolioSummary(positions: PositionRecord[], currentPrice: number) {
+  let heldOutputUnits = 0
+  let spentInputUnits = 0
+  for (const position of positions) {
+    if (position.side === 'buy') {
+      heldOutputUnits += Number(position.outAmount)
+      spentInputUnits += Number(position.inAmount)
+    } else {
+      heldOutputUnits -= Number(position.inAmount)
+      spentInputUnits -= Number(position.outAmount)
+    }
+  }
+  const markValueInputUnits = currentPrice > 0 ? heldOutputUnits / currentPrice : 0
+  return {
+    trades: positions.length,
+    heldOutputUnits,
+    spentInputUnits,
+    unrealizedPnlInputUnits: markValueInputUnits - spentInputUnits,
+  }
+}
+`
+
+const STRATEGY_TS = `export interface StrategyContext {
+  /** Latest output-per-input price from the Jupiter quote. */
+  price: number
+  /** Rolling price history, oldest first. */
+  history: number[]
+}
+
+export interface StrategySignal {
+  action: 'hold' | 'buy' | 'sell'
+  reason: string
+}
+
+const WINDOW = 10
+const BAND = Number(process.env.DIP_THRESHOLD ?? '0.02')
+
+/**
+ * Example mean-reversion band: buy when price drops BAND below the rolling
+ * average, sell when it rises BAND above. Replace this with your own signal
+ * logic — the rest of the bot only depends on the StrategySignal shape.
+ */
+export function evaluateStrategy({ price, history }: StrategyContext): StrategySignal {
+  if (history.length < WINDOW) {
+    return { action: 'hold', reason: 'warming up: ' + history.length + '/' + WINDOW + ' samples' }
+  }
+  const window = history.slice(-WINDOW)
+  const average = window.reduce((sum, value) => sum + value, 0) / window.length
+  const deviation = (price - average) / average
+  if (deviation <= -BAND) {
+    return { action: 'buy', reason: 'price ' + (deviation * 100).toFixed(2) + '% below rolling average' }
+  }
+  if (deviation >= BAND) {
+    return { action: 'sell', reason: 'price ' + (deviation * 100).toFixed(2) + '% above rolling average' }
+  }
+  return { action: 'hold', reason: 'price within ±' + BAND * 100 + '% band' }
+}
+`
+
+const INDEX_TS = `import { config } from './config.js'
+import { logger } from './logger.js'
+import { executeSwap } from './executor.js'
+import { fetchQuote } from './jupiter.js'
+import { loadPositions, portfolioSummary, recordPosition } from './positions.js'
+import { evaluateStrategy, type StrategySignal } from './strategy.js'
+import { loadWallet, type BotWallet } from './wallet.js'
+
+const history: number[] = []
+const MAX_HISTORY = 120
+let stopping = false
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function quoteForSignal(signal: StrategySignal, price: number) {
+  if (signal.action === 'buy') {
+    return fetchQuote(config.inputMint, config.outputMint, config.tradeAmount)
+  }
+  // Sell unwinds roughly the same notional, converted at the current price.
+  const sellAmount = BigInt(Math.max(1, Math.floor(Number(config.tradeAmount) * price)))
+  return fetchQuote(config.outputMint, config.inputMint, sellAmount)
+}
+
+async function tick(wallet: BotWallet | null): Promise<void> {
+  const monitorQuote = await fetchQuote(config.inputMint, config.outputMint, config.tradeAmount)
+  const price = Number(monitorQuote.outAmount) / Number(monitorQuote.inAmount)
+  history.push(price)
+  if (history.length > MAX_HISTORY) history.shift()
+
+  const signal = evaluateStrategy({ price, history })
+  logger.info({ price, action: signal.action, reason: signal.reason }, 'tick')
+  if (signal.action === 'hold') return
+
+  const quote = signal.action === 'buy' ? monitorQuote : await quoteForSignal(signal, price)
+
+  if (config.dryRun) {
+    logger.warn({ action: signal.action, inAmount: quote.inAmount, outAmount: quote.outAmount }, 'DRY_RUN active — trade logged, not sent. Set DRY_RUN=false to trade for real.')
+    recordPosition({ timestamp: Date.now(), side: signal.action, inAmount: quote.inAmount, outAmount: quote.outAmount, price, signature: null })
+    return
+  }
+
+  if (!wallet) throw new Error('Wallet not loaded — cannot execute live trade')
+  const signature = await executeSwap(quote, wallet)
+  logger.info({ signature, action: signal.action }, 'swap sent')
+  recordPosition({ timestamp: Date.now(), side: signal.action, inAmount: quote.inAmount, outAmount: quote.outAmount, price, signature })
+  logger.info(portfolioSummary(loadPositions(), price), 'portfolio')
+}
+
+async function main(): Promise<void> {
+  const wallet = config.dryRun ? null : await loadWallet()
+  logger.info(
+    {
+      dryRun: config.dryRun,
+      pair: config.inputMint + ' -> ' + config.outputMint,
+      tradeAmount: config.tradeAmount.toString(),
+      intervalMs: config.checkIntervalMs,
+      wallet: wallet?.address ?? 'not loaded (dry run)',
+    },
+    'trading bot started',
+  )
+  while (!stopping) {
+    try {
+      await tick(wallet)
+    } catch (err) {
+      logger.error({ err }, 'tick failed')
+    }
+    await sleep(config.checkIntervalMs)
+  }
+}
+
+process.on('SIGINT', () => { stopping = true; logger.warn('shutdown requested') })
+process.on('SIGTERM', () => { stopping = true; logger.warn('shutdown requested') })
+
+main().catch((err) => {
+  logger.error({ err }, 'fatal startup error')
+  process.exit(1)
+})
+`
+
+export function tradingBotFiles(): ScaffoldFile[] {
+  return [
+    { path: 'src/config.ts', content: CONFIG_TS },
+    { path: 'src/logger.ts', content: LOGGER_TS },
+    { path: 'src/jupiter.ts', content: JUPITER_TS },
+    { path: 'src/wallet.ts', content: WALLET_TS },
+    { path: 'src/executor.ts', content: EXECUTOR_TS },
+    { path: 'src/positions.ts', content: POSITIONS_TS },
+    { path: 'src/strategy.ts', content: STRATEGY_TS },
+    { path: 'src/index.ts', content: INDEX_TS },
+  ]
+}

--- a/src/panels/SettingsPanel/SettingsPanel.tsx
+++ b/src/panels/SettingsPanel/SettingsPanel.tsx
@@ -1252,11 +1252,23 @@ function DisplaySection() {
   const loadEditorPrefs = useEditorPrefsStore((s) => s.load)
   const updateEditorPrefs = useEditorPrefsStore((s) => s.update)
 
+  const [usagePingEnabled, setUsagePingEnabled] = useState(true)
+
   useEffect(() => { void loadEditorPrefs() }, [loadEditorPrefs])
+
+  useEffect(() => {
+    void window.daemon.telemetry.remoteEnabled().then((res) => {
+      if (res.ok && typeof res.data === 'boolean') setUsagePingEnabled(res.data)
+    })
+  }, [])
 
   const handleToggleMarketTape = (enabled: boolean) => { void setShowMarketTape(enabled) }
   const handleToggleTitlebarWallet = (enabled: boolean) => { void setShowTitlebarWallet(enabled) }
   const handleToggleLowPowerMode = (enabled: boolean) => { void setLowPowerMode(enabled) }
+  const handleToggleUsagePing = (enabled: boolean) => {
+    setUsagePingEnabled(enabled)
+    void window.daemon.telemetry.setRemoteEnabled(enabled)
+  }
 
   const adjustFontSize = (delta: number) => {
     const next = Math.min(EDITOR_FONT_SIZE_BOUNDS.max, Math.max(EDITOR_FONT_SIZE_BOUNDS.min, editorPrefs.fontSize + delta))
@@ -1287,6 +1299,15 @@ function DisplaySection() {
         <span className="settings-display-label">Low power mode</span>
         <span className="settings-display-hint">Reduce panel preloads, background polling, and UI motion for slower computers</span>
         <Toggle checked={lowPowerMode} onChange={handleToggleLowPowerMode} />
+      </div>
+
+      <div className="settings-divider" />
+      <div className="settings-section-label">Privacy</div>
+
+      <div className="settings-display-row">
+        <span className="settings-display-label">Anonymous usage ping</span>
+        <span className="settings-display-hint">Daily anonymous ping (install id, app version, OS) to count active installs — never code, prompts, paths, or keys</span>
+        <Toggle checked={usagePingEnabled} onChange={handleToggleUsagePing} />
       </div>
 
       <div className="settings-divider" />

--- a/src/types/daemon.d.ts
+++ b/src/types/daemon.d.ts
@@ -1650,6 +1650,8 @@ declare global {
     session: () => Promise<IpcResponse<TelemetrySessionInfo>>
     stats: () => Promise<IpcResponse<TelemetrySessionStats>>
     recent: (limit?: number) => Promise<IpcResponse<TelemetryEventRecord[]>>
+    remoteEnabled: () => Promise<IpcResponse<boolean>>
+    setRemoteEnabled: (enabled: boolean) => Promise<IpcResponse<boolean>>
   }
 
   interface DaemonVoight {

--- a/test/panels/ProjectStarter.runtime.test.ts
+++ b/test/panels/ProjectStarter.runtime.test.ts
@@ -173,6 +173,31 @@ describe('deterministic project scaffold', () => {
     expect(scaffold.files.some((file) => file.content.includes('claude --model'))).toBe(false)
   })
 
+  it('emits a runnable Jupiter bot for the trading-bot template, dry-run by default', () => {
+    const template = TEMPLATES.find((item) => item.id === 'trading-bot')
+    expect(template).toBeTruthy()
+
+    const scaffold = buildDeterministicScaffold(template!, 'JupBot')
+    const byPath = new Map(scaffold.files.map((file) => [file.path, file.content]))
+
+    for (const filePath of ['src/config.ts', 'src/jupiter.ts', 'src/wallet.ts', 'src/executor.ts', 'src/positions.ts', 'src/strategy.ts', 'src/index.ts']) {
+      expect(byPath.has(filePath), `missing ${filePath}`).toBe(true)
+      const transpiled = ts.transpileModule(byPath.get(filePath) ?? '', {
+        fileName: filePath,
+        compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+        reportDiagnostics: true,
+      })
+      expect(transpiled.diagnostics ?? []).toEqual([])
+    }
+
+    expect(byPath.get('.env.example')).toContain('DRY_RUN=true')
+    expect(byPath.get('src/config.ts')).toContain("!== 'false'")
+    expect(byPath.get('src/jupiter.ts')).toContain('/quote?')
+    expect(byPath.get('src/executor.ts')).toContain('signTransaction')
+    expect(byPath.get('src/index.ts')).toContain('DRY_RUN active')
+    expect(byPath.get('package.json')).not.toContain('@jup-ag/api')
+  })
+
   it('writes the expected project structure to disk', () => {
     const template: Template = {
       id: 'perps-trading-bot',

--- a/test/panels/ShellChrome.dom.test.tsx
+++ b/test/panels/ShellChrome.dom.test.tsx
@@ -70,6 +70,10 @@ function installDaemonBridge() {
           data: { configured: true, executionReady: true },
         }),
       },
+      telemetry: {
+        remoteEnabled: vi.fn().mockResolvedValue({ ok: true, data: true }),
+        setRemoteEnabled: vi.fn().mockResolvedValue({ ok: true, data: true }),
+      },
       voight: {
         status: vi.fn().mockResolvedValue({
           ok: true,

--- a/test/services/RemoteTelemetryService.test.ts
+++ b/test/services/RemoteTelemetryService.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getVersion: () => '4.3.0',
+    getLocale: () => 'en-US',
+  },
+}))
+
+const settings = new Map<string, boolean>()
+vi.mock('../../electron/services/SettingsService', () => ({
+  getBooleanSetting: (key: string, fallback: boolean) => settings.get(key) ?? fallback,
+  setBooleanSetting: (key: string, value: boolean) => { settings.set(key, value) },
+}))
+
+const state = new Map<string, string>()
+vi.mock('../../electron/db/db', () => ({
+  getDb: () => ({
+    exec: () => {},
+    prepare: (sql: string) => ({
+      get: (key?: string) => {
+        if (sql.includes('MIN(timestamp)')) return { firstSeenAt: null }
+        return state.has(String(key)) ? { value: state.get(String(key)) } : undefined
+      },
+      run: (...args: unknown[]) => { state.set(String(args[0]), String(args[1])) },
+    }),
+  }),
+}))
+
+vi.mock('../../electron/security/PrivacyGuard', () => ({
+  sanitizeErrorMessage: (err: unknown) => String(err),
+}))
+
+import {
+  flushRemoteTelemetry,
+  isRemoteTelemetryEnabled,
+  setRemoteTelemetryEnabled,
+} from '../../electron/services/RemoteTelemetryService'
+
+const fetchMock = vi.fn(async () => ({ ok: true }))
+vi.stubGlobal('fetch', fetchMock)
+
+function sentBody(callIndex: number): Record<string, unknown> {
+  const init = fetchMock.mock.calls[callIndex][1] as unknown as { body: string }
+  return JSON.parse(init.body)
+}
+
+beforeEach(() => {
+  settings.clear()
+  state.clear()
+  fetchMock.mockClear()
+  delete process.env.DAEMON_TELEMETRY_DISABLED
+})
+
+describe('RemoteTelemetryService', () => {
+  it('defaults to enabled and persists the user toggle', () => {
+    expect(isRemoteTelemetryEnabled()).toBe(true)
+    setRemoteTelemetryEnabled(false)
+    expect(isRemoteTelemetryEnabled()).toBe(false)
+    setRemoteTelemetryEnabled(true)
+    expect(isRemoteTelemetryEnabled()).toBe(true)
+  })
+
+  it('sends first_open and daily_active on first flush', async () => {
+    await flushRemoteTelemetry()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(sentBody(0).eventName).toBe('first_open')
+    expect(sentBody(1).eventName).toBe('daily_active')
+  })
+
+  it('dedupes repeat flushes within the same UTC day', async () => {
+    await flushRemoteTelemetry()
+    fetchMock.mockClear()
+    await flushRemoteTelemetry()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('sends nothing when the user opts out', async () => {
+    setRemoteTelemetryEnabled(false)
+    await flushRemoteTelemetry()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('payload carries no project paths, prompts, or key material', async () => {
+    await flushRemoteTelemetry()
+    expect(Object.keys(sentBody(0)).sort()).toEqual(
+      ['appVersion', 'arch', 'estimatedFirstSeenAt', 'eventId', 'eventName', 'installId', 'isPackaged', 'locale', 'osVersion', 'platform', 'schemaVersion', 'timestamp'].sort()
+    )
+  })
+})

--- a/test/services/cliSpawn.test.ts
+++ b/test/services/cliSpawn.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { quoteWinArg, buildCliSpawn, needsWinShell } from '../../electron/services/cliSpawn'
+
+const realPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform })
+}
+
+afterEach(() => setPlatform(realPlatform))
+
+describe('quoteWinArg', () => {
+  it('wraps the argument in double quotes', () => {
+    expect(quoteWinArg('hello world')).toBe('"hello world"')
+  })
+
+  it('escapes embedded double quotes', () => {
+    expect(quoteWinArg('say "hi"')).toBe('"say \\"hi\\""')
+  })
+
+  it('breaks %VAR% pairs so cmd cannot expand them', () => {
+    expect(quoteWinArg('%PATH%')).toBe('"%^PATH%^"')
+  })
+})
+
+describe('buildCliSpawn', () => {
+  it('routes .cmd shims through a shell with quoted args on Windows', () => {
+    setPlatform('win32')
+    const spec = buildCliSpawn('C:\\npm\\claude.cmd', ['-p', 'fix the & bug'])
+    expect(spec.shell).toBe(true)
+    expect(spec.command).toBe('"C:\\npm\\claude.cmd"')
+    expect(spec.args).toEqual(['"-p"', '"fix the & bug"'])
+  })
+
+  it('matches .bat case-insensitively', () => {
+    setPlatform('win32')
+    expect(needsWinShell('runner.BAT')).toBe(true)
+  })
+
+  it('leaves native executables untouched on Windows', () => {
+    setPlatform('win32')
+    const spec = buildCliSpawn('C:\\bin\\claude.exe', ['-p', 'task'])
+    expect(spec).toEqual({ command: 'C:\\bin\\claude.exe', args: ['-p', 'task'], shell: false })
+  })
+
+  it('never uses a shell off Windows', () => {
+    setPlatform('linux')
+    const spec = buildCliSpawn('/usr/bin/claude.cmd', ['-p', 'task'])
+    expect(spec.shell).toBe(false)
+    expect(spec.args).toEqual(['-p', 'task'])
+  })
+})


### PR DESCRIPTION
## Summary

Three fixes from the show feedback review.

### Swarm lanes on Windows (root cause found)
Swarm lanes never worked on Windows npm installs: `getClaudePath()` returns `claude.cmd`, and Node 20.12+ throws `spawn EINVAL` on `.cmd` files without a shell — every lane failed instantly at spawn. `ClaudeProvider` already had the shell-routing + arg-quoting fix, but it was never applied to `SwarmOrchestrator` or `ClaudeRouter`.

- New shared `cliSpawn.ts` (shell routing + cmd.exe-safe quoting); applied to the orchestrator and `ClaudeRouter`, deduped out of the Claude/Codex providers
- Lane teardown: `taskkill /T /F` tree-kill + wait-for-exit before worktree removal (dying processes hold cwd handles → EBUSY), retried `git worktree remove` with backoff, `rmSync` native retries, prune after the dir is gone
- Boot reconcile kills orphaned lane PIDs (image-name guarded) before cleanup
- Lane worktree dirs use 8-char ids for MAX_PATH headroom
- Queue fix: pending lanes drain across all running runs — a second queued run could previously starve forever

### Active-install telemetry
`daily_active` only fired at app startup, so an IDE session spanning days counted once. Now re-flushes hourly (per-day state keys dedupe). Adds an "Anonymous usage ping" toggle under Settings → Display → Privacy, persisted and checked before any send. Test suite asserts the payload carries no paths, prompts, or key material.

### Trading-bot scaffold
The template card promised a Jupiter swap bot but generated a hold-only stub. Now emits a runnable bot: quote polling, rolling price history, swappable mean-reversion strategy, keypair loading, swap signing via `@solana/kit`, JSON position tracking with PnL. `DRY_RUN=true` by default — a fresh scaffold can never trade real funds.

Verification caught a latent bug in all node scaffolds: NodeNext relative imports were missing `.js` extensions, so generated projects never typechecked. Fixed in the generic generator too. `scripts/verify-trading-bot-scaffold.mts` materializes the scaffold, installs real deps, and runs `tsc` against them.

## Test plan

- `pnpm run typecheck && pnpm run test && pnpm run build` green (875 tests)
- New suites: `cliSpawn.test.ts`, `RemoteTelemetryService.test.ts`, trading-bot scaffold transpile checks
- `node scripts/verify-trading-bot-scaffold.mts` — generated bot typechecks against real @solana/kit
- macOS CI run on this PR validates the cross-platform path