### PR TITLE
test(smoke): catch selectors up to the packs shell

### DIFF
--- a/scripts/smoke/daemon-mcp-stress.mjs
+++ b/scripts/smoke/daemon-mcp-stress.mjs
@@ -262,34 +262,38 @@ async function stressMcpBridge(page) {
 async function verifySolanaMcpUi(page) {
   await openToolFromLauncher(page, 'Solana Workflow', '.solana-toolbox')
   await page.getByRole('tab', { name: /^Connect\b/ }).click()
-  await page.waitForSelector('.solana-service-row', { timeout: 30000 })
+  // Services render as .ds-card entries (with a .solana-toggle each) since the
+  // toolbox redesign — .solana-service-row no longer exists.
+  await page.waitForSelector('.ds-card .solana-toggle', { timeout: 30000 })
   await page.waitForFunction((expectedCount) => {
-    const rows = Array.from(document.querySelectorAll('.solana-service-row'))
+    const rows = Array.from(document.querySelectorAll('.ds-card'))
+      .filter((card) => card.querySelector('.solana-toggle'))
     const enabled = rows.filter((row) => row.querySelector('.solana-toggle')?.classList.contains('on')).length
     return rows.length >= expectedCount && enabled >= expectedCount
   }, catalogMcpNames.length, { timeout: 30000 })
 
-  const heliusToggle = page.locator('.solana-service-row', { hasText: 'Helius' }).locator('.solana-toggle').first()
+  const heliusToggle = page.locator('.ds-card', { hasText: 'Helius' }).locator('.solana-toggle').first()
   await heliusToggle.click()
   await page.waitForFunction(() => {
-    const row = Array.from(document.querySelectorAll('.solana-service-row'))
-      .find((entry) => entry.textContent?.includes('Helius'))
+    const row = Array.from(document.querySelectorAll('.ds-card'))
+      .find((entry) => entry.querySelector('.solana-toggle') && entry.textContent?.includes('Helius'))
     return row && !row.querySelector('.solana-toggle')?.classList.contains('on')
   }, { timeout: 30000 })
 
   await heliusToggle.click()
   await page.waitForFunction(() => {
-    const row = Array.from(document.querySelectorAll('.solana-service-row'))
-      .find((entry) => entry.textContent?.includes('Helius'))
+    const row = Array.from(document.querySelectorAll('.ds-card'))
+      .find((entry) => entry.querySelector('.solana-toggle') && entry.textContent?.includes('Helius'))
     return row?.querySelector('.solana-toggle')?.classList.contains('on') === true
   }, { timeout: 30000 })
 
   return page.evaluate(() => {
-    const rows = Array.from(document.querySelectorAll('.solana-service-row'))
+    const rows = Array.from(document.querySelectorAll('.ds-card'))
+      .filter((card) => card.querySelector('.solana-toggle'))
     return {
       rows: rows.length,
       enabledRows: rows.filter((row) => row.querySelector('.solana-toggle')?.classList.contains('on')).length,
-      labels: rows.map((row) => row.querySelector('.solana-service-name')?.textContent?.trim()).filter(Boolean),
+      labels: rows.map((row) => row.querySelector('.ds-card-title')?.textContent?.trim()).filter(Boolean),
     }
   })
 }
@@ -309,7 +313,7 @@ async function verifyLowPowerStillResponds(page) {
   await setLowPower(true)
   await openToolFromLauncher(page, 'Solana Workflow', '.solana-toolbox')
   await page.getByRole('tab', { name: /^Connect\b/ }).click()
-  await page.waitForSelector('.solana-service-row', { timeout: 30000 })
+  await page.waitForSelector('.ds-card .solana-toggle', { timeout: 30000 })
   await setLowPower(false)
 }
 

--- a/scripts/smoke/electron-smoke.mjs
+++ b/scripts/smoke/electron-smoke.mjs
@@ -93,6 +93,13 @@ function attachPageDiagnostics(page) {
     rendererFailures.push(entry)
     console.log(entry)
   })
+  // Console "Failed to load resource" entries omit the URL — log the request
+  // failure itself so the offending resource is identifiable.
+  page.on('requestfailed', (request) => {
+    const entry = `[page-requestfailed] ${request.failure()?.errorText ?? 'unknown'} ${request.url()}`
+    rendererConsole.push(entry)
+    console.log(entry)
+  })
 }
 
 async function seedAppState(page) {
@@ -234,11 +241,13 @@ async function verifySidebarAddToolFlyout(page) {
     const drawerSearch = document.querySelector('.drawer-search')
     return !!flyout && !drawerSearch
   }, { timeout: 30000 })
-  await page.locator('.sidebar-submenu-item--tool', { hasText: 'Wallet' }).first().click()
+  // Wallet owns an activity-bar pack slot now, so it never appears in the
+  // add-tool flyout — pin Ports instead (slot-free, unpinned by default).
+  await page.locator('.sidebar-submenu-item--tool', { hasText: 'Ports' }).first().click()
   await page.waitForFunction(() => document.querySelector('.sidebar-submenu--tools') === null, { timeout: 30000 })
   await page.waitForFunction(() => {
     return Array.from(document.querySelectorAll('.icon-sidebar button[aria-label]'))
-      .some((button) => button.getAttribute('aria-label') === 'Wallet')
+      .some((button) => button.getAttribute('aria-label') === 'Ports')
   }, { timeout: 30000 })
 }
 
@@ -304,7 +313,11 @@ async function run() {
   await page.waitForSelector(`text=${smokeEcho}`, { timeout: 30000 })
 
   logStep('checking hackathon to browser transition')
-  await openToolFromLauncher(page, 'Hackathon', '.hackathon-panel')
+  // Hackathon is folded into the markets pack host — reach it through the
+  // Signalhouse drawer card and its Hackathon sub-tab.
+  await openToolFromLauncher(page, 'Signalhouse', '.sh-docs-link')
+  await page.getByRole('tab', { name: 'Hackathon', exact: true }).click()
+  await page.waitForSelector('.hackathon-panel', { timeout: 30000 })
 
   const tokenLink = page.getByText('Get a token at arena.colosseum.org/copilot')
   if (await tokenLink.isVisible().catch(() => false)) {

--- a/scripts/smoke/packaged-app-smoke.mjs
+++ b/scripts/smoke/packaged-app-smoke.mjs
@@ -196,7 +196,7 @@ async function run() {
   logStep('checking dynamic tool chunks')
   await openToolFromLauncher(page, 'Solana Workflow', '.solana-toolbox')
   await page.getByRole('tab', { name: /^Connect\b/ }).click()
-  await page.waitForSelector('.solana-service-row', { timeout: 30000 })
+  await page.waitForSelector('.ds-card .solana-toggle', { timeout: 30000 })
   await openToolFromLauncher(page, 'Settings', '.settings-center')
 
   logStep('checking packaged native terminal module')

--- a/scripts/smoke/workflow-journeys.mjs
+++ b/scripts/smoke/workflow-journeys.mjs
@@ -218,7 +218,7 @@ async function verifySolanaWorkflowTabs(page) {
   await openToolFromLauncher(page, 'Solana Workflow', '.solana-toolbox')
   const tabs = [
     { name: 'Start', check: () => page.locator('.solana-workflow-title').waitFor({ timeout: 30000 }) },
-    { name: 'Connect', check: () => page.locator('.solana-service-row, .solana-split-title').first().waitFor({ timeout: 30000 }) },
+    { name: 'Connect', check: () => page.locator('.ds-card .solana-toggle, .solana-split-title').first().waitFor({ timeout: 30000 }) },
     { name: 'Build', check: () => page.locator('.solana-ide-panel-title').first().waitFor({ timeout: 30000 }) },
     { name: 'Launch', check: () => page.locator('.solana-protocol-card').first().waitFor({ timeout: 30000 }) },
     { name: 'Inspect', check: () => page.locator('.solana-ide-panel-title').first().waitFor({ timeout: 30000 }) },


### PR DESCRIPTION
The local smoke fleet still drove the pre-packs UI, so the local gate has been silently broken since the v4.3.0 shell refactor (CI only asserts the renderer mounts):

- **Hackathon** lost its drawer card when it folded into the markets pack host — reach it through Signalhouse's Hackathon tab instead.
- **Wallet** owns an activity-bar pack slot, so it never appears in the add-tool flyout — pin Ports there instead.
- Connect-tab services render as \.ds-card\ entries now, not \.solana-service-row\ — updated mcp-stress, workflow-journeys, and packaged-app smoke.
- Log \equestfailed\ events so failed resource loads name their URL (console errors omit it).

Verified locally: electron-smoke, daemon-mcp-stress, and pro-entitlement-flow all pass end to end on current main + v4.4.0.