### PR TITLE
ci(release): raise Node heap to 4GB so the macOS build doesn't OOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# The Vite/tsc production build peaks past Node's ~2GB default heap on the hosted
+# runners (the macOS arm64 job OOM'd with exit 134 on v4.6.2). Give every job a
+# 4GB heap so the build can't run out of memory on any platform.
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
The v4.6.2 `release-macos` job failed with exit 134 (`JavaScript heap out of memory`) during `pnpm run build` on the arm64 runner, which skipped `publish` so no GitHub Release was created. Windows and Linux built the same tree fine.

Sets `NODE_OPTIONS=--max-old-space-size=4096` at the workflow `env` level so every platform build gets a 4GB heap. CI-only change; no app code touched.

After merge, the `v4.6.2` tag is re-cut on the new main HEAD to re-run the release build.