### PR TITLE
feat: npm-packaged MCP bridge shim + registry receipt spike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist-ssr
 dist-electron
 dist-cloud
 dist-bridge
+packages/bridge-shim/daemon-bridge-shim.mjs
+packages/bridge-shim/*.tgz
 release
 *.tsbuildinfo
 *.local

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "aria": "node scripts/aria.mjs",
     "build:daemon-ai-cloud": "vite build --config vite.cloud.config.ts",
     "build:bridge": "vite build --config vite.bridge.config.ts",
+    "build:bridge-pkg": "pnpm run build:bridge && node scripts/build-bridge-pkg.mjs",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch --preserveWatchOutput",
     "mobile:seeker": "npm --prefix apps/seeker-mobile run start",

--- a/packages/bridge-shim/LICENSE
+++ b/packages/bridge-shim/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 nullxnothing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/bridge-shim/README.md
+++ b/packages/bridge-shim/README.md
@@ -1,0 +1,66 @@
+# daemon-bridge-mcp
+
+Stdio MCP server that connects MCP clients (Claude Code, Cursor, and any other Model Context Protocol client) to a running [DAEMON](https://www.daemonide.tech) desktop app.
+
+It exposes DAEMON's bridge tool catalog over MCP: wallet operations, token launch flows, agent memory, and project file reads. The shim itself executes nothing. Every call is forwarded to the DAEMON app on your machine, where policy gating and user approval happen.
+
+**Requires the DAEMON desktop app.** Without DAEMON installed and running, the server starts but every tool call returns a "DAEMON is not running" error. Download DAEMON at [daemonide.tech](https://www.daemonide.tech).
+
+## Setup: Claude Code
+
+1. Install and open the DAEMON desktop app (it registers the bridge on startup).
+2. Add the server:
+
+   ```bash
+   claude mcp add daemon -- npx -y daemon-bridge-mcp
+   ```
+
+   Or add it to `.mcp.json` in your project:
+
+   ```json
+   {
+     "mcpServers": {
+       "daemon": {
+         "command": "npx",
+         "args": ["-y", "daemon-bridge-mcp"]
+       }
+     }
+   }
+   ```
+
+3. Restart Claude Code. The DAEMON tools appear in the tool list; write actions will pause until you approve them inside the DAEMON app.
+
+## Setup: Cursor
+
+1. Install and open the DAEMON desktop app.
+2. Create (or edit) `.cursor/mcp.json` in your project, or `~/.cursor/mcp.json` globally:
+
+   ```json
+   {
+     "mcpServers": {
+       "daemon": {
+         "command": "npx",
+         "args": ["-y", "daemon-bridge-mcp"]
+       }
+     }
+   }
+   ```
+
+3. Reload Cursor and enable the `daemon` server under Settings > MCP. Approvals for write actions still happen inside the DAEMON app.
+
+## What tools are exposed
+
+- **Wallet**: read balances, generate wallets, assign project wallets, store a Helius key.
+- **Launch**: list launchpads, preflight and create token launches.
+- **Memory**: remember, recall, update, and forget agent memory facts.
+- **Project files**: project status, file tree, file reads, and file search.
+
+Read-only tools run automatically. Anything that writes or spends requires explicit user approval inside the DAEMON app, and sensitive actions require typed confirmation there.
+
+## Security model
+
+The shim holds no keys and can approve nothing. It talks only to the DAEMON app over the local loopback interface (127.0.0.1), authenticating with a bearer token it reads from a `bridge.json` file in your user profile, written by the app. All risk gating happens server-side in DAEMON: reads are automatic, writes need in-app user approval, sensitive operations need typed confirmation, and reads of secret files (env files, keypairs) are denied outright. Rotating the token in DAEMON settings immediately invalidates existing shims.
+
+## License
+
+MIT

--- a/packages/bridge-shim/cli.mjs
+++ b/packages/bridge-shim/cli.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// Launcher for the bundled DAEMON bridge shim. The shim itself handles the
+// "DAEMON app not running" case gracefully per call; this wrapper only guards
+// the Node version and a broken install.
+const MIN_NODE_MAJOR = 22
+
+const nodeMajor = Number(process.versions.node.split('.')[0])
+if (Number.isFinite(nodeMajor) && nodeMajor < MIN_NODE_MAJOR) {
+  process.stderr.write(`[daemon-bridge-mcp] Node ${MIN_NODE_MAJOR}+ required (found ${process.versions.node}).\n`)
+  process.exit(1)
+}
+
+import('./daemon-bridge-shim.mjs').catch((error) => {
+  process.stderr.write(`[daemon-bridge-mcp] failed to start: ${error instanceof Error ? error.message : String(error)}\n`)
+  process.stderr.write('[daemon-bridge-mcp] The bundled shim could not be loaded. Reinstall the package, and make sure the DAEMON desktop app is installed: https://www.daemonide.tech\n')
+  process.exit(1)
+})

--- a/packages/bridge-shim/package.json
+++ b/packages/bridge-shim/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "daemon-bridge-mcp",
+  "version": "0.1.0",
+  "description": "Stdio MCP server that connects MCP clients to a running DAEMON desktop app for policy-gated Solana execution: wallet, token launch, memory, and project file tools. Requires the DAEMON app.",
+  "type": "module",
+  "bin": {
+    "daemon-bridge-mcp": "cli.mjs"
+  },
+  "files": [
+    "cli.mjs",
+    "daemon-bridge-shim.mjs"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT",
+  "author": "nullxnothing",
+  "homepage": "https://www.daemonide.tech",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nullxnothing/daemon.git",
+    "directory": "packages/bridge-shim"
+  },
+  "bugs": {
+    "url": "https://github.com/nullxnothing/daemon/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "solana",
+    "wallet",
+    "agent",
+    "security",
+    "daemon"
+  ],
+  "scripts": {
+    "prepublishOnly": "node -e \"require('fs').accessSync('./daemon-bridge-shim.mjs')\""
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,8 @@ importers:
 
   packages/bigint-buffer: {}
 
+  packages/bridge-shim: {}
+
   packages/shared:
     devDependencies:
       typescript:

--- a/scripts/build-bridge-pkg.mjs
+++ b/scripts/build-bridge-pkg.mjs
@@ -1,0 +1,18 @@
+// Stages the built bridge shim into packages/bridge-shim so the npm package
+// ships the exact artifact the app distributes. Run via `pnpm run build:bridge-pkg`.
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const src = path.join(root, 'dist-bridge', 'daemon-bridge-shim.mjs')
+const dest = path.join(root, 'packages', 'bridge-shim', 'daemon-bridge-shim.mjs')
+
+if (!fs.existsSync(src)) {
+  console.error('dist-bridge/daemon-bridge-shim.mjs not found. Run `pnpm run build:bridge` first.')
+  process.exit(1)
+}
+
+fs.copyFileSync(src, dest)
+const sizeKb = Math.round(fs.statSync(dest).size / 1024)
+console.log(`staged ${path.relative(root, dest)} (${sizeKb} kB)`)

--- a/scripts/receipt-spike/.gitignore
+++ b/scripts/receipt-spike/.gitignore
@@ -1,0 +1,3 @@
+out/
+node_modules/
+package-lock.json

--- a/scripts/receipt-spike/autorun.sh
+++ b/scripts/receipt-spike/autorun.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# DEVNET faucets are intermittently dry. This helper polls for devnet SOL on the
+# throwaway key, retrying the sanctioned faucet channels, and fires the spike the
+# instant funds land. Safe to leave running. DEVNET ONLY — throwaway key only.
+set -u
+cd "$(dirname "$0")"
+KEY=out/throwaway-devnet-key.json
+[ -f "$KEY" ] || { echo "run 'node spike.mjs' once to mint the throwaway key first"; exit 1; }
+PK=$(node -e "const{createUmi}=await import('@metaplex-foundation/umi-bundle-defaults');const fs=await import('node:fs');const u=createUmi('https://api.devnet.solana.com');console.log(u.eddsa.createKeypairFromSecretKey(new Uint8Array(JSON.parse(fs.readFileSync('$KEY','utf8')))).publicKey)")
+echo "throwaway key: $PK"
+bal() { curl -s https://api.devnet.solana.com -X POST -H 'Content-Type: application/json' \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getBalance\",\"params\":[\"$PK\"]}" | grep -o '"value":[0-9]*' | grep -o '[0-9]*$'; }
+for i in $(seq 1 120); do
+  b=$(bal); b=${b:-0}
+  if [ "$b" -ge 100000000 ]; then echo "funded ($b lamports) — running spike"; exec node spike.mjs; fi
+  curl -s https://api.devnet.solana.com -X POST -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"requestAirdrop\",\"params\":[\"$PK\",1000000000]}" >/dev/null 2>&1 || true
+  devnet-pow mine -k "$KEY" -u dev -d 2 --reward 0.05 -t 200000000 >/dev/null 2>&1 || true
+  sleep 60
+done
+echo "faucet still dry after ~2h — rerun later or fund $PK manually, then: node spike.mjs"

--- a/scripts/receipt-spike/package.json
+++ b/scripts/receipt-spike/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "daemon-receipt-spike",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "DEVNET-ONLY spike: attested execution receipt into the official Metaplex Agent Registry + memo-anchored content hash. Throwaway airdropped key only — never touches DAEMON vault/keychain.",
+  "scripts": {
+    "spike": "node spike.mjs"
+  },
+  "dependencies": {
+    "@metaplex-foundation/mpl-agent-registry": "0.2.6",
+    "@metaplex-foundation/mpl-bubblegum": "^5.0.2",
+    "@metaplex-foundation/mpl-core": "1.10.0",
+    "@metaplex-foundation/mpl-toolbox": "^0.10.0",
+    "@metaplex-foundation/umi": "^1.4.1",
+    "@metaplex-foundation/umi-bundle-defaults": "^1.4.1"
+  }
+}

--- a/scripts/receipt-spike/retry-airdrop.sh
+++ b/scripts/receipt-spike/retry-airdrop.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Retries the devnet faucet for the spike's throwaway key, then fires autorun.
+PUB="4bfCqhwmNoX44FGGTTQ89HbQj2vWzJZfLTd8GPUiXeS9"
+cd "$(dirname "$0")"
+for i in $(seq 1 12); do
+  BAL=$(solana balance "$PUB" -u devnet 2>/dev/null | grep -oE '^[0-9.]+')
+  if [ -n "$BAL" ] && [ "$(echo "$BAL > 0.01" | bc)" = "1" ]; then
+    echo "[retry-airdrop] funded: $BAL SOL — running autorun"
+    bash autorun.sh > out/autorun.log 2>&1
+    exit 0
+  fi
+  solana airdrop 1 "$PUB" -u devnet >/dev/null 2>&1 && continue
+  sleep 1800
+done
+echo "[retry-airdrop] gave up after 12 rounds (~6h); key still unfunded"
+exit 1

--- a/scripts/receipt-spike/spike.mjs
+++ b/scripts/receipt-spike/spike.mjs
@@ -1,0 +1,246 @@
+/**
+ * DAEMON receipt spike — DEVNET ONLY.
+ *
+ * Proves DAEMON can emit an attested execution receipt into the official
+ * Metaplex Agent Registry (mpl-agent-registry). Full chain:
+ *   1. throwaway airdropped key (never the DAEMON vault)
+ *   2. mint MPL Core asset  -> registerIdentityV1   (agent identity in official registry)
+ *   3. registerExecutiveV1  -> delegateExecutionV1  (executive may act for the agent)
+ *   4. bootstrap receipts collection + Bubblegum receipts tree (canonical PDAs, permissionless payer)
+ *   5. mintWorkReceiptV1    (cNFT work receipt carrying sha256 of the receipt JSON)
+ *   6. SPL Memo anchor of the same sha256 (belt-and-braces fallback path)
+ *
+ * Run: node spike.mjs   (from scripts/receipt-spike after npm install)
+ */
+import { createHash } from 'node:crypto'
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults'
+import { generateSigner, keypairIdentity, publicKey, sol } from '@metaplex-foundation/umi'
+import { base58 } from '@metaplex-foundation/umi/serializers'
+import { mplCore, create } from '@metaplex-foundation/mpl-core'
+import { addMemo, mplToolbox } from '@metaplex-foundation/mpl-toolbox'
+import { findTreeConfigPda, MPL_BUBBLEGUM_PROGRAM_ID } from '@metaplex-foundation/mpl-bubblegum'
+import {
+  mplAgentIdentity, mplAgentTools,
+  registerIdentityV1, registerExecutiveV1, delegateExecutionV1,
+  createReceiptsCollectionV1, registerReceiptsTreeV1, mintWorkReceiptV1,
+  findAgentIdentityV1Pda, findExecutiveProfileV1Pda, findExecutionDelegateRecordV1Pda,
+  findReceiptsCollectionPda, findReceiptsAuthorityPda, findReceiptsTreePda,
+} from '@metaplex-foundation/mpl-agent-registry'
+
+const DEVNET_RPC = 'https://api.devnet.solana.com'
+const DEVNET_GENESIS = 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG'
+const MPL_CORE_CPI_SIGNER = publicKey('CbNY3JiXdXNE9tPNEk1aRZVEkWdj2v7kfJLNQwZZgpXk')
+const HERE = dirname(fileURLToPath(import.meta.url))
+const OUT_DIR = join(HERE, 'out')
+const KEY_FILE = process.env.SPIKE_KEY_FILE ?? join(OUT_DIR, 'throwaway-devnet-key.json')
+
+const explorer = (sig) => `https://explorer.solana.com/tx/${sig}?cluster=devnet`
+const log = (...a) => console.log('[spike]', ...a)
+
+function sha256Hex(text) {
+  return createHash('sha256').update(text, 'utf8').digest('hex')
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort()
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(value[k])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function loadOrCreateThrowawayKey(umi) {
+  if (existsSync(KEY_FILE)) {
+    const secret = new Uint8Array(JSON.parse(readFileSync(KEY_FILE, 'utf8')))
+    return umi.eddsa.createKeypairFromSecretKey(secret)
+  }
+  const kp = umi.eddsa.generateKeypair()
+  mkdirSync(OUT_DIR, { recursive: true })
+  writeFileSync(KEY_FILE, JSON.stringify(Array.from(kp.secretKey)))
+  return kp
+}
+
+async function assertDevnet() {
+  const res = await fetch(DEVNET_RPC, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getGenesisHash' }),
+  })
+  const genesis = (await res.json()).result
+  if (genesis !== DEVNET_GENESIS) throw new Error(`RPC is not devnet (genesis ${genesis}) — refusing to continue`)
+  log('cluster check OK: devnet genesis', genesis)
+}
+
+async function ensureFunds(umi) {
+  const min = sol(0.6).basisPoints
+  let balance = (await umi.rpc.getBalance(umi.identity.publicKey)).basisPoints
+  log('throwaway key', umi.identity.publicKey, 'balance', Number(balance) / 1e9, 'SOL')
+  if (balance >= min) return
+  for (const amount of [2, 1, 0.5]) {
+    try {
+      log(`requesting devnet airdrop of ${amount} SOL...`)
+      await umi.rpc.airdrop(umi.identity.publicKey, sol(amount), { commitment: 'confirmed' })
+      balance = (await umi.rpc.getBalance(umi.identity.publicKey)).basisPoints
+      log('balance after airdrop:', Number(balance) / 1e9, 'SOL')
+      if (balance >= min) return
+    } catch (e) {
+      log(`airdrop ${amount} SOL failed:`, e.message ?? e)
+    }
+  }
+  if (balance === 0n) throw new Error('devnet faucet dry — rerun later, key is persisted')
+}
+
+async function send(umi, builder, label) {
+  const { signature } = await builder.sendAndConfirm(umi, { confirm: { commitment: 'confirmed' } })
+  const sig = base58.deserialize(signature)[0]
+  log(`${label}: ${sig}`)
+  log(`  ${explorer(sig)}`)
+  return sig
+}
+
+async function main() {
+  const umi = createUmi(DEVNET_RPC)
+    .use(mplCore()).use(mplToolbox()).use(mplAgentIdentity()).use(mplAgentTools())
+  await assertDevnet(umi)
+
+  const throwaway = loadOrCreateThrowawayKey(umi)
+  umi.use(keypairIdentity(throwaway))
+  await ensureFunds(umi)
+
+  const signatures = {}
+  const state = existsSync(join(OUT_DIR, 'state.json'))
+    ? JSON.parse(readFileSync(join(OUT_DIR, 'state.json'), 'utf8'))
+    : {}
+  const saveState = () => writeFileSync(join(OUT_DIR, 'state.json'), JSON.stringify(state, null, 2))
+
+  // ---- Stage 1: agent identity in the official registry ----
+  let assetPk
+  if (state.asset) {
+    assetPk = publicKey(state.asset)
+    log('reusing agent asset', assetPk)
+  } else {
+    const asset = generateSigner(umi)
+    assetPk = asset.publicKey
+    signatures.mintAsset = await send(umi,
+      create(umi, {
+        asset,
+        name: 'DAEMON Spike Agent',
+        uri: 'https://daemon.dev/agents/spike-agent.json',
+      }), 'mint MPL Core agent asset')
+    state.asset = assetPk
+    saveState()
+  }
+
+  const [identityPda] = findAgentIdentityV1Pda(umi, { asset: assetPk })
+  if (!(await umi.rpc.getAccount(identityPda)).exists) {
+    signatures.registerIdentity = await send(umi,
+      registerIdentityV1(umi, { agentIdentity: identityPda, asset: assetPk }),
+      'registerIdentityV1 (official Agent Registry)')
+  } else {
+    log('identity already registered:', identityPda)
+  }
+
+  // ---- Stage 2: executive profile + execution delegation ----
+  const [executiveProfile] = findExecutiveProfileV1Pda(umi, { authority: umi.identity.publicKey })
+  if (!(await umi.rpc.getAccount(executiveProfile)).exists) {
+    signatures.registerExecutive = await send(umi,
+      registerExecutiveV1(umi, { executiveProfile, authority: umi.identity }),
+      'registerExecutiveV1')
+  } else {
+    log('executive profile exists:', executiveProfile)
+  }
+
+  const [delegateRecord] = findExecutionDelegateRecordV1Pda(umi, { executiveProfile, agentAsset: assetPk })
+  if (!(await umi.rpc.getAccount(delegateRecord)).exists) {
+    signatures.delegateExecution = await send(umi,
+      delegateExecutionV1(umi, {
+        executiveProfile, agentAsset: assetPk, agentIdentity: identityPda,
+        executionDelegateRecord: delegateRecord, authority: umi.identity,
+      }), 'delegateExecutionV1')
+  } else {
+    log('delegate record exists:', delegateRecord)
+  }
+
+  // ---- Stage 3: the execution receipt (synthetic record, content-hash only) ----
+  const receipt = {
+    spec: 'daemon-receipt/1',
+    agent: { assetAddress: assetPk, identityPda, registry: 'mpl-agent-registry' },
+    action: { type: 'swap.execute', tool: 'autopilot_swap', summary: 'SYNTHETIC devnet spike: 0.1 SOL -> USDC quote accepted' },
+    cluster: 'devnet',
+    policy: { verdict: 'approved', mode: 'auto', riskTier: 'write', mandateId: 'spike-mandate-001' },
+    executionTxSignature: null,
+    operator: umi.identity.publicKey,
+    timestamp: new Date().toISOString(),
+  }
+  const receiptCanonical = canonicalJson(receipt)
+  const receiptHash = sha256Hex(receiptCanonical)
+  writeFileSync(join(OUT_DIR, 'receipt.json'), JSON.stringify(receipt, null, 2))
+  log('receipt sha256:', receiptHash)
+
+  // ---- Stage 4: registry-native work receipt (cNFT) — bootstrap infra if absent ----
+  let workReceiptOk = false
+  try {
+    const [collection] = findReceiptsCollectionPda(umi)
+    if (!(await umi.rpc.getAccount(collection)).exists) {
+      signatures.createReceiptsCollection = await send(umi,
+        createReceiptsCollectionV1(umi, {}), 'createReceiptsCollectionV1 (bootstrap devnet)')
+    }
+    const treeIndex = 0
+    const [merkleTree] = findReceiptsTreePda(umi, { treeIndex })
+    const treeConfig = findTreeConfigPda(umi, { merkleTree })
+    if (!(await umi.rpc.getAccount(merkleTree)).exists) {
+      const balance = (await umi.rpc.getBalance(umi.identity.publicKey)).basisPoints
+      const [maxDepth, maxBufferSize] = balance >= sol(0.5).basisPoints ? [14, 64] : [3, 8]
+      signatures.registerReceiptsTree = await send(umi,
+        registerReceiptsTreeV1(umi, { merkleTree, treeConfig, treeIndex, maxDepth, maxBufferSize, canopyDepth: 0 }),
+        `registerReceiptsTreeV1 (depth ${maxDepth}, buffer ${maxBufferSize})`)
+    }
+    signatures.mintWorkReceipt = await send(umi,
+      mintWorkReceiptV1(umi, {
+        executiveAuthority: umi.identity,
+        executionDelegateRecord: delegateRecord,
+        agentAsset: assetPk,
+        client: umi.identity.publicKey,
+        treeConfig,
+        merkleTree,
+        mplCoreCpiSigner: MPL_CORE_CPI_SIGNER,
+        treeIndex,
+        receiptUri: `daemon://receipt/v1?sha256=${receiptHash}`,
+      }), 'mintWorkReceiptV1 (registry-native execution receipt)')
+    workReceiptOk = true
+  } catch (e) {
+    log('registry-native work receipt path FAILED (falling back to memo only):', e.message ?? e)
+    if (e.logs) log(e.logs.join('\n'))
+  }
+
+  // ---- Stage 5: memo-anchored content hash (always) ----
+  signatures.memoAnchor = await send(umi,
+    addMemo(umi, { memo: `DAEMON-RECEIPT v1 sha256=${receiptHash} agent=${assetPk}` }),
+    'SPL Memo anchor of receipt hash')
+
+  const summary = {
+    cluster: 'devnet',
+    throwawayKey: umi.identity.publicKey,
+    agentAsset: assetPk,
+    identityPda,
+    executiveProfile,
+    delegateRecord,
+    receiptSha256: receiptHash,
+    registryNativeWorkReceipt: workReceiptOk,
+    signatures,
+    explorerUrls: Object.fromEntries(Object.entries(signatures).map(([k, v]) => [k, explorer(v)])),
+  }
+  writeFileSync(join(OUT_DIR, 'summary.json'), JSON.stringify(summary, null, 2))
+  log('=== SUMMARY ===')
+  console.log(JSON.stringify(summary, null, 2))
+}
+
+main().catch((e) => {
+  console.error('[spike] FATAL:', e)
+  if (e.logs) console.error(e.logs.join('\n'))
+  process.exit(1)
+})


### PR DESCRIPTION
Two pieces of the receipts/distribution track:

- packages/bridge-shim: publishable daemon-bridge-mcp package (bin wrapper, Node 22 guard, files whitelist, README with Claude Code/Cursor setup). npm pack/publish dry-runs clean; packed tarball tested via temp-prefix install including the graceful path when the DAEMON app is not running. Publish itself is a manual owner step.
- scripts/receipt-spike: standalone devnet spike for attested execution receipts against the live Metaplex Agent Registry programs (identity/executive/delegate/work-receipt flow + memo fallback). npm-isolated, excluded from repo tsconfig and vitest; touches no app code.

Suite 1027 passing, typecheck and build green. No money-path changes.