### PR TITLE
Release v4.6.3 — first-session fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to DAEMON are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 follows semantic-ish desktop release versioning.
 
+## [4.6.3] - 2026-07-03
+
+### Fixed
+- **Memory and Deploy activity-bar icons open their panels again.** Pack-owned plugin rows were
+  never seeded in the workspace tool registry, so the pack toggle's update no-oped and the icons
+  opened nothing on a fresh install. Migration V58 backfills the rows, and pack-owned plugins now
+  resolve from live pack state.
+- **Plain questions to the engine no longer escalate to approval cards.** The `ask` action was
+  removed from `run_engine_action`, and after an audit confirmed the engine service performs no
+  disk writes in any diagnostics handler, engine diagnostics were reclassified to the read tier
+  and auto-run. Scaffold/create actions still write to disk and still require an approval card.
+- **Activity panel no longer floods with toolchain probe spam.** The probe logs its first result
+  and state transitions only; identical rows collapse behind an occurrence badge with an install
+  hint. Info/success rows collapse only on exact repeats, so distinct deploys stay distinct
+  instead of being folded into one row.
+- **Tab strip handles overflow.** The active tab scrolls into view and overflow chevrons appear
+  when the strip is wider than the panel.
+
 ## [4.6.2] - 2026-07-02
 
 ### Fixed

--- a/Whatsnew.md
+++ b/Whatsnew.md
@@ -21,6 +21,13 @@ DAEMON v4.6 turns the operator into a full trading and execution surface: unatte
 - Bridge and ARIA file reads deny secret-bearing paths (.env, keypairs, key material) and enforce real-path containment.
 - Swarm lanes run with a minimal allowlisted environment and have push disabled at the git layer.
 
+## First-session polish (4.6.3)
+
+- Memory and Deploy icons open their panels on a fresh install.
+- Plain questions to the engine answer directly; only actions that write to disk raise an approval card.
+- The activity panel collapses repeated toolchain probes behind a count badge instead of flooding the log.
+- The tab strip scrolls the active tab into view and shows chevrons when tabs overflow.
+
 ## Verification
 
 - `pnpm run typecheck && pnpm run test && pnpm run build`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",


### PR DESCRIPTION
Patch release rolling up the first-session fixes from #213.

## Fixed
- **Memory/Deploy activity-bar icons open their panels again** — pack-owned plugin rows were never seeded, so the pack toggle's update no-oped on a fresh install. Migration V58 backfills the rows; pack-owned plugins now resolve from live pack state.
- **Plain questions no longer escalate to approval cards** — the `ask` action was removed from `run_engine_action`, and after an audit confirmed the engine service performs no disk writes in any diagnostics handler, engine diagnostics were reclassified read-tier and auto-run. Scaffold/create writes still raise an approval card.
- **Activity panel probe spam collapsed** — the toolchain probe logs first result + transitions only; identical rows fold behind an occurrence badge with an install hint. Info/success rows collapse only on exact repeats, so distinct deploys stay distinct.
- **Tab strip overflow** — the active tab scrolls into view and chevrons appear when tabs overflow.

## Release contents
- `package.json` → 4.6.3
- `CHANGELOG.md` 4.6.3 entry
- `Whatsnew.md` first-session polish section

## Verification (from #213)
- typecheck, build, lint:styles green; suite 1027 passing (baseline 1003, none skipped); live CDP sweep green (memory opens, x128 collapse, 13-tab overflow, read path silent, write gate blocks).