### PR TITLE
fix: refresh stale model ids on upgrade + surface rejected API keys

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -706,6 +706,17 @@ export function runMigrations(db: Database.Database) {
     })()
   }
 
+  if (currentVersion < 59) {
+    db.transaction(() => {
+      // Fresh installs seed agents with current model aliases, but upgraded
+      // installs kept rows pointing at models DAEMON seeded in old releases
+      // that Anthropic has since superseded. Refresh only those exact IDs —
+      // a still-valid model the user picked on purpose is never rewritten.
+      refreshSupersededAgentModels(db)
+      db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(59)
+    })()
+  }
+
   // Ensure Solana agent exists (idempotent — handles existing DBs before it was seeded)
   try {
     const hasSolanaAgent = db.prepare("SELECT id FROM agents WHERE id = 'solana-agent'").get()
@@ -891,6 +902,26 @@ Output: bullet points with inline citations. Be direct. No fluff.`,
 
   // Clean stale sessions from previous crashed runs — PTY processes are dead after restart
   db.prepare('DELETE FROM active_sessions').run()
+}
+
+/**
+ * Model IDs DAEMON itself seeded in past releases that no longer resolve as
+ * defaults on current Anthropic surfaces, mapped to their current aliases.
+ * Deliberately an exact allowlist: anything else on an agent row — including
+ * still-valid dated snapshots like the Haiku 4.5 ID — is treated as a user
+ * choice and left alone.
+ */
+export const SUPERSEDED_AGENT_MODELS: Record<string, string> = {
+  'claude-sonnet-4-20250514': 'claude-sonnet-4-6',
+  'claude-opus-4-20250514': 'claude-opus-4-8',
+}
+
+/** Rewrite agent rows whose model is a known-superseded seed ID (exact match only). */
+export function refreshSupersededAgentModels(db: Database.Database): void {
+  const update = db.prepare('UPDATE agents SET model = ? WHERE model = ?')
+  for (const [staleId, currentId] of Object.entries(SUPERSEDED_AGENT_MODELS)) {
+    update.run(currentId, staleId)
+  }
 }
 
 function seedDefaults(db: Database.Database) {

--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -1,5 +1,6 @@
 import type Database from 'better-sqlite3'
 import { SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4, SCHEMA_V5, SCHEMA_V6, SCHEMA_V7, SCHEMA_V8, SCHEMA_V9, SCHEMA_V10, SCHEMA_V11, SCHEMA_V12, SCHEMA_V13, SCHEMA_V14, SCHEMA_V15, SCHEMA_V16, SCHEMA_V17, SCHEMA_V18, SCHEMA_V19, SCHEMA_V20, SCHEMA_V21, SCHEMA_V22, SCHEMA_V23, SCHEMA_V24, SCHEMA_V25, SCHEMA_V26, SCHEMA_V27, SCHEMA_V28, SCHEMA_V29, SCHEMA_V30, SCHEMA_V31, SCHEMA_V32, SCHEMA_V33, SCHEMA_V34, SCHEMA_V35, SCHEMA_V36, SCHEMA_V37, SCHEMA_V38, SCHEMA_V39, SCHEMA_V40, SCHEMA_V41, SCHEMA_V42, SCHEMA_V43, SCHEMA_V44, SCHEMA_V45, SCHEMA_V46, SCHEMA_V47, SCHEMA_V48, SCHEMA_V49, SCHEMA_V50, SCHEMA_V51, SCHEMA_V52, SCHEMA_V53, SCHEMA_V54, SCHEMA_V55, SCHEMA_V56, SCHEMA_V57 } from './schema'
+import { CLAUDE_MODEL_IDS } from '../../packages/shared/src/constants'
 
 export function runMigrations(db: Database.Database) {
   db.exec(`
@@ -717,6 +718,16 @@ export function runMigrations(db: Database.Database) {
     })()
   }
 
+  if (currentVersion < 60) {
+    db.transaction(() => {
+      // Same refresh for Agent Station rows: the station's model picker itself
+      // offered superseded Claude IDs in earlier releases, so those values are
+      // DAEMON-originated — not user inventions — and safe to remap.
+      refreshSupersededStationModels(db)
+      db.prepare('INSERT INTO _migrations (version) VALUES (?)').run(60)
+    })()
+  }
+
   // Ensure Solana agent exists (idempotent — handles existing DBs before it was seeded)
   try {
     const hasSolanaAgent = db.prepare("SELECT id FROM agents WHERE id = 'solana-agent'").get()
@@ -912,14 +923,33 @@ Output: bullet points with inline citations. Be direct. No fluff.`,
  * choice and left alone.
  */
 export const SUPERSEDED_AGENT_MODELS: Record<string, string> = {
-  'claude-sonnet-4-20250514': 'claude-sonnet-4-6',
-  'claude-opus-4-20250514': 'claude-opus-4-8',
+  'claude-sonnet-4-20250514': CLAUDE_MODEL_IDS.sonnet,
+  'claude-opus-4-20250514': CLAUDE_MODEL_IDS.opus,
+}
+
+/**
+ * Model IDs the Agent Station picker offered in past releases that are no
+ * longer in the sanctioned set. Station rows only ever hold picker values, so
+ * every entry here is DAEMON-originated. Non-Claude models (gpt-*) pass
+ * through untouched.
+ */
+export const SUPERSEDED_STATION_MODELS: Record<string, string> = {
+  'claude-opus-4-20250514': CLAUDE_MODEL_IDS.opus,
+  'claude-sonnet-4-5': CLAUDE_MODEL_IDS.sonnet,
 }
 
 /** Rewrite agent rows whose model is a known-superseded seed ID (exact match only). */
 export function refreshSupersededAgentModels(db: Database.Database): void {
   const update = db.prepare('UPDATE agents SET model = ? WHERE model = ?')
   for (const [staleId, currentId] of Object.entries(SUPERSEDED_AGENT_MODELS)) {
+    update.run(currentId, staleId)
+  }
+}
+
+/** Rewrite Agent Station rows whose model is a superseded picker value (exact match only). */
+export function refreshSupersededStationModels(db: Database.Database): void {
+  const update = db.prepare('UPDATE agent_station_configs SET model = ? WHERE model = ?')
+  for (const [staleId, currentId] of Object.entries(SUPERSEDED_STATION_MODELS)) {
     update.run(currentId, staleId)
   }
 }

--- a/electron/services/AriaAgentService.ts
+++ b/electron/services/AriaAgentService.ts
@@ -9,7 +9,8 @@
  */
 import crypto from 'node:crypto'
 import { getDb } from '../db/db'
-import { runClaudeAgentTurn } from './providers/ClaudeProvider'
+import { runClaudeAgentTurn, getClaudeKeySource } from './providers/ClaudeProvider'
+import { isAnthropicAuthError, describeClaudeAuthFailure } from './providers/claudeAuth'
 import * as ProviderRegistry from './providers/ProviderRegistry'
 import { resolveOperatorBackend, getGlmEndpoint, type OperatorBackend, type OperatorEndpoint } from './providers/glmConfig'
 import { recordLocalAiUsage } from './DaemonAIService'
@@ -361,11 +362,18 @@ export async function sendMessage(
       messages.push({ role: 'user', content: toolResults })
     }
   } catch (err) {
+    // A rejected Anthropic credential (e.g. a disabled-org ANTHROPIC_API_KEY
+    // inherited from the shell) must not silently downgrade the operator to
+    // the tool-less CLI path — name the failing key source and how to fix it.
+    // GLM turns (endpoint set) fail on the ZAI key, not the Anthropic one.
+    const authNotice = !endpoint && isAnthropicAuthError(err)
+      ? describeClaudeAuthFailure(getClaudeKeySource())
+      : null
     const fallback = ProviderRegistry.getFeatureProvider('aria')
     if (fallback.id === 'claude' && await verifyPreferredProvider('claude')) {
-      return legacyAnswer(sessionId, userMessage, fallback, text, transport)
+      return legacyAnswer(sessionId, userMessage, fallback, text, transport, authNotice ?? undefined)
     }
-    finalText = `Error: ${(err as Error).message}`
+    finalText = authNotice ?? `Error: ${(err as Error).message}`
   }
 
   // Any plan steps left un-flipped are done once the loop settles.
@@ -711,13 +719,16 @@ function describeIntent(tool: AriaTool, input: Record<string, unknown>): string 
   return clusterMark(`${tool.name}${detail}`)
 }
 
-/** Non-Claude providers: single-shot text answer, no tools. */
+/** Non-Claude providers: single-shot text answer, no tools. When the caller is
+ *  degrading here because of an auth failure, `notice` is prepended to the
+ *  reply so the loss of operator tools is never silent. */
 async function legacyAnswer(
   sessionId: string,
   userMessage: string,
   provider: ReturnType<typeof ProviderRegistry.getFeatureProvider>,
   text: ConversationEntry[],
   transport: AriaTransport,
+  notice?: string,
 ): Promise<AriaResponse> {
   const prompt = [
     'ARIA side-panel conversation:',
@@ -725,7 +736,8 @@ async function legacyAnswer(
     '',
     'Respond as ARIA, concise and direct.',
   ].join('\n')
-  const out = await provider.runPrompt({ prompt, model: 'sonnet', effort: 'low', maxTokens: 1024, timeoutMs: 60_000 })
+  const answer = await provider.runPrompt({ prompt, model: 'sonnet', effort: 'low', maxTokens: 1024, timeoutMs: 60_000 })
+  const out = notice ? `${notice}\n\n${answer}` : answer
   text.push({ role: 'assistant', content: out })
   persistMessage({ role: 'assistant', content: out, metadata: '{}', session_id: sessionId })
   transport.emit({ kind: 'done', messageId: sessionId, text: out })

--- a/electron/services/AriaAgentService.ts
+++ b/electron/services/AriaAgentService.ts
@@ -304,6 +304,7 @@ export async function sendMessage(
   const endpoint = backend === 'glm' ? getGlmEndpoint() ?? undefined : undefined
 
   let finalText = ''
+  let turnNotice: string | null = null
   const deadline = Date.now() + AGENT_DEADLINE_MS
   let promptForUsage = userMessage
   let retriedStaleNoToolResponse = false
@@ -366,14 +367,22 @@ export async function sendMessage(
     // inherited from the shell) must not silently downgrade the operator to
     // the tool-less CLI path — name the failing key source and how to fix it.
     // GLM turns (endpoint set) fail on the ZAI key, not the Anthropic one.
-    const authNotice = !endpoint && isAnthropicAuthError(err)
-      ? describeClaudeAuthFailure(getClaudeKeySource())
-      : null
+    const failedKeySource = !endpoint && isAnthropicAuthError(err) ? getClaudeKeySource() : null
+    const authNotice = failedKeySource !== null ? describeClaudeAuthFailure(failedKeySource) : null
+    if (authNotice) {
+      // Surface as a warning banner, separate from the reply text. Log the
+      // key SOURCE only — key values never reach logs or the transcript.
+      console.warn(`[AriaAgent] Anthropic auth rejected (key source: ${failedKeySource}); operator tools are offline for this turn.`)
+      transport.emit({ kind: 'notice', messageId: sessionId, level: 'warn', text: authNotice })
+    }
     const fallback = ProviderRegistry.getFeatureProvider('aria')
     if (fallback.id === 'claude' && await verifyPreferredProvider('claude')) {
       return legacyAnswer(sessionId, userMessage, fallback, text, transport, authNotice ?? undefined)
     }
-    finalText = authNotice ?? `Error: ${(err as Error).message}`
+    turnNotice = authNotice
+    finalText = authNotice
+      ? 'Anthropic API authentication failed, so this turn could not run any operator tools.'
+      : `Error: ${(err as Error).message}`
   }
 
   // Any plan steps left un-flipped are done once the loop settles.
@@ -403,6 +412,7 @@ export async function sendMessage(
       toolCalls,
       ...(turnState.plan.length ? { plan: turnState.plan } : {}),
       ...(turnState.patch ? { patch: turnState.patch } : {}),
+      ...(turnNotice ? { notice: turnNotice } : {}),
     }),
     session_id: sessionId,
   })
@@ -720,8 +730,9 @@ function describeIntent(tool: AriaTool, input: Record<string, unknown>): string 
 }
 
 /** Non-Claude providers: single-shot text answer, no tools. When the caller is
- *  degrading here because of an auth failure, `notice` is prepended to the
- *  reply so the loss of operator tools is never silent. */
+ *  degrading here because of an auth failure, it emits a `notice` banner first
+ *  and passes the text along so the condition also survives a history reload
+ *  (via message metadata) — the reply itself stays clean. */
 async function legacyAnswer(
   sessionId: string,
   userMessage: string,
@@ -737,11 +748,15 @@ async function legacyAnswer(
     'Respond as ARIA, concise and direct.',
   ].join('\n')
   const answer = await provider.runPrompt({ prompt, model: 'sonnet', effort: 'low', maxTokens: 1024, timeoutMs: 60_000 })
-  const out = notice ? `${notice}\n\n${answer}` : answer
-  text.push({ role: 'assistant', content: out })
-  persistMessage({ role: 'assistant', content: out, metadata: '{}', session_id: sessionId })
-  transport.emit({ kind: 'done', messageId: sessionId, text: out })
-  return { text: out, actions: [], toolCalls: [] }
+  text.push({ role: 'assistant', content: answer })
+  persistMessage({
+    role: 'assistant',
+    content: answer,
+    metadata: notice ? JSON.stringify({ notice }) : '{}',
+    session_id: sessionId,
+  })
+  transport.emit({ kind: 'done', messageId: sessionId, text: answer })
+  return { text: answer, actions: [], toolCalls: [] }
 }
 
 export function getHistory(sessionId: string, limit = 50): AriaMessage[] {

--- a/electron/services/ClaudeAgentService.ts
+++ b/electron/services/ClaudeAgentService.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
+import { CLAUDE_MODEL_IDS } from '../../packages/shared/src/constants'
 import type { ClaudeAgentFile } from '../shared/types'
 
 export type { ClaudeAgentFile }
@@ -76,12 +77,12 @@ function parseSimpleFrontmatter(frontmatter: string): Record<string, string> {
 function normalizeModel(model: string | undefined): string {
   switch ((model ?? '').toLowerCase()) {
     case 'opus':
-      return 'claude-opus-4-8'
+      return CLAUDE_MODEL_IDS.opus
     case 'sonnet':
-      return 'claude-sonnet-4-6'
+      return CLAUDE_MODEL_IDS.sonnet
     case 'haiku':
-      return 'claude-haiku-4-5-20251001'
+      return CLAUDE_MODEL_IDS.haiku
     default:
-      return model && model.length > 0 ? model : 'claude-sonnet-4-6'
+      return model && model.length > 0 ? model : CLAUDE_MODEL_IDS.sonnet
   }
 }

--- a/electron/services/ClaudeRouter.ts
+++ b/electron/services/ClaudeRouter.ts
@@ -7,6 +7,7 @@ import * as SecureKey from './SecureKeyService'
 import { sanitizeAiPrompt } from '../security/PrivacyGuard'
 import { writeProjectMcpConfig, readProjectMcpConfig, getRegistryMcps, hasProjectMcpFile } from './McpConfig'
 import { getRegisteredPorts } from './PortService'
+import { MODEL_MAP } from '../../packages/shared/src/constants'
 import type { ClaudeConnection } from '../shared/types'
 
 // --- In-memory cache ---
@@ -385,12 +386,7 @@ function buildPortMap(): string {
 }
 
 function resolveModelName(shorthand: string): string {
-  const modelMap: Record<string, string> = {
-    'haiku': 'claude-haiku-4-5-20251001',
-    'sonnet': 'claude-sonnet-4-6',
-    'opus': 'claude-opus-4-8',
-  }
-  return modelMap[shorthand] ?? shorthand
+  return MODEL_MAP[shorthand] ?? shorthand
 }
 
 function buildSubscriptionEnv(): NodeJS.ProcessEnv {

--- a/electron/services/providers/ClaudeProvider.ts
+++ b/electron/services/providers/ClaudeProvider.ts
@@ -9,6 +9,7 @@ import { TIMEOUTS } from '../../config/constants'
 import { writeProjectMcpConfig, readProjectMcpConfig, getRegistryMcps, hasProjectMcpFile } from '../McpConfig'
 import { parseContextTags, stripContextTags, buildPortMap, buildEmailContext, buildMppContext } from './contextUtils'
 import { resolveClaudeKeySource, type ClaudeKeySource } from './claudeAuth'
+import { MODEL_MAP } from '../../../packages/shared/src/constants'
 import type { ProviderInterface, ProviderConnection, ProviderBuildResult, ProviderRunPromptOpts, AgentRow, ProjectRow } from './ProviderInterface'
 import type { RunAgentTurnOpts, AgentTurnResult, AgentToolUse } from './agentTurn'
 
@@ -18,12 +19,6 @@ let cachedConnection: ProviderConnection | null = null
 let cachedClaudePath: string | null = null
 
 // --- Model Resolution ---
-
-const MODEL_MAP: Record<string, string> = {
-  'haiku': 'claude-haiku-4-5-20251001',
-  'sonnet': 'claude-sonnet-4-6',
-  'opus': 'claude-opus-4-8',
-}
 
 function resolveModelName(shorthand: string): string {
   return MODEL_MAP[shorthand] ?? shorthand

--- a/electron/services/providers/ClaudeProvider.ts
+++ b/electron/services/providers/ClaudeProvider.ts
@@ -8,6 +8,7 @@ import * as SecureKey from '../SecureKeyService'
 import { TIMEOUTS } from '../../config/constants'
 import { writeProjectMcpConfig, readProjectMcpConfig, getRegistryMcps, hasProjectMcpFile } from '../McpConfig'
 import { parseContextTags, stripContextTags, buildPortMap, buildEmailContext, buildMppContext } from './contextUtils'
+import { resolveClaudeKeySource, type ClaudeKeySource } from './claudeAuth'
 import type { ProviderInterface, ProviderConnection, ProviderBuildResult, ProviderRunPromptOpts, AgentRow, ProjectRow } from './ProviderInterface'
 import type { RunAgentTurnOpts, AgentTurnResult, AgentToolUse } from './agentTurn'
 
@@ -367,6 +368,15 @@ function withToolCache(tools: RunAgentTurnOpts['tools']): unknown[] {
   return tools.map((tool, i) =>
     i === tools.length - 1 ? { ...tool, cache_control: { type: 'ephemeral' } } : tool
   )
+}
+
+/**
+ * Where runClaudeAgentTurn's key would come from right now (stored key shadows
+ * the shell env — same order as the resolution below). Used to explain auth
+ * failures to the user without ever exposing key material.
+ */
+export function getClaudeKeySource(): ClaudeKeySource {
+  return resolveClaudeKeySource(() => SecureKey.getKey('ANTHROPIC_API_KEY'), process.env)
 }
 
 export async function runClaudeAgentTurn(

--- a/electron/services/providers/claudeAuth.ts
+++ b/electron/services/providers/claudeAuth.ts
@@ -1,0 +1,51 @@
+/**
+ * Anthropic credential-source introspection for the ARIA operator loop.
+ *
+ * runClaudeAgentTurn resolves its API key as stored (SecureKeyService) first,
+ * then the shell environment. When the key in play is rejected, the operator
+ * must tell the user which credential failed and how to fix it instead of
+ * silently degrading to the tool-less CLI fallback. This module is pure so it
+ * stays trivially testable; key VALUES never pass through it — sources only.
+ */
+
+export type ClaudeKeySource = 'stored' | 'env' | 'none'
+
+/**
+ * Mirror of runClaudeAgentTurn's key precedence: a stored key shadows the
+ * shell environment. A throwing key reader (secure storage unavailable)
+ * falls through to the environment, matching the runtime behavior.
+ */
+export function resolveClaudeKeySource(
+  readStoredKey: () => string | null | undefined,
+  env: Record<string, string | undefined>,
+): ClaudeKeySource {
+  try {
+    if (readStoredKey()) return 'stored'
+  } catch { /* secure storage unavailable — fall through to env */ }
+  if (env.ANTHROPIC_API_KEY) return 'env'
+  return 'none'
+}
+
+/**
+ * True for Anthropic auth/permission rejections (invalid, revoked, or
+ * disabled-org keys). Rate limits, overloads, and network failures are NOT
+ * auth errors — those should keep their original error message.
+ */
+export function isAnthropicAuthError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const status = (err as { status?: unknown }).status
+  if (status === 401 || status === 403) return true
+  const message = err instanceof Error ? err.message : ''
+  return /authentication_error|permission_error|invalid x-api-key|organization has been disabled/i.test(message)
+}
+
+/** Actionable user-facing explanation for an auth failure, keyed by credential source. */
+export function describeClaudeAuthFailure(source: ClaudeKeySource): string {
+  if (source === 'env') {
+    return 'ARIA operator tools are unavailable: the ANTHROPIC_API_KEY inherited from your shell environment was rejected by the Anthropic API (invalid or disabled). Unset that environment variable or save a valid key in Settings > AI Providers to restore tools. Answering without tools for now.'
+  }
+  if (source === 'stored') {
+    return 'ARIA operator tools are unavailable: the Anthropic API key saved in Settings was rejected (invalid or disabled). Replace it in Settings > AI Providers to restore tools. Answering without tools for now.'
+  }
+  return 'ARIA operator tools are unavailable: Anthropic API authentication failed. Add a valid API key in Settings > AI Providers to restore tools. Answering without tools for now.'
+}

--- a/electron/shared/types.ts
+++ b/electron/shared/types.ts
@@ -2915,6 +2915,8 @@ export type AriaToolEvent =
   | { kind: 'action-result'; proposalId: string; action: AriaPatchAction; status: 'applied' | 'rejected' | 'failed'; meta?: string }
   | { kind: 'memory-suggestion'; messageId: string; suggestion: AriaMemorySuggestionLite }
   | { kind: 'memory-recall'; messageId: string; recalled: AriaMemorySuggestionLite[] }
+  /** Out-of-band condition the user must see (e.g. auth degradation) — rendered as a banner, never merged into the reply text. */
+  | { kind: 'notice'; messageId: string; level: 'warn'; text: string }
   | { kind: 'done'; messageId: string; text: string }
 
 /** A memory the operator captured from its own work, pending the user's keep/dismiss. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -17,13 +17,20 @@ export const SOLANA_ENDPOINTS = {
   heliusMainnet: (apiKey: string) => `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
 } as const
 
-// Current model aliases. Sonnet/Opus aliases are dateless and complete as
-// written — never append a date suffix. Keep in sync with resolveModelName
-// in validation.ts and the desktop maps in electron/services/providers.
-export const MODEL_MAP: Record<string, string> = {
-  haiku: 'claude-haiku-4-5-20251001',
-  sonnet: 'claude-sonnet-4-6',
+// Canonical Claude model IDs — the single source of truth for every seeded
+// agent, shorthand resolution, migration target, and UI picker across desktop
+// and mobile. The Sonnet/Opus aliases are dateless and complete as written —
+// never append a date suffix to them.
+export const CLAUDE_MODEL_IDS = {
   opus: 'claude-opus-4-8',
+  sonnet: 'claude-sonnet-4-6',
+  haiku: 'claude-haiku-4-5-20251001',
 } as const
+
+export type ClaudeModelShorthand = keyof typeof CLAUDE_MODEL_IDS
+
+// Shorthand → full model ID. Derived from CLAUDE_MODEL_IDS so the two can
+// never drift apart.
+export const MODEL_MAP: Record<string, string> = { ...CLAUDE_MODEL_IDS }
 
 export const DEFAULT_MAX_TOKENS = 4096

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -17,10 +17,13 @@ export const SOLANA_ENDPOINTS = {
   heliusMainnet: (apiKey: string) => `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
 } as const
 
+// Current model aliases. Sonnet/Opus aliases are dateless and complete as
+// written — never append a date suffix. Keep in sync with resolveModelName
+// in validation.ts and the desktop maps in electron/services/providers.
 export const MODEL_MAP: Record<string, string> = {
   haiku: 'claude-haiku-4-5-20251001',
-  sonnet: 'claude-sonnet-4-20250514',
-  opus: 'claude-opus-4-20250514',
+  sonnet: 'claude-sonnet-4-6',
+  opus: 'claude-opus-4-8',
 } as const
 
 export const DEFAULT_MAX_TOKENS = 4096

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -1,5 +1,7 @@
 // Portable validation helpers shared between desktop and mobile.
 
+import { MODEL_MAP } from './constants'
+
 const SOLANA_ADDRESS_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
 
 export function isValidSolanaAddress(address: string): boolean {
@@ -19,10 +21,5 @@ export function sanitizeString(input: string, maxLength = 256): string {
 }
 
 export function resolveModelName(shorthand: string): string {
-  const modelMap: Record<string, string> = {
-    haiku: 'claude-haiku-4-5-20251001',
-    sonnet: 'claude-sonnet-4-6',
-    opus: 'claude-opus-4-8',
-  }
-  return modelMap[shorthand] ?? shorthand
+  return MODEL_MAP[shorthand] ?? shorthand
 }

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -21,8 +21,8 @@ export function sanitizeString(input: string, maxLength = 256): string {
 export function resolveModelName(shorthand: string): string {
   const modelMap: Record<string, string> = {
     haiku: 'claude-haiku-4-5-20251001',
-    sonnet: 'claude-sonnet-4-20250514',
-    opus: 'claude-opus-4-20250514',
+    sonnet: 'claude-sonnet-4-6',
+    opus: 'claude-opus-4-8',
   }
   return modelMap[shorthand] ?? shorthand
 }

--- a/src/panels/AgentLauncher/AgentForm.tsx
+++ b/src/panels/AgentLauncher/AgentForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { CLAUDE_MODEL_IDS } from '../../../packages/shared/src/constants'
 
 const PROVIDER_OPTIONS = [
   { value: 'claude', label: 'Claude' },
@@ -7,9 +8,9 @@ const PROVIDER_OPTIONS = [
 ]
 
 const CLAUDE_MODEL_OPTIONS = [
-  { value: 'claude-opus-4-8', label: 'Opus' },
-  { value: 'claude-sonnet-4-6', label: 'Sonnet' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Haiku' },
+  { value: CLAUDE_MODEL_IDS.opus, label: 'Opus' },
+  { value: CLAUDE_MODEL_IDS.sonnet, label: 'Sonnet' },
+  { value: CLAUDE_MODEL_IDS.haiku, label: 'Haiku' },
 ]
 
 const CODEX_MODEL_OPTIONS = [
@@ -27,7 +28,7 @@ interface AgentFormProps {
 export function AgentForm({ agent, onSave, onCancel }: AgentFormProps) {
   const [name, setName] = useState(agent?.name ?? '')
   const [provider, setProvider] = useState(agent?.provider ?? (agent ? 'auto' : 'claude'))
-  const [model, setModel] = useState(agent?.model ?? 'claude-sonnet-4-6')
+  const [model, setModel] = useState(agent?.model ?? CLAUDE_MODEL_IDS.sonnet)
   const [prompt, setPrompt] = useState(agent?.system_prompt ?? '')
   const [shortcut, setShortcut] = useState(agent?.shortcut ?? '')
   const [nameError, setNameError] = useState('')

--- a/src/panels/AgentStation/AgentStation.tsx
+++ b/src/panels/AgentStation/AgentStation.tsx
@@ -3,6 +3,7 @@ import { daemon } from '../../lib/daemonBridge'
 import { SkeletonRows } from '../../components/Panel'
 import { useAppActions } from '../../store/appActions'
 import { useUIStore } from '../../store/ui'
+import { CLAUDE_MODEL_IDS } from '../../../packages/shared/src/constants'
 import type { SynapseSapAgent, SynapseSapCluster, SynapseSapDiscoveryResult, WalletListEntry } from '../../types/daemon'
 import css from './AgentStation.module.css'
 
@@ -173,8 +174,8 @@ export function CreateForm({ onCreated, onCancel }: CreateFormProps) {
           <option value="gpt-4o">GPT-4o</option>
           <option value="gpt-4o-mini">GPT-4o Mini</option>
           <option value="gpt-4-turbo">GPT-4 Turbo</option>
-          <option value="claude-opus-4-8">Claude Opus 4</option>
-          <option value="claude-sonnet-4-5">Claude Sonnet 4.5</option>
+          <option value={CLAUDE_MODEL_IDS.opus}>Claude Opus 4.8</option>
+          <option value={CLAUDE_MODEL_IDS.sonnet}>Claude Sonnet 4.6</option>
         </select>
       </div>
 

--- a/src/panels/AgentWorkbench/AgentTranscript.tsx
+++ b/src/panels/AgentWorkbench/AgentTranscript.tsx
@@ -49,6 +49,13 @@ export function AgentTranscript({ turns, isLoading }: { turns: AriaTurn[]; isLoa
             <ApprovalCard key={a.callId} approval={a} />
           ))}
 
+          {(turn.notices ?? []).map((notice, i) => (
+            <div key={`notice-${i}`} className="agent-tr-notice" role="status">
+              <span className="agent-tr-notice-dot" aria-hidden="true" />
+              <span>{notice}</span>
+            </div>
+          ))}
+
           {turn.text ? (
             turn.role === 'assistant'
               ? <AriaMarkdown source={turn.text} className="agent-tr-text" />

--- a/src/panels/AgentWorkbench/AgentWorkbench.css
+++ b/src/panels/AgentWorkbench/AgentWorkbench.css
@@ -745,6 +745,29 @@
   padding: var(--space-xs) 0;
 }
 
+/* Out-of-band warning banner (e.g. auth degradation) — amber-lined, never part
+   of the reply markdown. Dot mirrors the 5px status-dot language. */
+.agent-tr-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid color-mix(in srgb, var(--amber) 40%, transparent);
+  background: var(--amber-glow);
+  color: var(--t1);
+  font-size: var(--fs-12);
+  line-height: 1.5;
+}
+.agent-tr-notice-dot {
+  position: relative;
+  top: 6px;
+  flex: none;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--amber);
+}
+
 /* ---------------- approval cards ---------------- */
 .agent-approval {
   display: grid;

--- a/src/store/aria.ts
+++ b/src/store/aria.ts
@@ -48,6 +48,8 @@ export interface AriaTurn {
   actionState?: AriaActionState
   memorySuggestions?: AriaMemorySuggestionLite[]
   recalledMemories?: AriaMemorySuggestionLite[]
+  /** Out-of-band warnings for this turn (e.g. auth degradation) rendered as banners. */
+  notices?: string[]
 }
 
 const DEFAULT_LANE: DaemonAiModelLane = 'auto'
@@ -375,22 +377,24 @@ export const useAriaStore = create<AriaState>((set, get) => ({
       let toolCalls: AriaToolCallLive[] = []
       let plan: AriaPlanStep[] | undefined
       let patch: AriaPatchProposalLite | undefined
+      let notices: string[] | undefined
       try {
         const meta = JSON.parse(m.metadata || '{}') as {
-          toolCalls?: AriaToolCallRecord[]; plan?: AriaPlanStep[]; patch?: AriaPatchProposalLite
+          toolCalls?: AriaToolCallRecord[]; plan?: AriaPlanStep[]; patch?: AriaPatchProposalLite; notice?: string
         }
         toolCalls = (meta.toolCalls ?? []).map((tc) => ({
           callId: tc.callId, name: tc.name, label: tc.name, toolKind: tc.toolKind, risk: tc.risk, status: tc.status, meta: tc.summary,
         }))
         plan = meta.plan
         patch = meta.patch
+        if (typeof meta.notice === 'string' && meta.notice) notices = [meta.notice]
       } catch { /* ignore malformed metadata */ }
       const actionState = patch
         ? patch.status === 'applied' ? 'applied' : patch.status === 'rejected' ? 'rejected' : 'idle'
         : undefined
       return {
         id: m.id, role: m.role as 'user' | 'assistant', text: m.content, createdAt: m.created_at,
-        toolCalls, approvals: [], plan, patch, actionState,
+        toolCalls, approvals: [], plan, patch, actionState, notices,
       }
     })
     set({ turns })
@@ -463,6 +467,9 @@ function applyEvent(
       break
     case 'memory-recall':
       patchActive(set, (t) => ({ ...t, recalledMemories: ev.recalled }), sid)
+      break
+    case 'notice':
+      patchActive(set, (t) => ({ ...t, notices: [...(t.notices ?? []), ev.text] }), sid)
       break
     case 'action-result':
       set((s) => ({

--- a/test/services/AgentModelMigration.test.ts
+++ b/test/services/AgentModelMigration.test.ts
@@ -1,26 +1,36 @@
 import { describe, it, expect } from 'vitest'
 import type Database from 'better-sqlite3'
-import { SUPERSEDED_AGENT_MODELS, refreshSupersededAgentModels } from '../../electron/db/migrations'
+import {
+  SUPERSEDED_AGENT_MODELS,
+  SUPERSEDED_STATION_MODELS,
+  refreshSupersededAgentModels,
+  refreshSupersededStationModels,
+} from '../../electron/db/migrations'
 
-// Minimal in-memory stand-in for the better-sqlite3 surface the refresh uses.
+// Minimal in-memory stand-in for the better-sqlite3 surface the refreshes use.
 // Avoids loading the Electron-ABI native module under vitest's plain-Node runtime.
 interface AgentRow { id: string; model: string }
 
 class FakeDb {
   agents: AgentRow[]
+  stations: AgentRow[]
 
-  constructor(rows: AgentRow[]) {
+  constructor(rows: AgentRow[], stations: AgentRow[] = []) {
     this.agents = rows.map((r) => ({ ...r }))
+    this.stations = stations.map((r) => ({ ...r }))
   }
 
   prepare(sql: string) {
-    if (sql.trim() !== 'UPDATE agents SET model = ? WHERE model = ?') {
-      throw new Error(`unexpected sql: ${sql}`)
-    }
+    const table = sql.trim() === 'UPDATE agents SET model = ? WHERE model = ?'
+      ? this.agents
+      : sql.trim() === 'UPDATE agent_station_configs SET model = ? WHERE model = ?'
+        ? this.stations
+        : null
+    if (!table) throw new Error(`unexpected sql: ${sql}`)
     return {
       run: (nextModel: string, prevModel: string) => {
         let changes = 0
-        for (const row of this.agents) {
+        for (const row of table) {
           if (row.model === prevModel) {
             row.model = nextModel
             changes++
@@ -93,6 +103,50 @@ describe('refreshSupersededAgentModels (V59 upgrade migration)', () => {
     for (const [stale, current] of Object.entries(SUPERSEDED_AGENT_MODELS)) {
       expect(stale).not.toBe(current)
       expect(current in SUPERSEDED_AGENT_MODELS).toBe(false)
+    }
+  })
+})
+
+describe('refreshSupersededStationModels (V60 upgrade migration)', () => {
+  it('rewrites superseded picker values to the current aliases', () => {
+    const db = new FakeDb([], [
+      { id: 'station-1', model: 'claude-opus-4-20250514' },
+      { id: 'station-2', model: 'claude-sonnet-4-5' },
+    ])
+    refreshSupersededStationModels(asDb(db))
+    expect(db.stations.map((s) => s.model)).toEqual(['claude-opus-4-8', 'claude-sonnet-4-6'])
+  })
+
+  it('leaves non-Claude and current-alias station rows untouched', () => {
+    const db = new FakeDb([], [
+      { id: 'station-1', model: 'gpt-4o' },
+      { id: 'station-2', model: 'claude-opus-4-8' },
+      { id: 'station-3', model: 'claude-sonnet-4-6' },
+    ])
+    refreshSupersededStationModels(asDb(db))
+    expect(db.stations.map((s) => s.model)).toEqual(['gpt-4o', 'claude-opus-4-8', 'claude-sonnet-4-6'])
+  })
+
+  it('never touches agent rows and stays idempotent', () => {
+    const db = new FakeDb(
+      [{ id: 'daemon-debug', model: 'claude-sonnet-4-20250514' }],
+      [{ id: 'station-1', model: 'claude-sonnet-4-5' }],
+    )
+    refreshSupersededStationModels(asDb(db))
+    expect(db.agents[0].model).toBe('claude-sonnet-4-20250514')
+    const afterFirst = db.stations.map((s) => ({ ...s }))
+    refreshSupersededStationModels(asDb(db))
+    expect(db.stations).toEqual(afterFirst)
+  })
+
+  it('station map targets are exact current aliases', () => {
+    expect(SUPERSEDED_STATION_MODELS).toEqual({
+      'claude-opus-4-20250514': 'claude-opus-4-8',
+      'claude-sonnet-4-5': 'claude-sonnet-4-6',
+    })
+    for (const [stale, current] of Object.entries(SUPERSEDED_STATION_MODELS)) {
+      expect(stale).not.toBe(current)
+      expect(current).not.toMatch(/-20\d{6}$/)
     }
   })
 })

--- a/test/services/AgentModelMigration.test.ts
+++ b/test/services/AgentModelMigration.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import type Database from 'better-sqlite3'
+import { SUPERSEDED_AGENT_MODELS, refreshSupersededAgentModels } from '../../electron/db/migrations'
+
+// Minimal in-memory stand-in for the better-sqlite3 surface the refresh uses.
+// Avoids loading the Electron-ABI native module under vitest's plain-Node runtime.
+interface AgentRow { id: string; model: string }
+
+class FakeDb {
+  agents: AgentRow[]
+
+  constructor(rows: AgentRow[]) {
+    this.agents = rows.map((r) => ({ ...r }))
+  }
+
+  prepare(sql: string) {
+    if (sql.trim() !== 'UPDATE agents SET model = ? WHERE model = ?') {
+      throw new Error(`unexpected sql: ${sql}`)
+    }
+    return {
+      run: (nextModel: string, prevModel: string) => {
+        let changes = 0
+        for (const row of this.agents) {
+          if (row.model === prevModel) {
+            row.model = nextModel
+            changes++
+          }
+        }
+        return { changes }
+      },
+    }
+  }
+}
+
+function asDb(fake: FakeDb): Database.Database {
+  return fake as unknown as Database.Database
+}
+
+describe('refreshSupersededAgentModels (V59 upgrade migration)', () => {
+  it('rewrites the superseded seeded IDs to the current aliases', () => {
+    const db = new FakeDb([
+      { id: 'daemon-debug', model: 'claude-sonnet-4-20250514' },
+      { id: 'solana-agent', model: 'claude-opus-4-20250514' },
+    ])
+    refreshSupersededAgentModels(asDb(db))
+    expect(db.agents).toEqual([
+      { id: 'daemon-debug', model: 'claude-sonnet-4-6' },
+      { id: 'solana-agent', model: 'claude-opus-4-8' },
+    ])
+  })
+
+  it('leaves the still-valid dated Haiku snapshot untouched', () => {
+    const db = new FakeDb([{ id: 'git-agent', model: 'claude-haiku-4-5-20251001' }])
+    refreshSupersededAgentModels(asDb(db))
+    expect(db.agents[0].model).toBe('claude-haiku-4-5-20251001')
+  })
+
+  it('never rewrites a deliberate non-default model that is still valid', () => {
+    const db = new FakeDb([
+      { id: 'custom-a', model: 'claude-opus-4-5' },
+      { id: 'custom-b', model: 'claude-sonnet-4-6' },
+      { id: 'custom-c', model: 'claude-opus-4-8' },
+    ])
+    refreshSupersededAgentModels(asDb(db))
+    expect(db.agents.map((a) => a.model)).toEqual([
+      'claude-opus-4-5',
+      'claude-sonnet-4-6',
+      'claude-opus-4-8',
+    ])
+  })
+
+  it('is idempotent — a second run changes nothing', () => {
+    const db = new FakeDb([
+      { id: 'daemon-debug', model: 'claude-sonnet-4-20250514' },
+      { id: 'git-agent', model: 'claude-haiku-4-5-20251001' },
+    ])
+    refreshSupersededAgentModels(asDb(db))
+    const afterFirst = db.agents.map((a) => ({ ...a }))
+    refreshSupersededAgentModels(asDb(db))
+    expect(db.agents).toEqual(afterFirst)
+  })
+
+  it('maps only superseded IDs onto exact current aliases', () => {
+    expect(SUPERSEDED_AGENT_MODELS).toEqual({
+      'claude-sonnet-4-20250514': 'claude-sonnet-4-6',
+      'claude-opus-4-20250514': 'claude-opus-4-8',
+    })
+    // Targets are dateless current aliases — never invented date suffixes.
+    for (const target of Object.values(SUPERSEDED_AGENT_MODELS)) {
+      expect(target).not.toMatch(/-20\d{6}$/)
+    }
+    // No key maps to itself and no still-valid ID appears as a key.
+    for (const [stale, current] of Object.entries(SUPERSEDED_AGENT_MODELS)) {
+      expect(stale).not.toBe(current)
+      expect(current in SUPERSEDED_AGENT_MODELS).toBe(false)
+    }
+  })
+})

--- a/test/services/AriaAuthNotice.test.ts
+++ b/test/services/AriaAuthNotice.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AriaTransport } from '../../electron/services/AriaAgentService'
+
+// Mock the operator loop's heavy import chain. providers/claudeAuth stays REAL:
+// these tests exercise the actual auth-error classification and user-facing copy.
+const insertedMessages: Array<{ role: string; content: string; metadata: string }> = []
+vi.mock('../../electron/db/db', () => ({
+  getDb: () => ({
+    prepare: (sql: string) => ({
+      run: (...params: unknown[]) => {
+        if (sql.startsWith('INSERT INTO aria_messages')) {
+          insertedMessages.push({
+            role: String(params[1]),
+            content: String(params[2]),
+            metadata: String(params[3]),
+          })
+        }
+        return { changes: 1 }
+      },
+      get: () => undefined,
+      all: () => [],
+    }),
+  }),
+}))
+
+const runClaudeAgentTurn = vi.fn()
+const getClaudeKeySource = vi.fn(() => 'env')
+vi.mock('../../electron/services/providers/ClaudeProvider', () => ({
+  runClaudeAgentTurn: (...args: unknown[]) => runClaudeAgentTurn(...args),
+  getClaudeKeySource: () => getClaudeKeySource(),
+}))
+
+const getFeatureProvider = vi.fn()
+vi.mock('../../electron/services/providers/ProviderRegistry', () => ({
+  get: vi.fn(() => ({ getConnection: () => ({ isAuthenticated: true, authMode: 'cli' }) })),
+  getFeatureProvider: (...args: unknown[]) => getFeatureProvider(...args),
+  getPreferences: vi.fn(() => ({ aria: { provider: 'claude', model: 'standard' } })),
+}))
+
+const resolveOperatorBackend = vi.fn(() => 'claude')
+const getGlmEndpoint = vi.fn(() => null)
+vi.mock('../../electron/services/providers/glmConfig', () => ({
+  resolveOperatorBackend: () => resolveOperatorBackend(),
+  getGlmEndpoint: () => getGlmEndpoint(),
+}))
+
+vi.mock('../../electron/services/DaemonAIService', () => ({ recordLocalAiUsage: vi.fn() }))
+vi.mock('../../electron/services/MemoryService', () => ({ createSuggestion: vi.fn() }))
+vi.mock('../../electron/services/aria/contextAssembler', () => ({
+  assembleSystemPrompt: vi.fn(async () => ({ system: 'sys', recalled: [] })),
+}))
+vi.mock('../../electron/services/aria/patchUtils', () => ({
+  laneToClaudeModel: vi.fn(() => 'sonnet'),
+  buildPlanSteps: vi.fn(() => []),
+  buildPatchProposal: vi.fn(),
+}))
+vi.mock('../../electron/services/aria/tools/shared', () => ({
+  clusterMark: (summary: string) => summary,
+}))
+vi.mock('../../electron/services/aria/toolCatalog', () => ({
+  ARIA_TOOLS: [],
+  getTool: () => undefined,
+}))
+vi.mock('../../electron/services/aria/AriaTool', () => ({
+  toAnthropicTools: () => [],
+}))
+
+import { sendMessage } from '../../electron/services/AriaAgentService'
+
+const snapshot = {
+  activeProjectId: null,
+  activeProjectPath: null,
+  currentPanelId: null,
+  openFilePath: null,
+  chips: { activeFile: false, projectTree: false, gitDiff: false, terminalLogs: false, walletContext: false },
+} as never
+
+// Long enough (and question-shaped) to never hit the direct-tool fast path.
+const QUESTION = 'Can you walk me through what the swap orchestrator does on a failed quote?'
+
+function makeTransport() {
+  return {
+    emit: vi.fn(),
+    requestApproval: vi.fn(async () => true),
+    requestPatchDecision: vi.fn(async () => 'discard' as const),
+    runUiEffect: vi.fn(async () => undefined),
+  } satisfies AriaTransport
+}
+
+function noticeEvents(transport: ReturnType<typeof makeTransport>) {
+  return transport.emit.mock.calls
+    .map(([ev]) => ev as { kind: string; level?: string; text?: string; messageId?: string })
+    .filter((ev) => ev.kind === 'notice')
+}
+
+const authError = () => Object.assign(new Error('401 {"type":"authentication_error"}'), { status: 401 })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  insertedMessages.length = 0
+  resolveOperatorBackend.mockReturnValue('claude')
+  getGlmEndpoint.mockReturnValue(null)
+  getClaudeKeySource.mockReturnValue('env')
+})
+
+describe('sendMessage — Anthropic auth degradation is surfaced, never silent', () => {
+  it('emits a warn banner naming the shell env key, then answers via CLI without merging the notice into the reply', async () => {
+    runClaudeAgentTurn.mockRejectedValue(authError())
+    getFeatureProvider.mockReturnValue({
+      id: 'claude',
+      getConnection: () => ({ isAuthenticated: true, authMode: 'cli' }),
+      runPrompt: vi.fn(async () => 'plain cli answer'),
+    })
+
+    const transport = makeTransport()
+    const res = await sendMessage('sess-1', QUESTION, snapshot, transport)
+
+    const notices = noticeEvents(transport)
+    expect(notices).toHaveLength(1)
+    expect(notices[0].level).toBe('warn')
+    expect(notices[0].messageId).toBe('sess-1')
+    expect(notices[0].text).toContain('shell environment')
+    expect(notices[0].text).toContain('ANTHROPIC_API_KEY')
+    // The reply stays clean — the warning lives in the banner, not the answer.
+    expect(res.text).toBe('plain cli answer')
+    // The condition survives a history reload via message metadata.
+    const assistant = insertedMessages.find((m) => m.role === 'assistant')
+    expect(assistant).toBeDefined()
+    expect(JSON.parse(assistant!.metadata).notice).toContain('shell environment')
+  })
+
+  it('names the stored key when that credential was in play', async () => {
+    getClaudeKeySource.mockReturnValue('stored')
+    runClaudeAgentTurn.mockRejectedValue(authError())
+    getFeatureProvider.mockReturnValue({
+      id: 'claude',
+      getConnection: () => ({ isAuthenticated: true, authMode: 'cli' }),
+      runPrompt: vi.fn(async () => 'answer'),
+    })
+
+    const transport = makeTransport()
+    await sendMessage('sess-2', QUESTION, snapshot, transport)
+
+    const notices = noticeEvents(transport)
+    expect(notices).toHaveLength(1)
+    expect(notices[0].text).toContain('saved in Settings')
+    expect(notices[0].text).not.toContain('shell environment')
+  })
+
+  it('still surfaces the banner when no CLI fallback exists and keeps the reply text short', async () => {
+    runClaudeAgentTurn.mockRejectedValue(authError())
+    getFeatureProvider.mockReturnValue({ id: 'codex' })
+
+    const transport = makeTransport()
+    const res = await sendMessage('sess-3', QUESTION, snapshot, transport)
+
+    expect(noticeEvents(transport)).toHaveLength(1)
+    expect(res.text).toContain('authentication failed')
+    const assistant = insertedMessages.find((m) => m.role === 'assistant')
+    expect(JSON.parse(assistant!.metadata).notice).toContain('ANTHROPIC_API_KEY')
+  })
+
+  it('does not blame the Anthropic key when a GLM endpoint turn fails auth', async () => {
+    resolveOperatorBackend.mockReturnValue('glm')
+    getGlmEndpoint.mockReturnValue({ apiKey: 'z', baseURL: 'https://api.z.ai/api/anthropic', model: 'glm-4.7' } as never)
+    runClaudeAgentTurn.mockRejectedValue(authError())
+    getFeatureProvider.mockReturnValue({ id: 'codex' })
+
+    const transport = makeTransport()
+    const res = await sendMessage('sess-4', QUESTION, snapshot, transport)
+
+    expect(noticeEvents(transport)).toHaveLength(0)
+    expect(res.text).toContain('Error:')
+  })
+
+  it('does not classify network failures as auth degradation', async () => {
+    runClaudeAgentTurn.mockRejectedValue(new Error('ECONNRESET'))
+    getFeatureProvider.mockReturnValue({
+      id: 'claude',
+      getConnection: () => ({ isAuthenticated: true, authMode: 'cli' }),
+      runPrompt: vi.fn(async () => 'cli answer'),
+    })
+
+    const transport = makeTransport()
+    const res = await sendMessage('sess-5', QUESTION, snapshot, transport)
+
+    expect(noticeEvents(transport)).toHaveLength(0)
+    expect(res.text).toBe('cli answer')
+  })
+})

--- a/test/services/MigrationRunner.test.ts
+++ b/test/services/MigrationRunner.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
+import type Database from 'better-sqlite3'
+import {
+  runMigrations,
+  SUPERSEDED_AGENT_MODELS,
+  SUPERSEDED_STATION_MODELS,
+} from '../../electron/db/migrations'
+import { CLAUDE_MODEL_IDS } from '../../packages/shared/src/constants'
+
+/**
+ * Real-SQL migration harness. node:sqlite ships with the test runtime and
+ * exposes the same prepare/run/get/all surface runMigrations uses, so the
+ * full migration chain executes against a real SQLite engine without the
+ * Electron-ABI better-sqlite3 binding that vitest's plain-Node runtime
+ * cannot load.
+ */
+function makeDb(): Database.Database {
+  const raw = new DatabaseSync(':memory:')
+  const adapter = {
+    exec: (sql: string) => raw.exec(sql),
+    prepare: (sql: string) => {
+      const stmt = raw.prepare(sql)
+      return {
+        run: (...params: unknown[]) => stmt.run(...(params as never[])),
+        get: (...params: unknown[]) => stmt.get(...(params as never[])),
+        all: (...params: unknown[]) => stmt.all(...(params as never[])),
+      }
+    },
+    transaction: (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) => {
+        raw.exec('BEGIN')
+        try {
+          const out = fn(...args)
+          raw.exec('COMMIT')
+          return out
+        } catch (err) {
+          raw.exec('ROLLBACK')
+          throw err
+        }
+      },
+  }
+  return adapter as unknown as Database.Database
+}
+
+function agentModels(db: Database.Database): Array<{ id: string; model: string }> {
+  return db.prepare('SELECT id, model FROM agents ORDER BY id').all() as Array<{ id: string; model: string }>
+}
+
+function maxVersion(db: Database.Database): number {
+  return (db.prepare('SELECT MAX(version) v FROM _migrations').get() as { v: number }).v
+}
+
+describe('runMigrations — fresh install', () => {
+  it('reaches the current schema version and seeds only sanctioned Claude model IDs', () => {
+    const db = makeDb()
+    runMigrations(db)
+
+    expect(maxVersion(db)).toBeGreaterThanOrEqual(60)
+
+    const sanctioned = new Set<string>(Object.values(CLAUDE_MODEL_IDS))
+    const rows = agentModels(db)
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(sanctioned.has(row.model), `${row.id} seeded with ${row.model}`).toBe(true)
+      expect(row.model in SUPERSEDED_AGENT_MODELS).toBe(false)
+    }
+  })
+})
+
+describe('runMigrations — upgraded install', () => {
+  /** Build a DB that looks like a pre-V59 install carrying stale model rows. */
+  function makeStaleDb(): Database.Database {
+    const db = makeDb()
+    runMigrations(db)
+    // Rewind the model-refresh migrations, then reintroduce the stale IDs the
+    // old releases seeded / offered in pickers.
+    db.prepare('DELETE FROM _migrations WHERE version >= 59').run()
+    db.prepare('UPDATE agents SET model = ? WHERE id = ?').run('claude-sonnet-4-20250514', 'daemon-debug')
+    db.prepare('UPDATE agents SET model = ? WHERE id = ?').run('claude-opus-4-20250514', 'solana-agent')
+    const insertStation = db.prepare(
+      'INSERT INTO agent_station_configs (id, name, template, plugins, model, status) VALUES (?,?,?,?,?,?)'
+    )
+    insertStation.run('st-sonnet', 'Old Sonnet Station', 'basic', '[]', 'claude-sonnet-4-5', 'idle')
+    insertStation.run('st-opus', 'Old Opus Station', 'basic', '[]', 'claude-opus-4-20250514', 'idle')
+    insertStation.run('st-gpt', 'GPT Station', 'basic', '[]', 'gpt-4o', 'idle')
+    return db
+  }
+
+  it('remaps stale seeded agent models to the current aliases (V59)', () => {
+    const db = makeStaleDb()
+    runMigrations(db)
+
+    const rows = Object.fromEntries(agentModels(db).map((r) => [r.id, r.model]))
+    expect(rows['daemon-debug']).toBe(CLAUDE_MODEL_IDS.sonnet)
+    expect(rows['solana-agent']).toBe(CLAUDE_MODEL_IDS.opus)
+    expect(maxVersion(db)).toBeGreaterThanOrEqual(60)
+  })
+
+  it('remaps stale Agent Station picker models but never non-Claude rows (V60)', () => {
+    const db = makeStaleDb()
+    runMigrations(db)
+
+    const rows = Object.fromEntries(
+      (db.prepare('SELECT id, model FROM agent_station_configs').all() as Array<{ id: string; model: string }>)
+        .map((r) => [r.id, r.model]),
+    )
+    expect(rows['st-sonnet']).toBe(CLAUDE_MODEL_IDS.sonnet)
+    expect(rows['st-opus']).toBe(CLAUDE_MODEL_IDS.opus)
+    expect(rows['st-gpt']).toBe('gpt-4o')
+  })
+
+  it('is idempotent — re-running the full chain changes nothing', () => {
+    const db = makeStaleDb()
+    runMigrations(db)
+    const afterFirst = agentModels(db)
+    runMigrations(db)
+    expect(agentModels(db)).toEqual(afterFirst)
+    expect(maxVersion(db)).toBeGreaterThanOrEqual(60)
+  })
+})
+
+describe('model refresh maps stay inside the sanctioned set', () => {
+  it('every refresh target is a canonical CLAUDE_MODEL_IDS value', () => {
+    const sanctioned = new Set<string>(Object.values(CLAUDE_MODEL_IDS))
+    for (const target of Object.values({ ...SUPERSEDED_AGENT_MODELS, ...SUPERSEDED_STATION_MODELS })) {
+      expect(sanctioned.has(target), `${target} is not a sanctioned model ID`).toBe(true)
+    }
+  })
+
+  it('no stale key survives as a value and no key maps to itself', () => {
+    const merged = { ...SUPERSEDED_AGENT_MODELS, ...SUPERSEDED_STATION_MODELS }
+    for (const [stale, current] of Object.entries(merged)) {
+      expect(stale).not.toBe(current)
+      expect(current in merged).toBe(false)
+    }
+  })
+})

--- a/test/services/claudeAuth.test.ts
+++ b/test/services/claudeAuth.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveClaudeKeySource,
+  isAnthropicAuthError,
+  describeClaudeAuthFailure,
+} from '../../electron/services/providers/claudeAuth'
+
+describe('resolveClaudeKeySource (mirrors runClaudeAgentTurn precedence)', () => {
+  it('prefers the stored key over a shell env key when both exist', () => {
+    const source = resolveClaudeKeySource(() => 'stored-key', { ANTHROPIC_API_KEY: 'env-key' })
+    expect(source).toBe('stored')
+  })
+
+  it('falls back to the shell env key when no stored key exists', () => {
+    expect(resolveClaudeKeySource(() => null, { ANTHROPIC_API_KEY: 'env-key' })).toBe('env')
+    expect(resolveClaudeKeySource(() => undefined, { ANTHROPIC_API_KEY: 'env-key' })).toBe('env')
+  })
+
+  it('reports none when neither credential exists', () => {
+    expect(resolveClaudeKeySource(() => null, {})).toBe('none')
+  })
+
+  it('treats an empty env value as absent', () => {
+    expect(resolveClaudeKeySource(() => null, { ANTHROPIC_API_KEY: '' })).toBe('none')
+  })
+
+  it('falls through to env when secure storage throws', () => {
+    const source = resolveClaudeKeySource(
+      () => { throw new Error('keychain locked') },
+      { ANTHROPIC_API_KEY: 'env-key' },
+    )
+    expect(source).toBe('env')
+  })
+})
+
+describe('isAnthropicAuthError', () => {
+  it('matches 401/403 SDK errors by status', () => {
+    expect(isAnthropicAuthError(Object.assign(new Error('bad'), { status: 401 }))).toBe(true)
+    expect(isAnthropicAuthError(Object.assign(new Error('bad'), { status: 403 }))).toBe(true)
+  })
+
+  it('matches auth error types by message when status is missing', () => {
+    expect(isAnthropicAuthError(new Error('400 {"type":"authentication_error"}'))).toBe(true)
+    expect(isAnthropicAuthError(new Error('permission_error: org restricted'))).toBe(true)
+    expect(isAnthropicAuthError(new Error('invalid x-api-key'))).toBe(true)
+    expect(isAnthropicAuthError(new Error('Your organization has been disabled.'))).toBe(true)
+  })
+
+  it('does not classify rate limits, overloads, or network failures as auth errors', () => {
+    expect(isAnthropicAuthError(Object.assign(new Error('rate_limit_error'), { status: 429 }))).toBe(false)
+    expect(isAnthropicAuthError(Object.assign(new Error('overloaded_error'), { status: 529 }))).toBe(false)
+    expect(isAnthropicAuthError(new Error('ECONNRESET'))).toBe(false)
+    expect(isAnthropicAuthError(null)).toBe(false)
+    expect(isAnthropicAuthError('authentication_error')).toBe(false)
+  })
+})
+
+describe('describeClaudeAuthFailure', () => {
+  it('tells the user the SHELL key failed when the env credential was in play', () => {
+    const msg = describeClaudeAuthFailure('env')
+    expect(msg).toContain('ANTHROPIC_API_KEY')
+    expect(msg).toContain('shell environment')
+    expect(msg).toContain('Settings')
+  })
+
+  it('points at Settings when the stored key failed', () => {
+    const msg = describeClaudeAuthFailure('stored')
+    expect(msg).toContain('saved in Settings')
+    expect(msg).not.toContain('shell environment')
+  })
+
+  it('gives a generic actionable message when no source is known', () => {
+    const msg = describeClaudeAuthFailure('none')
+    expect(msg).toContain('Settings')
+  })
+
+  it('never asks for or echoes key material', () => {
+    for (const source of ['env', 'stored', 'none'] as const) {
+      expect(describeClaudeAuthFailure(source)).not.toMatch(/sk-ant/i)
+    }
+  })
+})

--- a/test/shared/modelConstants.test.ts
+++ b/test/shared/modelConstants.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { MODEL_MAP } from '../../packages/shared/src/constants'
+import { resolveModelName } from '../../packages/shared/src/validation'
+
+// Guards the shared model shorthand maps against reintroducing retired
+// date-suffixed Sonnet/Opus IDs (the current aliases are dateless; only the
+// Haiku 4.5 snapshot legitimately carries a date).
+describe('shared model constants', () => {
+  it('maps shorthands to the current model aliases', () => {
+    expect(MODEL_MAP).toEqual({
+      haiku: 'claude-haiku-4-5-20251001',
+      sonnet: 'claude-sonnet-4-6',
+      opus: 'claude-opus-4-8',
+    })
+  })
+
+  it('sonnet/opus aliases carry no date suffix', () => {
+    expect(MODEL_MAP.sonnet).not.toMatch(/-20\d{6}$/)
+    expect(MODEL_MAP.opus).not.toMatch(/-20\d{6}$/)
+  })
+
+  it('resolveModelName agrees with MODEL_MAP for every shorthand', () => {
+    for (const [shorthand, id] of Object.entries(MODEL_MAP)) {
+      expect(resolveModelName(shorthand)).toBe(id)
+    }
+  })
+
+  it('resolveModelName passes explicit model IDs through unchanged', () => {
+    expect(resolveModelName('claude-opus-4-5')).toBe('claude-opus-4-5')
+    expect(resolveModelName('claude-sonnet-4-6')).toBe('claude-sonnet-4-6')
+  })
+})


### PR DESCRIPTION
Two reliability fixes found during the first-run work, plus a shared-constant cleanup.

- Upgraded installs kept agent rows pinned to superseded dated model ids (claude-sonnet-4-20250514 / claude-opus-4-20250514), and the same dated ids were hardcoded in packages/shared. Forward-only migrations (V59 agents, V60 agent_station_configs) remap only those two exact ids to the current aliases; a still-valid deliberate pick is never touched. All model ids now derive from one CLAUDE_MODEL_IDS constant.
- A disabled-org ANTHROPIC_API_KEY inherited from the shell silently degraded ARIA to a tool-less CLI. Auth rejections (401/403, disabled org, invalid key) now raise an amber transcript banner naming which credential failed and how to fix it; rate limits and network errors keep their original message. Key values never logged.

New pure module electron/services/providers/claudeAuth.ts (source resolution + auth-error classifier). Suite 1027 to 1063 (+36, none skipped), including real-SQL full-chain migration tests. Typecheck, build, lint:styles green.