### PR TITLE
Release v4.6.4 — first-run experience + reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to DAEMON are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 follows semantic-ish desktop release versioning.
 
+## [4.6.4] - 2026-07-03
+
+### Added
+- **Guided first-run experience.** A fresh install now walks through a five-step wizard: pick a
+  workspace, connect Claude, open a one-click demo project, learn the approval gate on a mock
+  write card, then run a first mission where a scripted ARIA turn answers read chips silently and
+  raises a real approval card the user decides on. A fresh profile reaches that first decision in
+  about three and a half minutes. Onboarding is chain-safe by construction: mission turns are
+  pinned to devnet at the IPC boundary, pinned reads answer from local wallet inventory with no
+  RPC calls, and sensitive tools are refused before any card can appear. First-session empty
+  states were added across the console, wallet, activity, swarm, and memory panels.
+
+### Fixed
+- **Upgraded installs no longer keep agents pinned to superseded model IDs.** Migrations V59 and
+  V60 remap only the two exact retired dated IDs to the current aliases; a still-valid deliberate
+  model choice is never touched. Model IDs now derive from one shared constant.
+- **A rejected or disabled Anthropic API key surfaces a clear warning.** A disabled-org or invalid
+  key inherited from the shell used to silently degrade ARIA to a tool-less CLI; auth rejections
+  now raise a transcript banner naming which credential failed and how to fix it, while rate
+  limits and network errors keep their original message. Key values are never logged.
+
+### Developer tooling
+- **Packaged the agent bridge as an installable npm package** (`daemon-bridge-mcp`) with a bin
+  wrapper, Node 22 guard, and setup docs for Claude Code and Cursor, so external agents can wire
+  up the bridge without cloning the repo.
+
 ## [4.6.3] - 2026-07-03
 
 ### Fixed

--- a/Whatsnew.md
+++ b/Whatsnew.md
@@ -21,6 +21,13 @@ DAEMON v4.6 turns the operator into a full trading and execution surface: unatte
 - Bridge and ARIA file reads deny secret-bearing paths (.env, keypairs, key material) and enforce real-path containment.
 - Swarm lanes run with a minimal allowlisted environment and have push disabled at the git layer.
 
+## First-run experience and reliability (4.6.4)
+
+- A guided five-step wizard takes a fresh install from a new workspace to its first real approval decision in about three and a half minutes, ending on a mission where ARIA runs reads silently and raises a live approval card you accept or reject.
+- Onboarding stays on devnet the whole way through, so nothing can touch mainnet while you learn the approval gate.
+- First-session empty states now guide you across the console, wallet, activity, swarm, and memory panels.
+- Upgraded installs refresh agents that were pinned to retired model IDs, and a rejected or disabled API key now shows a clear warning instead of quietly dropping ARIA's tools.
+
 ## First-session polish (4.6.3)
 
 - Memory and Deploy icons open their panels on a fresh install.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",


### PR DESCRIPTION
Patch release rolling up the first-run experience (#216), reliability fixes (#217), and the packaged bridge shim (#214) since v4.6.3.

## Added
- **Guided first-run experience** (#216). A fresh install walks a five-step wizard — workspace, connect Claude, one-click demo project, an approval-gate primer with a mock write card, then a first mission where a scripted ARIA turn runs read chips silently and raises a real approval card the user decides on. Fresh profile to first decision measured at ~3:31. Chain-safe by construction: mission turns are devnet-pinned at the IPC boundary, pinned reads answer from local wallet inventory with no RPC, and sensitive tools are refused before any card can appear. First-session empty states added across console, wallet, activity, swarm, and memory.

## Fixed
- **Stale agent model IDs refreshed on upgrade** (#217). Migrations V59/V60 remap only the two retired dated IDs to the current aliases; a still-valid deliberate pick is untouched. All model IDs now derive from one shared constant.
- **Rejected/disabled API keys now surface a clear warning** (#217). A disabled-org or invalid ANTHROPIC_API_KEY inherited from the shell used to silently degrade ARIA to a tool-less CLI; auth rejections now raise a transcript banner naming the failing credential and the fix. Rate-limit and network errors keep their original message; key values are never logged.

## Developer tooling
- **npm-packaged agent bridge** (#214). `daemon-bridge-mcp` is now a publishable package (bin wrapper, Node 22 guard, setup docs for Claude Code and Cursor), so external agents can wire up the bridge without cloning the repo.

## Release contents
- `package.json` → 4.6.4
- `CHANGELOG.md` 4.6.4 entry
- `Whatsnew.md` first-run experience section

## Verification
- Each change verified on its own PR: suite 1073 passing at #216 merge (from 1027); typecheck, build, lint:styles green; fresh-profile E2E driven over CDP including an adversarial mainnet-forced run (pinned readout shown, card clean, zero console errors).