### PR TITLE
fix: clear empty Apple credentials for unsigned builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.4'
+      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.5'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -141,7 +141,12 @@ jobs:
           restore-keys: electron-cache-${{ runner.os }}-${{ runner.arch }}-
       - run: pnpm install --frozen-lockfile
       - name: Build Apple Silicon release
-        run: pnpm run package:lite:mac
+        shell: bash
+        run: |
+          if [ "$DAEMON_MAC_RELEASE_MODE" = 'unsigned' ]; then
+            unset CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+          fi
+          pnpm run package:lite:mac
       - name: Verify signature mode, architecture, and updater metadata
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      DAEMON_REQUIRE_MAC_NOTARIZATION: '1'
+      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.4'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -105,17 +105,32 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - name: Require Apple release credentials
+      - name: Select signed or version-scoped unsigned mode
         shell: bash
         run: |
-          missing=()
+          present=0
           for name in CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
-            if [ -z "${!name:-}" ]; then missing+=("$name"); fi
+            if [ -n "${!name:-}" ]; then present=$((present + 1)); fi
           done
-          if [ "${#missing[@]}" -ne 0 ]; then
-            printf 'Missing required macOS release secrets: %s\n' "${missing[*]}"
+          version="$(node -p "require('./package.json').version")"
+          if [ "$present" -eq 5 ]; then
+            mode=signed
+            echo 'DAEMON_REQUIRE_MAC_NOTARIZATION=1' >> "$GITHUB_ENV"
+            echo 'DAEMON_MAC_ADHOC=0' >> "$GITHUB_ENV"
+          elif [ "$present" -ne 0 ]; then
+            echo 'Partial Apple credentials are not allowed'
+            exit 1
+          elif [ "$version" = "$DAEMON_ALLOW_UNSIGNED_MAC_VERSION" ]; then
+            mode=unsigned
+            echo 'DAEMON_REQUIRE_MAC_NOTARIZATION=0' >> "$GITHUB_ENV"
+            echo 'DAEMON_MAC_ADHOC=1' >> "$GITHUB_ENV"
+            echo 'CSC_IDENTITY_AUTO_DISCOVERY=false' >> "$GITHUB_ENV"
+          else
+            echo "Apple credentials are required for macOS release $version"
             exit 1
           fi
+          echo "DAEMON_MAC_RELEASE_MODE=$mode" >> "$GITHUB_ENV"
+          echo "macOS release mode: $mode"
       - name: Cache Electron
         uses: actions/cache@v5
         with:
@@ -125,34 +140,97 @@ jobs:
           key: electron-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: electron-cache-${{ runner.os }}-${{ runner.arch }}-
       - run: pnpm install --frozen-lockfile
-      - name: Build signed Apple Silicon release
+      - name: Build Apple Silicon release
         run: pnpm run package:lite:mac
-      - name: Verify signature, notarization, architecture, and updater metadata
+      - name: Verify signature mode, architecture, and updater metadata
         shell: bash
         run: |
           VERSION="$(node -p "require('./package.json').version")"
           RELEASE_DIR="release-lite/$VERSION"
           APP_PATH="$RELEASE_DIR/mac-arm64/DAEMON.app"
           test "$(uname -m)" = arm64
-          file "$APP_PATH/Contents/MacOS/DAEMON" | grep -q 'arm64'
-          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-          codesign -dv --verbose=4 "$APP_PATH" 2>&1 | grep -q '^Authority=Developer ID Application:'
-          xcrun stapler validate "$APP_PATH"
-          spctl --assess --type execute -vv "$APP_PATH"
-          NATIVE_DIR="$APP_PATH/Contents/Resources/app.asar.unpacked/node_modules"
-          addons=("$NATIVE_DIR/better-sqlite3/build/Release/better_sqlite3.node")
-          for candidate in \
-            "$NATIVE_DIR/node-pty/bin/darwin-arm64-145/node-pty.node" \
-            "$NATIVE_DIR/node-pty/build/Release/pty.node" \
-            "$NATIVE_DIR/node-pty/prebuilds/darwin-arm64/pty.node"; do
-            if [ -f "$candidate" ]; then addons+=("$candidate"); fi
-          done
-          test "${#addons[@]}" -ge 2
-          for addon in "${addons[@]}"; do
-            file "$addon" | grep -q 'arm64'
-            codesign --verify --strict --verbose=2 "$addon"
-          done
-          node scripts/release-tools/verify-macos-artifacts.mjs "$RELEASE_DIR" "$VERSION"
+          case "$DAEMON_MAC_RELEASE_MODE" in
+            signed) artifact_stem='DAEMON-arm64'; verifier_args=() ;;
+            unsigned) artifact_stem='DAEMON-unsigned-arm64'; verifier_args=(--unsigned) ;;
+            *) echo "Invalid macOS release mode: $DAEMON_MAC_RELEASE_MODE"; exit 1 ;;
+          esac
+
+          verify_bundle() {
+            local app_path="$1"
+            local executable="$app_path/Contents/MacOS/DAEMON"
+            test "$(lipo -archs "$executable")" = arm64
+            codesign --verify --deep --strict --verbose=2 "$app_path"
+            local app_details app_team
+            app_details="$(codesign -dv --verbose=4 "$app_path" 2>&1)"
+            case "$DAEMON_MAC_RELEASE_MODE" in
+              signed)
+                grep -q '^Authority=Developer ID Application:' <<< "$app_details"
+                app_team="$(sed -n 's/^TeamIdentifier=//p' <<< "$app_details")"
+                test -n "$app_team"
+                xcrun stapler validate "$app_path"
+                spctl --assess --type execute -vv "$app_path"
+                ;;
+              unsigned)
+                grep -q '^Signature=adhoc$' <<< "$app_details"
+                ! grep -q '^Authority=' <<< "$app_details"
+                local entitlements
+                entitlements="$(mktemp)"
+                codesign -d --entitlements :- "$app_path" > "$entitlements" 2>/dev/null
+                test "$(plutil -extract com.apple.security.cs.disable-library-validation raw -o - "$entitlements")" = true
+                rm -f "$entitlements"
+                if spctl --assess --type execute -vv "$app_path"; then
+                  echo 'Unsigned mode unexpectedly passed Gatekeeper assessment'
+                  exit 1
+                fi
+                ;;
+            esac
+
+            local native_dir="$app_path/Contents/Resources/app.asar.unpacked/node_modules"
+            local addons=("$native_dir/better-sqlite3/build/Release/better_sqlite3.node")
+            for candidate in \
+              "$native_dir/node-pty/bin/darwin-arm64-145/node-pty.node" \
+              "$native_dir/node-pty/build/Release/pty.node" \
+              "$native_dir/node-pty/prebuilds/darwin-arm64/pty.node"; do
+              if [ -f "$candidate" ]; then addons+=("$candidate"); fi
+            done
+            test "${#addons[@]}" -ge 2
+            for addon in "${addons[@]}"; do
+              test "$(lipo -archs "$addon")" = arm64
+              codesign --verify --strict --verbose=2 "$addon"
+              local addon_details
+              addon_details="$(codesign -dv --verbose=4 "$addon" 2>&1)"
+              if [ "$DAEMON_MAC_RELEASE_MODE" = signed ]; then
+                grep -q '^Authority=Developer ID Application:' <<< "$addon_details"
+                test "$(sed -n 's/^TeamIdentifier=//p' <<< "$addon_details")" = "$app_team"
+              else
+                grep -q '^Signature=adhoc$' <<< "$addon_details"
+                ! grep -q '^Authority=' <<< "$addon_details"
+              fi
+            done
+          }
+
+          verify_bundle "$APP_PATH"
+          node scripts/release-tools/verify-macos-artifacts.mjs "$RELEASE_DIR" "$VERSION" "${verifier_args[@]}"
+
+          dmg_path="$RELEASE_DIR/$artifact_stem.dmg"
+          zip_path="$RELEASE_DIR/$artifact_stem.zip"
+          hdiutil verify "$dmg_path"
+          unzip -t "$zip_path"
+          mount_dir="$(mktemp -d)"
+          zip_dir="$(mktemp -d)"
+          cleanup() {
+            hdiutil detach "$mount_dir" -force >/dev/null 2>&1 || true
+            rm -rf "$mount_dir" "$zip_dir"
+          }
+          trap cleanup EXIT
+          hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_dir"
+          verify_bundle "$mount_dir/DAEMON.app"
+          ditto -x -k "$zip_path" "$zip_dir"
+          verify_bundle "$zip_dir/DAEMON.app"
+          DAEMON_PACKAGED_EXE="$zip_dir/DAEMON.app/Contents/MacOS/DAEMON" \
+            node scripts/smoke/lite-app-smoke.mjs
+          cleanup
+          trap - EXIT
       - name: Packaged smoke
         run: |
           node scripts/smoke/lite-app-smoke.mjs
@@ -162,18 +240,25 @@ jobs:
         run: |
           VERSION="$(node -p "require('./package.json').version")"
           RELEASE_DIR="release-lite/$VERSION"
-          shasum -a 256 "$RELEASE_DIR/DAEMON-arm64.dmg" "$RELEASE_DIR/DAEMON-arm64.zip" \
+          case "$DAEMON_MAC_RELEASE_MODE" in
+            signed) artifact_stem='DAEMON-arm64' ;;
+            unsigned) artifact_stem='DAEMON-unsigned-arm64' ;;
+            *) echo "Invalid macOS release mode: $DAEMON_MAC_RELEASE_MODE"; exit 1 ;;
+          esac
+          shasum -a 256 "$RELEASE_DIR/$artifact_stem.dmg" "$RELEASE_DIR/$artifact_stem.zip" \
             | sed "s#$RELEASE_DIR/##" > release-lite/checksums-macos.txt
+          printf '%s\n' "$DAEMON_MAC_RELEASE_MODE" > release-lite/mac-release-mode.txt
       - uses: actions/upload-artifact@v7
         with:
           name: daemon-macos-arm64-release
           path: |
-            release-lite/*/DAEMON-arm64.dmg
-            release-lite/*/DAEMON-arm64.dmg.blockmap
-            release-lite/*/DAEMON-arm64.zip
-            release-lite/*/DAEMON-arm64.zip.blockmap
+            release-lite/*/DAEMON-*arm64.dmg
+            release-lite/*/DAEMON-*arm64.dmg.blockmap
+            release-lite/*/DAEMON-*arm64.zip
+            release-lite/*/DAEMON-*arm64.zip.blockmap
             release-lite/*/latest-mac.yml
             release-lite/checksums-macos.txt
+            release-lite/mac-release-mode.txt
           retention-days: 1
 
   publish:
@@ -197,7 +282,23 @@ jobs:
       - name: Generate changelog
         run: |
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || git rev-list --max-parents=0 HEAD)
-          echo '## DAEMON focused workbench' > changelog.md
+          MAC_RELEASE_MODE="$(cat artifacts/macos/mac-release-mode.txt)"
+          case "$MAC_RELEASE_MODE" in
+            unsigned)
+              echo '## macOS Apple Silicon warning' > changelog.md
+              echo '' >> changelog.md
+              echo 'This Apple Silicon build is ad-hoc signed and is not Apple-notarized. Gatekeeper will block the first launch. Verify the SHA-256 checksum below, then follow the [macOS install steps](https://www.daemonide.tech/docs/install-help). Automatic macOS updates are disabled; install future releases manually.' >> changelog.md
+              echo '' >> changelog.md
+              echo "RELEASE_TITLE=DAEMON ${GITHUB_REF_NAME} (macOS unsigned)" >> "$GITHUB_ENV"
+              ;;
+            signed)
+              : > changelog.md
+              echo "RELEASE_TITLE=DAEMON ${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+              ;;
+            *) echo "Invalid macOS release mode: $MAC_RELEASE_MODE"; exit 1 ;;
+          esac
+          echo "MAC_RELEASE_MODE=$MAC_RELEASE_MODE" >> "$GITHUB_ENV"
+          echo '## DAEMON focused workbench' >> changelog.md
           echo '' >> changelog.md
           echo '- Conversation-first Solana development shell' >> changelog.md
           echo '- Project explorer, offline Monaco editor, and scoped terminal' >> changelog.md
@@ -213,20 +314,27 @@ jobs:
           cat artifacts/windows/checksums-windows.txt >> changelog.md
           cat artifacts/macos/checksums-macos.txt >> changelog.md
           echo '```' >> changelog.md
+      - name: Stage release assets
+        shell: bash
+        run: |
+          mkdir -p artifacts/release
+          find artifacts/windows -type f \( -name 'DAEMON-setup.exe' -o -name 'DAEMON-setup.exe.blockmap' -o -name 'latest.yml' \) \
+            -exec cp {} artifacts/release/ \;
+          cp artifacts/windows/checksums-windows.txt artifacts/release/
+          find artifacts/macos -type f \( -name 'DAEMON-*arm64.dmg' -o -name 'DAEMON-*arm64.dmg.blockmap' -o -name 'DAEMON-*arm64.zip' -o -name 'DAEMON-*arm64.zip.blockmap' \) \
+            -exec cp {} artifacts/release/ \;
+          cp artifacts/macos/checksums-macos.txt artifacts/release/
+          case "$MAC_RELEASE_MODE" in
+            signed) find artifacts/macos -type f -name 'latest-mac.yml' -exec cp {} artifacts/release/ \; ;;
+            unsigned) ;;
+            *) echo "Invalid macOS release mode: $MAC_RELEASE_MODE"; exit 1 ;;
+          esac
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
+          name: ${{ env.RELEASE_TITLE }}
           body_path: changelog.md
           draft: false
           prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-alpha') || contains(github.ref, '-rc') }}
           files: |
-            artifacts/windows/*/DAEMON-setup.exe
-            artifacts/windows/*/DAEMON-setup.exe.blockmap
-            artifacts/windows/*/latest.yml
-            artifacts/windows/checksums-windows.txt
-            artifacts/macos/*/DAEMON-arm64.dmg
-            artifacts/macos/*/DAEMON-arm64.dmg.blockmap
-            artifacts/macos/*/DAEMON-arm64.zip
-            artifacts/macos/*/DAEMON-arm64.zip.blockmap
-            artifacts/macos/*/latest-mac.yml
-            artifacts/macos/checksums-macos.txt
+            artifacts/release/*

--- a/build/entitlements.mac.adhoc.plist
+++ b/build/entitlements.mac.adhoc.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+</dict>
+</plist>

--- a/build/macPackaging.cjs
+++ b/build/macPackaging.cjs
@@ -1,0 +1,14 @@
+const SIGNED_ENTITLEMENTS = 'build/entitlements.mac.plist'
+const ADHOC_ENTITLEMENTS = 'build/entitlements.mac.adhoc.plist'
+
+function macSigningConfig(env = process.env) {
+  const isAdHoc = env.DAEMON_MAC_ADHOC === '1'
+  return {
+    isAdHoc,
+    identity: isAdHoc ? '-' : undefined,
+    entitlements: isAdHoc ? ADHOC_ENTITLEMENTS : SIGNED_ENTITLEMENTS,
+    artifactName: isAdHoc ? 'DAEMON-unsigned-${arch}.${ext}' : 'DAEMON-${arch}.${ext}',
+  }
+}
+
+module.exports = { macSigningConfig }

--- a/build/macos-adhoc-release
+++ b/build/macos-adhoc-release
@@ -1,0 +1,1 @@
+This macOS build is ad-hoc signed and not Apple-notarized.

--- a/electron-builder.lite.cjs
+++ b/electron-builder.lite.cjs
@@ -4,6 +4,8 @@
  * dependency closure of the built focused bundles ships.
  */
 const { liteExcludePatterns } = require('./scripts/lite-deps.cjs')
+const { macSigningConfig } = require('./build/macPackaging.cjs')
+const macSigning = macSigningConfig()
 
 module.exports = {
   appId: 'com.daemon.app',
@@ -18,6 +20,9 @@ module.exports = {
     name: 'daemon',
     main: 'dist-electron-lite/main/lite.js',
   },
+  extraResources: macSigning.isAdHoc
+    ? [{ from: 'build/macos-adhoc-release', to: 'macos-adhoc-release' }]
+    : undefined,
   publish: [{ provider: 'github', owner: 'nullxnothing', repo: 'daemon' }],
   files: [
     'dist-electron-lite/**',
@@ -40,12 +45,13 @@ module.exports = {
     icon: 'build/icon.icns',
     target: ['dmg', 'zip'],
     category: 'public.app-category.developer-tools',
-    artifactName: 'DAEMON-${arch}.${ext}',
+    artifactName: macSigning.artifactName,
+    identity: macSigning.identity,
     hardenedRuntime: true,
     gatekeeperAssess: false,
     notarize: false,
-    entitlements: 'build/entitlements.mac.plist',
-    entitlementsInherit: 'build/entitlements.mac.plist',
+    entitlements: macSigning.entitlements,
+    entitlementsInherit: macSigning.entitlements,
   },
   afterSign: 'build/notarize.mjs',
   win: {

--- a/electron/main/autoUpdatePolicy.ts
+++ b/electron/main/autoUpdatePolicy.ts
@@ -1,0 +1,13 @@
+type AutoUpdateContext = {
+  isPackaged: boolean
+  isDisabled: boolean
+  isSmokeTest: boolean
+  isAdHocMacBuild: boolean
+}
+
+export function shouldEnableAutoUpdate(context: AutoUpdateContext) {
+  return context.isPackaged
+    && !context.isDisabled
+    && !context.isSmokeTest
+    && !context.isAdHocMacBuild
+}

--- a/electron/main/lite.ts
+++ b/electron/main/lite.ts
@@ -8,6 +8,7 @@ import { app, BrowserWindow, ipcMain, session } from 'electron'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import crypto from 'node:crypto'
+import { existsSync } from 'node:fs'
 import { getDb, closeDb } from '../db/db'
 import { registerAriaHandlers } from '../ipc/aria'
 import { registerProviderHandlers } from '../ipc/provider'
@@ -29,6 +30,7 @@ import { ClaudeProvider, CodexProvider, ProviderRegistry } from '../services/pro
 import { getKeyEncryptionWarning, getStorageBackend } from '../services/SecureKeyService'
 import { isSafeExternalUrl, openSafeExternalUrl } from '../security/externalNavigation'
 import { isTrustedSender, setTrustedIpcOrigin } from '../security/ipcSender'
+import { shouldEnableAutoUpdate } from './autoUpdatePolicy'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -37,6 +39,8 @@ process.env.APP_ROOT = path.join(__dirname, '../..')
 const RENDERER_DIST = path.join(process.env.APP_ROOT, 'dist-lite')
 const VITE_DEV_SERVER_URL = app.isPackaged ? undefined : process.env.VITE_DEV_SERVER_URL
 const SMOKE_TEST_MODE = process.env.DAEMON_SMOKE_TEST === '1'
+const IS_ADHOC_MAC_BUILD = process.platform === 'darwin'
+  && existsSync(path.join(process.resourcesPath, 'macos-adhoc-release'))
 
 process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL
   ? path.join(process.env.APP_ROOT, 'public')
@@ -225,7 +229,12 @@ app.whenReady().then(async () => {
 
   await createWindow()
 
-  if (app.isPackaged && process.env.DAEMON_DISABLE_AUTO_UPDATE !== '1' && !SMOKE_TEST_MODE) {
+  if (shouldEnableAutoUpdate({
+    isPackaged: app.isPackaged,
+    isDisabled: process.env.DAEMON_DISABLE_AUTO_UPDATE === '1',
+    isSmokeTest: SMOKE_TEST_MODE,
+    isAdHocMacBuild: IS_ADHOC_MAC_BUILD,
+  })) {
     const pkg = await import('electron-updater')
     const { autoUpdater } = pkg.default
     autoUpdater.on('error', (error: Error) => console.error('[AutoUpdater]', error.message))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",

--- a/scripts/release-tools/verify-macos-artifacts.mjs
+++ b/scripts/release-tools/verify-macos-artifacts.mjs
@@ -3,7 +3,10 @@ import { existsSync, readFileSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const MAC_ARTIFACTS = ['DAEMON-arm64.dmg', 'DAEMON-arm64.zip']
+function macArtifacts(isUnsigned) {
+  const prefix = isUnsigned ? 'DAEMON-unsigned-arm64' : 'DAEMON-arm64'
+  return [`${prefix}.dmg`, `${prefix}.zip`]
+}
 
 function fail(message) {
   throw new Error(`[mac-release] ${message}`)
@@ -22,7 +25,9 @@ function metadataEntry(metadata, artifactName) {
   return { sha512: match[1].trim(), size: Number(match[2]) }
 }
 
-export function verifyMacRelease(releaseDir, expectedVersion) {
+export function verifyMacRelease(releaseDir, expectedVersion, { isUnsigned = false } = {}) {
+  const artifacts = macArtifacts(isUnsigned)
+  const zipName = artifacts.find((name) => name.endsWith('.zip'))
   const metadataPath = path.join(releaseDir, 'latest-mac.yml')
   if (!existsSync(metadataPath)) fail(`missing ${metadataPath}`)
 
@@ -30,14 +35,14 @@ export function verifyMacRelease(releaseDir, expectedVersion) {
   if (!metadata.includes(`version: ${expectedVersion}`)) {
     fail(`latest-mac.yml version does not match ${expectedVersion}`)
   }
-  if (!metadata.includes('path: DAEMON-arm64.zip')) {
-    fail('latest-mac.yml updater path is not DAEMON-arm64.zip')
+  if (!metadata.includes(`path: ${zipName}`)) {
+    fail(`latest-mac.yml updater path is not ${zipName}`)
   }
-  if (/DAEMON-(?:x64|universal)\.(?:dmg|zip)/.test(metadata)) {
+  if (/DAEMON-(?:unsigned-)?(?:x64|universal)\.(?:dmg|zip)/.test(metadata)) {
     fail('latest-mac.yml contains a non-arm64 artifact')
   }
 
-  for (const artifactName of MAC_ARTIFACTS) {
+  for (const artifactName of artifacts) {
     const artifactPath = path.join(releaseDir, artifactName)
     const blockmapPath = `${artifactPath}.blockmap`
     if (!existsSync(artifactPath)) fail(`missing ${artifactPath}`)
@@ -58,8 +63,9 @@ export function verifyMacRelease(releaseDir, expectedVersion) {
 if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
   const releaseDir = path.resolve(process.argv[2] ?? '')
   const expectedVersion = process.argv[3]
-  if (!process.argv[2] || !expectedVersion) {
-    fail('usage: verify-macos-artifacts.mjs <release-dir> <version>')
+  const flags = process.argv.slice(4)
+  if (!process.argv[2] || !expectedVersion || flags.some((flag) => flag !== '--unsigned') || flags.length > 1) {
+    fail('usage: verify-macos-artifacts.mjs <release-dir> <version> [--unsigned]')
   }
-  verifyMacRelease(releaseDir, expectedVersion)
+  verifyMacRelease(releaseDir, expectedVersion, { isUnsigned: flags[0] === '--unsigned' })
 }

--- a/scripts/smoke/lite-workbench-smoke.mjs
+++ b/scripts/smoke/lite-workbench-smoke.mjs
@@ -35,6 +35,21 @@ const projectDir = path.join(sandboxRoot, 'solana-monitor')
 const readmePath = path.join(projectDir, 'README.md')
 const outputDir = path.join(repoRoot, 'output', 'playwright')
 const savedMarker = '# Solana monitor\n\nSaved from packaged DAEMON Workbench.\n'
+const shortcutModifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+const terminalCommands = process.platform === 'win32'
+  ? {
+      ready: 'Write-Output ("__DAEMON_" + "TERMINAL_READY__")',
+      project: 'Write-Output ("__DAEMON_" + "PROJECT__" + (Get-Content .\\package.json | ConvertFrom-Json).name)',
+      node: 'node --version; Write-Output ("__DAEMON_" + "NODE_DONE__")',
+      compact: 'Write-Output ("__DAEMON_" + "COMPACT_READY__")',
+    }
+  : {
+      ready: "printf '%s\\n' '__DAEMON_''TERMINAL_READY__'",
+      project: `node -p '"__DAEMON_" + "PROJECT__" + require("./package.json").name'`,
+      node: "node --version; printf '%s\\n' '__DAEMON_''NODE_DONE__'",
+      compact: "printf '%s\\n' '__DAEMON_''COMPACT_READY__'",
+    }
 
 let appProcess
 let browser
@@ -114,7 +129,7 @@ async function waitForFile(expected, timeoutMs = 10_000) {
     if (readFileSync(readmePath, 'utf8') === expected) return
     await new Promise((resolve) => setTimeout(resolve, 100))
   }
-  assert.equal(readFileSync(readmePath, 'utf8'), expected, 'Ctrl+S did not save the edited README')
+  assert.equal(readFileSync(readmePath, 'utf8'), expected, 'editor shortcut did not save the edited README')
 }
 
 async function waitForTerminalText(page, expected, timeout = 60_000) {
@@ -187,14 +202,14 @@ async function run() {
   await page.getByRole('region', { name: 'Code editor' }).waitFor()
   const editorSurface = page.locator('.monaco-editor .view-lines').first()
   await editorSurface.click()
-  await page.keyboard.press('Control+A')
+  await page.keyboard.press(`${shortcutModifier}+A`)
   await page.keyboard.type(savedMarker)
   await page.getByRole('button', { name: 'Save' }).waitFor({ state: 'visible' })
   await page.waitForFunction(() => {
     const save = Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.trim() === 'Save')
     return save instanceof HTMLButtonElement && !save.disabled
   })
-  await page.keyboard.press('Control+S')
+  await page.keyboard.press(`${shortcutModifier}+S`)
   await waitForFile(savedMarker)
   await page.screenshot({ path: path.join(outputDir, 'lite-simple-code-desktop.png'), fullPage: true })
   await page.setViewportSize({ width: 820, height: 720 })
@@ -206,16 +221,16 @@ async function run() {
   await page.getByRole('button', { name: 'Terminal', exact: true }).click()
   await page.getByRole('button', { name: 'New terminal' }).click()
   await page.locator('.xterm-helper-textarea').first().waitFor({ timeout: 60_000 })
-  await waitForTerminalText(page, 'PS ')
+  await runTerminalCommand(page, terminalCommands.ready, '__DAEMON_TERMINAL_READY__')
   const projectOutput = await runTerminalCommand(
     page,
-    'Write-Output ("__DAEMON_" + "PROJECT__" + (Get-Content .\\package.json | ConvertFrom-Json).name)',
+    terminalCommands.project,
     '__DAEMON_PROJECT__',
   )
   assert.ok(projectOutput?.includes('__DAEMON_PROJECT__solana-monitor'), 'terminal did not resolve the imported project fixture')
   const nodeOutput = await runTerminalCommand(
     page,
-    'node --version; Write-Output ("__DAEMON_" + "NODE_DONE__")',
+    terminalCommands.node,
     '__DAEMON_NODE_DONE__',
   )
   assert.ok(nodeOutput?.includes(`v${process.versions.node.split('.')[0]}.`), 'terminal Node version did not match the release runtime')
@@ -224,7 +239,7 @@ async function run() {
   await page.waitForTimeout(500)
   await runTerminalCommand(
     page,
-    'Write-Output ("__DAEMON_" + "COMPACT_READY__")',
+    terminalCommands.compact,
     '__DAEMON_COMPACT_READY__',
   )
   await page.screenshot({ path: path.join(outputDir, 'lite-simple-terminal-compact.png'), fullPage: true })

--- a/test/shared/autoUpdatePolicy.test.ts
+++ b/test/shared/autoUpdatePolicy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { shouldEnableAutoUpdate } from '../../electron/main/autoUpdatePolicy'
+
+const DEFAULT_CONTEXT = {
+  isPackaged: true,
+  isDisabled: false,
+  isSmokeTest: false,
+  isAdHocMacBuild: false,
+}
+
+describe('automatic update policy', () => {
+  it('enables updates for ordinary packaged releases', () => {
+    expect(shouldEnableAutoUpdate(DEFAULT_CONTEXT)).toBe(true)
+  })
+
+  it.each([
+    ['ad-hoc macOS build', { isAdHocMacBuild: true }],
+    ['disabled update environment', { isDisabled: true }],
+    ['smoke test', { isSmokeTest: true }],
+    ['development build', { isPackaged: false }],
+  ])('disables updates for %s', (_label, override) => {
+    expect(shouldEnableAutoUpdate({ ...DEFAULT_CONTEXT, ...override })).toBe(false)
+  })
+})

--- a/test/shared/macosArtifacts.test.ts
+++ b/test/shared/macosArtifacts.test.ts
@@ -12,11 +12,12 @@ function sha512(contents: string) {
   return createHash('sha512').update(contents).digest('base64')
 }
 
-function writeFixture() {
+function writeFixture(isUnsigned = false) {
   releaseDir = mkdtempSync(path.join(tmpdir(), 'daemon-mac-release-'))
+  const prefix = isUnsigned ? 'DAEMON-unsigned-arm64' : 'DAEMON-arm64'
   const artifacts = {
-    'DAEMON-arm64.dmg': 'dmg-contents',
-    'DAEMON-arm64.zip': 'zip-contents',
+    [`${prefix}.dmg`]: 'dmg-contents',
+    [`${prefix}.zip`]: 'zip-contents',
   }
   for (const [name, contents] of Object.entries(artifacts)) {
     writeFileSync(path.join(releaseDir, name), contents)
@@ -25,13 +26,13 @@ function writeFixture() {
   writeFileSync(path.join(releaseDir, 'latest-mac.yml'), [
     `version: ${VERSION}`,
     'files:',
-    '  - url: DAEMON-arm64.zip',
-    `    sha512: ${sha512(artifacts['DAEMON-arm64.zip'])}`,
-    `    size: ${artifacts['DAEMON-arm64.zip'].length}`,
-    '  - url: DAEMON-arm64.dmg',
-    `    sha512: ${sha512(artifacts['DAEMON-arm64.dmg'])}`,
-    `    size: ${artifacts['DAEMON-arm64.dmg'].length}`,
-    'path: DAEMON-arm64.zip',
+    `  - url: ${prefix}.zip`,
+    `    sha512: ${sha512(artifacts[`${prefix}.zip`])}`,
+    `    size: ${artifacts[`${prefix}.zip`].length}`,
+    `  - url: ${prefix}.dmg`,
+    `    sha512: ${sha512(artifacts[`${prefix}.dmg`])}`,
+    `    size: ${artifacts[`${prefix}.dmg`].length}`,
+    `path: ${prefix}.zip`,
   ].join('\n'))
 }
 
@@ -44,6 +45,12 @@ describe('macOS release artifacts', () => {
   it('accepts matching arm64 artifacts and updater metadata', () => {
     writeFixture()
     expect(() => verifyMacRelease(releaseDir, VERSION)).not.toThrow()
+  })
+
+  it('accepts explicitly labeled unsigned artifacts only in unsigned mode', () => {
+    writeFixture(true)
+    expect(() => verifyMacRelease(releaseDir, VERSION, { isUnsigned: true })).not.toThrow()
+    expect(() => verifyMacRelease(releaseDir, VERSION)).toThrow(/DAEMON-arm64/)
   })
 
   it('rejects metadata with a mismatched artifact hash', () => {

--- a/test/shared/macosPackaging.test.ts
+++ b/test/shared/macosPackaging.test.ts
@@ -1,0 +1,39 @@
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+type MacConfig = {
+  isAdHoc: boolean
+  identity?: string
+  entitlements: string
+  artifactName: string
+}
+
+const require = createRequire(import.meta.url)
+const { macSigningConfig } = require('../../build/macPackaging.cjs') as {
+  macSigningConfig: (env?: NodeJS.ProcessEnv) => MacConfig
+}
+
+describe('macOS packaging configuration', () => {
+  it('keeps Developer ID releases on the production entitlements', () => {
+    const mac = macSigningConfig({})
+    expect(mac.isAdHoc).toBe(false)
+    expect(mac.identity).toBeUndefined()
+    expect(mac.entitlements).toBe('build/entitlements.mac.plist')
+    expect(mac.artifactName).toBe('DAEMON-${arch}.${ext}')
+    const entitlements = readFileSync(path.resolve(mac.entitlements), 'utf8')
+    expect(entitlements).not.toContain('com.apple.security.cs.disable-library-validation')
+  })
+
+  it('uses explicit ad-hoc signing with its required library entitlement', () => {
+    const mac = macSigningConfig({ DAEMON_MAC_ADHOC: '1' })
+    expect(mac.isAdHoc).toBe(true)
+    expect(mac.identity).toBe('-')
+    expect(mac.entitlements).toBe('build/entitlements.mac.adhoc.plist')
+    expect(mac.artifactName).toBe('DAEMON-unsigned-${arch}.${ext}')
+
+    const entitlements = readFileSync(path.resolve(mac.entitlements), 'utf8')
+    expect(entitlements).toMatch(/com\.apple\.security\.cs\.disable-library-validation<\/key>\s*<true\/>/)
+  })
+})


### PR DESCRIPTION
## Summary
- clear empty Apple secret environment variables before the scoped unsigned macOS build
- release the retry as v4.7.5 without rewriting the failed v4.7.4 tag

## Verification
- 11 targeted tests pass
- typecheck passes
- actionlint passes