### PR TITLE
fix: clear empty Apple credentials for unsigned builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.4'
+      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.5'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -141,7 +141,12 @@ jobs:
           restore-keys: electron-cache-${{ runner.os }}-${{ runner.arch }}-
       - run: pnpm install --frozen-lockfile
       - name: Build Apple Silicon release
-        run: pnpm run package:lite:mac
+        shell: bash
+        run: |
+          if [ "$DAEMON_MAC_RELEASE_MODE" = 'unsigned' ]; then
+            unset CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+          fi
+          pnpm run package:lite:mac
       - name: Verify signature mode, architecture, and updater metadata
         shell: bash
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- clear empty Apple secret environment variables before the scoped unsigned macOS build
- release the retry as v4.7.5 without rewriting the failed v4.7.4 tag

## Verification
- 11 targeted tests pass
- typecheck passes
- actionlint passes