### PR TITLE
fix: embed entitlements in ad-hoc macOS build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.5'
+      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.6'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/build/notarize.mjs
+++ b/build/notarize.mjs
@@ -1,5 +1,6 @@
 import { notarize } from '@electron/notarize'
 import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
 
 const REQUIRED_SIGNING_ENV_VARS = ['CSC_LINK', 'CSC_KEY_PASSWORD']
 const REQUIRED_ENV_VARS = [
@@ -28,16 +29,23 @@ function assertDeveloperIdSignature(appPath) {
   }
 }
 
+function signAdHoc(appPath) {
+  const entitlements = resolve('build/entitlements.mac.adhoc.plist')
+  const result = spawnSync('codesign', [
+    '--force',
+    '--sign', '-',
+    '--options', 'runtime',
+    '--entitlements', entitlements,
+    appPath,
+  ], { encoding: 'utf8' })
+  if (result.status !== 0) {
+    throw new Error(`Ad-hoc signing failed: ${result.stderr || result.stdout}`)
+  }
+  console.log('[notarize] Applied ad-hoc signature with runtime entitlements')
+}
+
 export default async function afterSign(context) {
   if (process.platform !== 'darwin') {
-    return
-  }
-
-  if (!hasNotarizeEnv()) {
-    if (isNotarizationRequired()) {
-      throw new Error(`Missing required macOS notarization credentials: ${REQUIRED_ENV_VARS.join(', ')}`)
-    }
-    console.log('[notarize] Skipping notarization; missing Apple credentials in environment')
     return
   }
 
@@ -45,10 +53,20 @@ export default async function afterSign(context) {
   if (electronPlatformName !== 'darwin') {
     return
   }
-
   const appName = packager.appInfo.productFilename
   const appBundleId = packager.appInfo.id
   const appPath = `${appOutDir}/${appName}.app`
+
+  if (!hasNotarizeEnv()) {
+    if (isNotarizationRequired()) {
+      throw new Error(`Missing required macOS notarization credentials: ${REQUIRED_ENV_VARS.join(', ')}`)
+    }
+    if (process.env.DAEMON_MAC_ADHOC === '1') {
+      signAdHoc(appPath)
+    }
+    console.log('[notarize] Skipping notarization; missing Apple credentials in environment')
+    return
+  }
 
   if (isNotarizationRequired()) {
     const missingSigningVars = missingEnvVars(REQUIRED_SIGNING_ENV_VARS)

--- a/electron-builder.lite.cjs
+++ b/electron-builder.lite.cjs
@@ -12,7 +12,7 @@ module.exports = {
   productName: 'DAEMON',
   asar: true,
   npmRebuild: false,
-  compression: 'maximum',
+  compression: macSigning.isAdHoc ? 'normal' : 'maximum',
   directories: {
     output: 'release-lite/${version}',
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "4.7.5",
+  "version": "4.7.6",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- explicitly re-sign the outer app bundle with the required runtime entitlements in the ad-hoc after-sign hook
- use normal compression for the temporary unsigned package
- release the retry as v4.7.6 without rewriting failed tags

## Verification
- Apple Silicon packaging completed in v4.7.5 CI
- 11 targeted tests pass
- typecheck and actionlint pass