### PR TITLE
fix: omit package command shims from macOS bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.7'
+      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.8'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/electron-builder.lite.cjs
+++ b/electron-builder.lite.cjs
@@ -35,6 +35,7 @@ module.exports = {
       filter: [
         '**/*',
         '!@types{,/**/*}',
+        '!**/.bin{,/**/*}',
         '!**/*.map',
         '!better-sqlite3/{deps,src}/**',
         '!better-sqlite3/build/Release/{obj,sqlite3.a,test_extension.node}',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "4.7.7",
+  "version": "4.7.8",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- omit unused package-manager command shims from the packaged runtime
- remove the dangling nested symlink that blocked macOS codesign
- scope the temporary unsigned release to v4.7.8

## Verification
- typecheck passes
- 11 macOS release policy and artifact tests pass
- both packaged app smokes pass against v4.7.8
- staged archive contains no .bin paths
- independent release review found no P0/P1 issues