### PR TITLE
fix: embed ad-hoc macOS entitlements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.8'
+      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.9'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -180,7 +180,7 @@ jobs:
                 ! grep -q '^Authority=' <<< "$app_details"
                 local entitlements
                 entitlements="$(mktemp)"
-                codesign -d --entitlements :- "$app_path" > "$entitlements" 2>/dev/null
+                codesign --display --entitlements - --xml "$app_path" > "$entitlements" 2>/dev/null
                 test "$(plutil -extract com.apple.security.cs.disable-library-validation raw -o - "$entitlements")" = true
                 rm -f "$entitlements"
                 if spctl --assess --type execute -vv "$app_path"; then

--- a/build/notarize.mjs
+++ b/build/notarize.mjs
@@ -36,10 +36,20 @@ function signAdHoc(appPath) {
     '--sign', '-',
     '--options', 'runtime',
     '--entitlements', entitlements,
+    '--generate-entitlement-der',
     appPath,
   ], { encoding: 'utf8' })
   if (result.status !== 0) {
     throw new Error(`Ad-hoc signing failed: ${result.stderr || result.stdout}`)
+  }
+  const inspected = spawnSync('codesign', [
+    '--display',
+    '--entitlements', '-',
+    '--xml',
+    appPath,
+  ], { encoding: 'utf8' })
+  if (inspected.status !== 0 || !inspected.stdout.includes('com.apple.security.cs.disable-library-validation')) {
+    throw new Error(`Ad-hoc signing did not embed runtime entitlements: ${inspected.stderr || inspected.stdout}`)
   }
   console.log('[notarize] Applied ad-hoc signature with runtime entitlements')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "4.7.8",
+  "version": "4.7.9",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",


### PR DESCRIPTION
## Summary
- emit XML and DER entitlements during temporary ad-hoc signing
- fail immediately if the required library-validation entitlement is absent
- verify embedded entitlements with Apple's documented XML output mode
- scope the temporary unsigned release to v4.7.9

## Verification
- v4.7.8 completed the native ARM build and produced both DMG and ZIP artifacts
- codesign deep verification passed on the built app
- typecheck and 11 macOS release tests pass
- independent codesign review found no P0/P1 issues