### PR TITLE
fix: accept system Node in packaged terminal smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.10'
+      DAEMON_ALLOW_UNSIGNED_MAC_VERSION: '4.7.11'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "4.7.10",
+  "version": "4.7.11",
   "main": "dist-electron/main/index.js",
   "description": "Solana-native agent workbench for verifiable AI development",
   "author": "nullxnothing",

--- a/scripts/smoke/lite-workbench-smoke.mjs
+++ b/scripts/smoke/lite-workbench-smoke.mjs
@@ -233,7 +233,7 @@ async function run() {
     terminalCommands.node,
     '__DAEMON_NODE_DONE__',
   )
-  assert.ok(nodeOutput?.includes(`v${process.versions.node.split('.')[0]}.`), 'terminal Node version did not match the release runtime')
+  assert.match(nodeOutput ?? '', /v\d+\.\d+\.\d+__DAEMON_NODE_DONE__/, 'terminal did not report a Node.js version')
   await page.screenshot({ path: path.join(outputDir, 'lite-simple-terminal-desktop.png'), fullPage: true })
   await page.setViewportSize({ width: 820, height: 720 })
   await page.waitForTimeout(500)


### PR DESCRIPTION
## Summary
- validate the actual terminal Node version and command completion marker
- stop requiring the user's shell Node major to match Electron's embedded Node major
- scope the temporary unsigned release to v4.7.11

## Verification
- v4.7.10 passed macOS DMG/ZIP, final signature, architecture, native addon, mounted artifact, and app launch gates
- corrected packaged workbench smoke passes locally
- typecheck and 11 macOS release tests pass
- independent review found no P0/P1 issues